### PR TITLE
feat: Replace threshold-based PR split with explicit --split-pr flag

### DIFF
--- a/cmd/workflow/main.go
+++ b/cmd/workflow/main.go
@@ -12,8 +12,7 @@ import (
 
 var (
 	baseDir                    string
-	maxLines                   int
-	maxFiles                   int
+	splitPR                    bool
 	claudePath                 string
 	dangerouslySkipPermissions bool
 	timeoutPlanning            time.Duration
@@ -37,8 +36,7 @@ func newRootCmd() *cobra.Command {
 	}
 
 	rootCmd.PersistentFlags().StringVar(&baseDir, "base-dir", ".claude/workflow", "base directory for workflows")
-	rootCmd.PersistentFlags().IntVar(&maxLines, "max-lines", 100, "PR split threshold for lines")
-	rootCmd.PersistentFlags().IntVar(&maxFiles, "max-files", 10, "PR split threshold for files")
+	rootCmd.PersistentFlags().BoolVar(&splitPR, "split-pr", false, "enable PR split phase to split large PRs into smaller child PRs")
 	rootCmd.PersistentFlags().StringVar(&claudePath, "claude-path", "claude", "path to claude CLI")
 	rootCmd.PersistentFlags().BoolVar(&dangerouslySkipPermissions, "dangerously-skip-permissions", false, "skip all permission prompts in Claude Code (use with caution)")
 	rootCmd.PersistentFlags().DurationVar(&timeoutPlanning, "timeout-planning", 1*time.Hour, "planning phase timeout")
@@ -59,8 +57,7 @@ func newRootCmd() *cobra.Command {
 
 func createOrchestrator() (*workflow.Orchestrator, error) {
 	config := workflow.DefaultConfig(baseDir)
-	config.MaxLines = maxLines
-	config.MaxFiles = maxFiles
+	config.SplitPR = splitPR
 	config.ClaudePath = claudePath
 	config.DangerouslySkipPermissions = dangerouslySkipPermissions
 	config.Timeouts = workflow.PhaseTimeouts{

--- a/cmd/workflow/main_test.go
+++ b/cmd/workflow/main_test.go
@@ -30,8 +30,7 @@ func TestNewRootCmd(t *testing.T) {
 
 	persistentFlags := cmd.PersistentFlags()
 	assert.NotNil(t, persistentFlags.Lookup("base-dir"))
-	assert.NotNil(t, persistentFlags.Lookup("max-lines"))
-	assert.NotNil(t, persistentFlags.Lookup("max-files"))
+	assert.NotNil(t, persistentFlags.Lookup("split-pr"))
 	assert.NotNil(t, persistentFlags.Lookup("claude-path"))
 	assert.NotNil(t, persistentFlags.Lookup("dangerously-skip-permissions"))
 	assert.NotNil(t, persistentFlags.Lookup("timeout-planning"))
@@ -121,16 +120,10 @@ func TestPersistentFlags(t *testing.T) {
 			defaultValue: ".claude/workflow",
 		},
 		{
-			name:         "max-lines flag",
-			flagName:     "max-lines",
-			flagType:     "int",
-			defaultValue: "100",
-		},
-		{
-			name:         "max-files flag",
-			flagName:     "max-files",
-			flagType:     "int",
-			defaultValue: "10",
+			name:         "split-pr flag",
+			flagName:     "split-pr",
+			flagType:     "bool",
+			defaultValue: "false",
 		},
 		{
 			name:         "claude-path flag",
@@ -614,8 +607,7 @@ func TestCreateOrchestrator(t *testing.T) {
 	tests := []struct {
 		name                       string
 		baseDir                    string
-		maxLines                   int
-		maxFiles                   int
+		splitPR                    bool
 		claudePath                 string
 		dangerouslySkipPermissions bool
 		timeoutPlanning            time.Duration
@@ -626,8 +618,7 @@ func TestCreateOrchestrator(t *testing.T) {
 		{
 			name:                       "default values",
 			baseDir:                    ".claude/workflow",
-			maxLines:                   100,
-			maxFiles:                   10,
+			splitPR:                    false,
 			claudePath:                 "claude",
 			dangerouslySkipPermissions: false,
 			timeoutPlanning:            1 * time.Hour,
@@ -638,8 +629,7 @@ func TestCreateOrchestrator(t *testing.T) {
 		{
 			name:                       "custom values",
 			baseDir:                    "/tmp/workflows",
-			maxLines:                   200,
-			maxFiles:                   20,
+			splitPR:                    true,
 			claudePath:                 "/usr/local/bin/claude",
 			dangerouslySkipPermissions: true,
 			timeoutPlanning:            2 * time.Hour,
@@ -652,8 +642,7 @@ func TestCreateOrchestrator(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			baseDir = tt.baseDir
-			maxLines = tt.maxLines
-			maxFiles = tt.maxFiles
+			splitPR = tt.splitPR
 			claudePath = tt.claudePath
 			dangerouslySkipPermissions = tt.dangerouslySkipPermissions
 			timeoutPlanning = tt.timeoutPlanning
@@ -781,8 +770,7 @@ func TestPersistentFlagsInheritance(t *testing.T) {
 
 			persistentFlags := []string{
 				"base-dir",
-				"max-lines",
-				"max-files",
+				"split-pr",
 				"claude-path",
 				"dangerously-skip-permissions",
 				"timeout-planning",
@@ -989,11 +977,8 @@ func TestPersistentFlagDefaults(t *testing.T) {
 	baseDir := cmd.PersistentFlags().Lookup("base-dir")
 	assert.Equal(t, ".claude/workflow", baseDir.DefValue)
 
-	maxLines := cmd.PersistentFlags().Lookup("max-lines")
-	assert.Equal(t, "100", maxLines.DefValue)
-
-	maxFiles := cmd.PersistentFlags().Lookup("max-files")
-	assert.Equal(t, "10", maxFiles.DefValue)
+	splitPR := cmd.PersistentFlags().Lookup("split-pr")
+	assert.Equal(t, "false", splitPR.DefValue)
 
 	claudePath := cmd.PersistentFlags().Lookup("claude-path")
 	assert.Equal(t, "claude", claudePath.DefValue)
@@ -1237,12 +1222,8 @@ func TestPersistentFlagUsage(t *testing.T) {
 			usage:    "base directory for workflows",
 		},
 		{
-			flagName: "max-lines",
-			usage:    "PR split threshold for lines",
-		},
-		{
-			flagName: "max-files",
-			usage:    "PR split threshold for files",
+			flagName: "split-pr",
+			usage:    "enable PR split phase to split large PRs into smaller child PRs",
 		},
 		{
 			flagName: "claude-path",
@@ -1589,8 +1570,7 @@ func TestPersistentFlags_Modification(t *testing.T) {
 		setValue string
 	}{
 		{"base-dir", "/custom/path"},
-		{"max-lines", "200"},
-		{"max-files", "20"},
+		{"split-pr", "true"},
 		{"claude-path", "/custom/claude"},
 		{"dangerously-skip-permissions", "true"},
 		{"timeout-planning", "2h"},

--- a/internal/workflow/orchestrator_test.go
+++ b/internal/workflow/orchestrator_test.go
@@ -1514,7 +1514,7 @@ func TestOrchestrator_Start(t *testing.T) {
 			o := &Orchestrator{
 				stateManager: mockSM,
 				config:       DefaultConfig("/tmp/workflows"),
-				logger:          NewLogger(LogLevelNormal),
+				logger:       NewLogger(LogLevelNormal),
 			}
 
 			err := o.Start(context.Background(), "test-workflow", "test description", WorkflowTypeFeature)
@@ -1670,7 +1670,7 @@ func TestOrchestrator_Resume(t *testing.T) {
 			o := &Orchestrator{
 				stateManager: mockSM,
 				config:       DefaultConfig("/tmp/workflows"),
-			logger:       NewLogger(LogLevelNormal),
+				logger:       NewLogger(LogLevelNormal),
 			}
 
 			err := o.Resume(context.Background(), "test-workflow")
@@ -1754,7 +1754,7 @@ func TestOrchestrator_Resume_RestoresFailedPhase(t *testing.T) {
 			o := &Orchestrator{
 				stateManager: mockSM,
 				config:       DefaultConfig("/tmp/workflows"),
-			logger:       NewLogger(LogLevelNormal),
+				logger:       NewLogger(LogLevelNormal),
 			}
 
 			// Resume will fail because SaveState returns error, but we verify state was correctly set
@@ -2229,8 +2229,7 @@ func TestDefaultConfig(t *testing.T) {
 	config := DefaultConfig(baseDir)
 
 	assert.Equal(t, baseDir, config.BaseDir)
-	assert.Equal(t, 100, config.MaxLines)
-	assert.Equal(t, 10, config.MaxFiles)
+	assert.Equal(t, false, config.SplitPR)
 	assert.Equal(t, "claude", config.ClaudePath)
 	assert.Equal(t, 1*time.Hour, config.Timeouts.Planning)
 	assert.Equal(t, 6*time.Hour, config.Timeouts.Implementation)
@@ -3386,7 +3385,7 @@ func TestGetCIChecker(t *testing.T) {
 
 			o := &Orchestrator{
 				config:           config,
-				logger:          NewLogger(LogLevelNormal),
+				logger:           NewLogger(LogLevelNormal),
 				ciCheckerFactory: tt.ciCheckerFactory,
 			}
 

--- a/internal/workflow/types.go
+++ b/internal/workflow/types.go
@@ -49,6 +49,7 @@ type WorkflowState struct {
 	Phases       map[Phase]*PhaseState `json:"phases"`
 	Error        *WorkflowError        `json:"error,omitempty"`
 	WorktreePath string                `json:"worktreePath,omitempty"`
+	SplitPR      bool                  `json:"splitPR,omitempty"`
 }
 
 // PhaseState represents the state of a single phase


### PR DESCRIPTION
## Summary

- Add `--split-pr` CLI flag (default: false) to explicitly enable PR split phase
- Remove automatic threshold-based PR split logic (`--max-lines`, `--max-files` flags)
- Add `SplitPR` field to `WorkflowState` to persist the decision across workflow resume
- PR split now only runs when explicitly requested

## Motivation

Previously, PR split was triggered automatically based on size thresholds (lines changed > 100 or files changed > 10). This was inflexible and sometimes triggered unwanted PR splits. With this change, users explicitly opt-in to PR split via the `--split-pr` flag.

## Changes

| File | Description |
|------|-------------|
| `types.go` | Add `SplitPR bool` field to `WorkflowState` |
| `orchestrator.go` | Add `SplitPR` to Config, remove `MaxLines`/`MaxFiles`, update `executeRefactoring()` logic |
| `main.go` | Add `--split-pr` flag, remove `--max-lines`/`--max-files` flags |
| `*_test.go` | Update tests for new flag structure |

## Test plan

- [x] All existing tests pass
- [x] Build succeeds
- [x] New flag `--split-pr` appears in CLI help
- [ ] Manual test: workflow without `--split-pr` skips PR split phase
- [ ] Manual test: workflow with `--split-pr` runs PR split phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)