### PR TITLE
fix: Resume from CI failure skips to CI fix instead of restarting implementation

### DIFF
--- a/internal/workflow/types.go
+++ b/internal/workflow/types.go
@@ -71,12 +71,23 @@ type PRMetrics struct {
 	FilesDeleted  []string `json:"filesDeleted,omitempty"`
 }
 
+// FailureType represents the type of failure that occurred
+type FailureType string
+
+const (
+	// FailureTypeExecution indicates the phase execution itself failed (e.g., code generation)
+	FailureTypeExecution FailureType = "execution"
+	// FailureTypeCI indicates CI check failed after successful execution
+	FailureTypeCI FailureType = "ci"
+)
+
 // WorkflowError represents an error that occurred during workflow
 type WorkflowError struct {
 	Message     string                 `json:"message"`
 	Phase       Phase                  `json:"phase"`
 	Timestamp   time.Time              `json:"timestamp"`
 	Recoverable bool                   `json:"recoverable"`
+	FailureType FailureType            `json:"failureType,omitempty"`
 	Context     map[string]interface{} `json:"context,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
- Fixes bug where `resume` command restarted implementation from scratch after CI check timeout
- When resuming from a CI failure, the workflow now skips directly to the CI fix loop instead of re-running implementation

## Changes
- Added `FailureType` field to `WorkflowError` to distinguish CI failures from execution failures
- Updated CI check failure calls to use `failWorkflowCI()` 
- CI failures now store error message in phase feedback before failing
- `Resume()` now preserves CI failure errors for phase execution to detect
- `executeImplementation()` and `executeRefactoring()` detect CI failure resume and start from attempt 2

## Test plan
- [x] Added test `TestOrchestrator_Resume_PreservesCIFailure` with 3 test cases
- [x] All existing tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)