### PR TITLE
fix: Handle CANCELLED job state in CI status checking

### DIFF
--- a/internal/workflow/checks.go
+++ b/internal/workflow/checks.go
@@ -343,7 +343,7 @@ checkLoop:
 
 // parseCIOutput parses gh pr checks --json output to extract status and failed jobs
 // The output is expected to be JSON array: [{"name":"build","state":"SUCCESS"},...]
-// State values: SUCCESS, FAILURE, PENDING, QUEUED, IN_PROGRESS, SKIPPED, NEUTRAL
+// State values: SUCCESS, FAILURE, PENDING, QUEUED, IN_PROGRESS, SKIPPED, NEUTRAL, CANCELLED
 func parseCIOutput(output string) (string, []string) {
 	var checks []ciCheck
 	if err := json.Unmarshal([]byte(output), &checks); err != nil {
@@ -364,7 +364,7 @@ func parseCIOutput(output string) (string, []string) {
 		switch state {
 		case "SUCCESS", "SKIPPED", "NEUTRAL":
 			// These are considered passing states
-		case "FAILURE":
+		case "FAILURE", "CANCELLED":
 			allPassed = false
 			failedJobs = append(failedJobs, check.Name)
 		case "PENDING", "QUEUED", "IN_PROGRESS", "":
@@ -398,7 +398,7 @@ func countJobStatuses(output string) (passed, failed, pending int) {
 		switch state {
 		case "SUCCESS", "SKIPPED", "NEUTRAL":
 			passed++
-		case "FAILURE":
+		case "FAILURE", "CANCELLED":
 			failed++
 		case "PENDING", "QUEUED", "IN_PROGRESS", "":
 			pending++

--- a/internal/workflow/checks_test.go
+++ b/internal/workflow/checks_test.go
@@ -84,6 +84,30 @@ func TestParseCIOutput(t *testing.T) {
 			wantStatus:     "failure",
 			wantFailedJobs: []string{"test"},
 		},
+		{
+			name:           "cancelled job treated as failure",
+			output:         `[{"name":"build","state":"SUCCESS"},{"name":"test","state":"CANCELLED"}]`,
+			wantStatus:     "failure",
+			wantFailedJobs: []string{"test"},
+		},
+		{
+			name:           "multiple cancelled jobs",
+			output:         `[{"name":"build","state":"CANCELLED"},{"name":"test","state":"CANCELLED"}]`,
+			wantStatus:     "failure",
+			wantFailedJobs: []string{"build", "test"},
+		},
+		{
+			name:           "mixed failure and cancelled",
+			output:         `[{"name":"build","state":"FAILURE"},{"name":"test","state":"CANCELLED"},{"name":"lint","state":"SUCCESS"}]`,
+			wantStatus:     "failure",
+			wantFailedJobs: []string{"build", "test"},
+		},
+		{
+			name:           "lowercase cancelled state",
+			output:         `[{"name":"build","state":"success"},{"name":"test","state":"cancelled"}]`,
+			wantStatus:     "failure",
+			wantFailedJobs: []string{"test"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -165,6 +189,34 @@ func TestCountJobStatuses(t *testing.T) {
 			wantPassed:  1,
 			wantFailed:  1,
 			wantPending: 1,
+		},
+		{
+			name:        "cancelled job counted as failed",
+			output:      `[{"name":"build","state":"SUCCESS"},{"name":"test","state":"CANCELLED"}]`,
+			wantPassed:  1,
+			wantFailed:  1,
+			wantPending: 0,
+		},
+		{
+			name:        "multiple cancelled jobs",
+			output:      `[{"name":"build","state":"CANCELLED"},{"name":"test","state":"CANCELLED"},{"name":"lint","state":"SUCCESS"}]`,
+			wantPassed:  1,
+			wantFailed:  2,
+			wantPending: 0,
+		},
+		{
+			name:        "mixed failure and cancelled states",
+			output:      `[{"name":"build","state":"SUCCESS"},{"name":"test","state":"FAILURE"},{"name":"deploy","state":"CANCELLED"},{"name":"lint","state":"PENDING"}]`,
+			wantPassed:  1,
+			wantFailed:  2,
+			wantPending: 1,
+		},
+		{
+			name:        "lowercase cancelled state",
+			output:      `[{"name":"build","state":"success"},{"name":"test","state":"cancelled"}]`,
+			wantPassed:  1,
+			wantFailed:  1,
+			wantPending: 0,
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Add support for `CANCELLED` state from GitHub Actions in the workflow package
- Previously, cancelled jobs fell into the default case and were treated as pending, causing the workflow to wait indefinitely
- This fix treats `CANCELLED` jobs as failures similar to `FAILURE` state, triggering the retry logic

## Problem

When GitHub Actions jobs are cancelled (due to `cancel-in-progress: true` or timeout), the workflow command:
1. Treated `CANCELLED` as "pending" (unknown state defaults to pending)
2. Kept waiting indefinitely for these jobs to complete
3. Eventually timed out or required user interruption

## Solution

`CANCELLED` is now treated as a **failure** state, which will:
1. Stop the CI check loop
2. Trigger the retry logic with `GenerateFixCIPrompt`
3. Ask Claude to fix the CI issue (re-trigger jobs, address root cause, etc.)

## Changes

- Update `parseCIOutput` to treat `CANCELLED` as failure state
- Update `countJobStatuses` to count `CANCELLED` jobs as failed
- Add `CANCELLED` to state values comment
- Add comprehensive test cases for `CANCELLED` state handling

## Test plan

- [x] Run `go test ./internal/workflow/...` - all tests pass
- [x] New test cases added for CANCELLED state in both `parseCIOutput` and `countJobStatuses`

🤖 Generated with [Claude Code](https://claude.com/claude-code)