### PR TITLE
fix: Resolve CI check 'signal: killed' error with isolated timeouts

### DIFF
--- a/internal/workflow/orchestrator.go
+++ b/internal/workflow/orchestrator.go
@@ -21,6 +21,7 @@ type Config struct {
 	DangerouslySkipPermissions bool
 	CICheckInterval            time.Duration
 	CICheckTimeout             time.Duration
+	GHCommandTimeout           time.Duration
 	MaxFixAttempts             int
 }
 
@@ -42,6 +43,7 @@ func DefaultConfig(baseDir string) *Config {
 		DangerouslySkipPermissions: false,
 		CICheckInterval:            30 * time.Second,
 		CICheckTimeout:             30 * time.Minute,
+		GHCommandTimeout:           2 * time.Minute,
 		MaxFixAttempts:             10,
 		Timeouts: PhaseTimeouts{
 			Planning:       1 * time.Hour,
@@ -63,7 +65,7 @@ type Orchestrator struct {
 	worktreeManager WorktreeManager
 
 	// For testing - if nil, creates real checker
-	ciCheckerFactory func(workingDir string, checkInterval time.Duration) CIChecker
+	ciCheckerFactory func(workingDir string, checkInterval time.Duration, commandTimeout time.Duration) CIChecker
 }
 
 // NewOrchestrator creates orchestrator with default config
@@ -988,7 +990,7 @@ func formatCIErrors(result *CIResult) string {
 // getCIChecker creates or retrieves a CIChecker for the given working directory
 func (o *Orchestrator) getCIChecker(workingDir string) CIChecker {
 	if o.ciCheckerFactory != nil {
-		return o.ciCheckerFactory(workingDir, o.config.CICheckInterval)
+		return o.ciCheckerFactory(workingDir, o.config.CICheckInterval, o.config.GHCommandTimeout)
 	}
-	return NewCIChecker(workingDir, o.config.CICheckInterval)
+	return NewCIChecker(workingDir, o.config.CICheckInterval, o.config.GHCommandTimeout)
 }

--- a/internal/workflow/orchestrator_test.go
+++ b/internal/workflow/orchestrator_test.go
@@ -595,7 +595,7 @@ func TestOrchestrator_executeImplementation(t *testing.T) {
 				parser:          mockOP,
 				config:          DefaultConfig("/tmp/workflows"),
 				worktreeManager: mockWM,
-				ciCheckerFactory: func(workingDir string, checkInterval time.Duration) CIChecker {
+				ciCheckerFactory: func(workingDir string, checkInterval time.Duration, commandTimeout time.Duration) CIChecker {
 					return mockCI
 				},
 			}
@@ -1323,7 +1323,7 @@ func TestOrchestrator_executePRSplit_CIFailureRetry(t *testing.T) {
 		promptGenerator: mockPG,
 		parser:          mockOP,
 		config:          config,
-		ciCheckerFactory: func(workingDir string, checkInterval time.Duration) CIChecker {
+		ciCheckerFactory: func(workingDir string, checkInterval time.Duration, commandTimeout time.Duration) CIChecker {
 			return mockCI
 		},
 	}

--- a/internal/workflow/types.go
+++ b/internal/workflow/types.go
@@ -180,4 +180,5 @@ var (
 	ErrClaude              = errors.New("claude execution failed")
 	ErrParseJSON           = errors.New("failed to parse JSON output")
 	ErrUserCancelled       = errors.New("workflow cancelled by user")
+	ErrCICheckTimeout      = errors.New("CI check command timeout")
 )


### PR DESCRIPTION
## Summary
Fixes the cryptic "failed to check CI: failed to check CI status: signal: killed (stderr: )" error that occurred when the CI check command timed out.

**Root cause**: `exec.CommandContext()` sends SIGKILL when the context deadline expires, and the same parent context was being passed to `CheckCI()`. When the parent polling context expired, the subprocess was killed abruptly.

## Changes
- Add `GHCommandTimeout` config (default 2 minutes) for individual `gh` commands
- Isolate command context from parent context in `CheckCI()` using `context.Background()`
- Add retry logic (3 attempts) with exponential backoff for transient failures
- Add `ErrCICheckTimeout` error for clear timeout error messages
- Handle context cancellation gracefully during initial delay and polling
- Update tests to verify isolated timeout behavior

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] New tests added for timeout scenarios:
  - `TestCheckCI_ContextCancellation` - verifies parent context cancellation is respected
  - `TestCheckCI_IsolatedCommandContext` - verifies command uses isolated context
  - `TestWaitForCIWithOptions_ParentContextCancellation` - verifies proper handling during polling

## How it fixes the bug
The `gh` command now uses its own 2-minute timeout context (created from `context.Background()`) that is independent of the 30-minute polling timeout. This prevents the subprocess from being killed when the polling context changes state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)