### PR TITLE
fix: Replace arbitrary PR size limits with logical grouping guidelines

### DIFF
--- a/internal/templates/workflow/pr-split.tmpl
+++ b/internal/templates/workflow/pr-split.tmpl
@@ -32,7 +32,13 @@ You need to split the current changes into multiple pull requests for easier rev
    - Each address a specific aspect of the change
 
 ## Guidelines
-- Each child PR should be <100 lines or <10 files when possible
+- Group changes by logical boundaries such as:
+  - By subproject or module (if monorepo)
+  - By change type (refactoring vs feature additions vs bug fixes)
+  - By domain or feature area
+  - By dependency order (foundational changes before dependent ones)
+- Keep related changes together even if they span multiple files
+- Prioritize reviewability and logical cohesion over arbitrary size limits
 - Child PRs should have dependencies in the right order
 - Parent PR should reference all child PRs
 - Each PR should have a clear, descriptive title and description


### PR DESCRIPTION
## Summary
- Removes the rigid "<100 lines or <10 files" criteria from PR splitting prompt
- Adds intelligent grouping guidelines that leverage Claude Code's semantic understanding:
  - Group by subproject/module (for monorepos)
  - Group by change type (refactoring vs features vs bug fixes)
  - Group by domain or feature area
  - Group by dependency order
- Emphasizes keeping related changes together and prioritizing logical cohesion

## Test plan
- [ ] Verify the template renders correctly
- [ ] Test PR splitting with the new guidelines produces more meaningful groupings

🤖 Generated with [Claude Code](https://claude.com/claude-code)