### PR TITLE
feat: Add golangci-lint with unused code detection

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,22 @@ on:
 
 jobs:
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+        cache: true
+
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v7
+      with:
+        version: v2.6.2
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -18,6 +34,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
+        cache: true
 
     - name: Build
       run: go build -v ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,19 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: none
+  enable:
+    # Dead code detection (replaces deprecated deadcode and varcheck)
+    - unused
+    # Detects unused assignments
+    - ineffassign
+    # Static analysis
+    - staticcheck
+
+formatters:
+  enable:
+    # Import formatting
+    - goimports

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,16 +9,16 @@ repos:
 
   - repo: local
     hooks:
-      - id: go-fmt
-        name: go fmt
-        entry: bash -c 'gofmt -l . | tee /dev/stderr | (! grep .)'
+      - id: goimports
+        name: goimports
+        entry: bash -c 'goimports -l . | tee /dev/stderr | (! grep .)'
         language: system
         files: \.go$
         pass_filenames: false
 
-      - id: go-vet
-        name: go vet
-        entry: go vet ./...
+      - id: golangci-lint
+        name: golangci-lint
+        entry: golangci-lint run ./...
         language: system
         files: \.go$
         pass_filenames: false

--- a/cmd/workflow/main.go
+++ b/cmd/workflow/main.go
@@ -146,7 +146,7 @@ func newListCmd() *cobra.Command {
 				workflow.Bold("UPDATED"),
 			)
 			for _, wf := range workflows {
-				statusStr := wf.Status
+				var statusStr string
 				switch wf.Status {
 				case "completed":
 					statusStr = workflow.Green(wf.Status)

--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -340,7 +340,7 @@ func (e *claudeExecutor) ExecuteStreaming(ctx context.Context, config ExecuteCon
 
 	// Extract output from final chunk
 	if finalChunk != nil {
-		if finalChunk.StructuredOutput != nil && len(finalChunk.StructuredOutput) > 0 {
+		if len(finalChunk.StructuredOutput) > 0 {
 			// Wrap structured output in the expected envelope format
 			envelope := map[string]interface{}{
 				"type":              "result",

--- a/internal/workflow/orchestrator.go
+++ b/internal/workflow/orchestrator.go
@@ -574,11 +574,6 @@ func (o *Orchestrator) executeImplementation(ctx context.Context, state *Workflo
 		lastError = formatCIErrors(ciResult)
 		displayCIFailure(ciResult)
 
-		prompt, err = o.promptGenerator.GenerateFixCIPrompt(lastError)
-		if err != nil {
-			return o.failWorkflow(state, fmt.Errorf("failed to generate CI fix prompt: %w", err))
-		}
-
 		if err := o.stateManager.SaveState(state.Name, state); err != nil {
 			return fmt.Errorf("failed to save state: %w", err)
 		}
@@ -723,11 +718,6 @@ func (o *Orchestrator) executeRefactoring(ctx context.Context, state *WorkflowSt
 
 		lastError = formatCIErrors(ciResult)
 		displayCIFailure(ciResult)
-
-		prompt, err = o.promptGenerator.GenerateFixCIPrompt(lastError)
-		if err != nil {
-			return o.failWorkflow(state, fmt.Errorf("failed to generate CI fix prompt: %w", err))
-		}
 
 		if err := o.stateManager.SaveState(state.Name, state); err != nil {
 			return fmt.Errorf("failed to save state: %w", err)

--- a/internal/workflow/orchestrator_test.go
+++ b/internal/workflow/orchestrator_test.go
@@ -817,7 +817,7 @@ func TestOrchestrator_executeImplementation_CIRetryLoop(t *testing.T) {
 					FailedJobs: []string{"test-job"},
 				}, nil).Once()
 
-				pg.On("GenerateFixCIPrompt", mock.Anything).Return("fix CI prompt", nil).Times(2)
+				pg.On("GenerateFixCIPrompt", mock.Anything).Return("fix CI prompt", nil).Once()
 				exec.On("ExecuteStreaming", mock.Anything, mock.Anything, mock.Anything).Return(&ExecuteResult{
 					Output:   "```json\n{\"summary\": \"fixed\"}\n```",
 					ExitCode: 0,
@@ -857,7 +857,7 @@ func TestOrchestrator_executeImplementation_CIRetryLoop(t *testing.T) {
 					FailedJobs: []string{"test-job"},
 				}, nil).Times(2)
 
-				pg.On("GenerateFixCIPrompt", mock.Anything).Return("fix CI prompt", nil).Times(3)
+				pg.On("GenerateFixCIPrompt", mock.Anything).Return("fix CI prompt", nil).Once()
 			},
 			wantErr:       true,
 			wantNextPhase: PhaseFailed,
@@ -1152,7 +1152,7 @@ func TestOrchestrator_executeRefactoring_CIRetryLoop(t *testing.T) {
 					FailedJobs: []string{"test-job"},
 				}, nil).Times(2)
 
-				pg.On("GenerateFixCIPrompt", mock.Anything).Return("fix CI prompt", nil).Times(3)
+				pg.On("GenerateFixCIPrompt", mock.Anything).Return("fix CI prompt", nil).Once()
 			},
 			wantErr:       true,
 			wantNextPhase: PhaseFailed,
@@ -1180,9 +1180,6 @@ func TestOrchestrator_executeRefactoring_CIRetryLoop(t *testing.T) {
 					Output:     "still failing",
 					FailedJobs: []string{"test-job"},
 				}, nil).Once()
-
-				// GenerateFixCIPrompt called once more before exceeding max attempts
-				pg.On("GenerateFixCIPrompt", mock.Anything).Return("fix CI prompt", nil).Once()
 			},
 			wantErr:       true,
 			wantNextPhase: PhaseFailed,

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -16,6 +16,28 @@ fi
 
 echo "pre-commit version: $(pre-commit --version)"
 
+# Check if golangci-lint is installed
+if ! command -v golangci-lint &> /dev/null; then
+    echo "ERROR: golangci-lint is not installed"
+    echo "Please install golangci-lint v2.0+:"
+    echo "  - Using go install: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest"
+    echo "  - Using homebrew: brew install golangci-lint"
+    echo "  - See https://golangci-lint.run/welcome/install/ for more options"
+    exit 1
+fi
+
+echo "golangci-lint version: $(golangci-lint version 2>&1 | head -1)"
+
+# Check if goimports is installed
+if ! command -v goimports &> /dev/null; then
+    echo "ERROR: goimports is not installed"
+    echo "Please install goimports:"
+    echo "  - Using go install: go install golang.org/x/tools/cmd/goimports@latest"
+    exit 1
+fi
+
+echo "goimports installed: $(which goimports)"
+
 # Install pre-commit hooks (idempotent)
 echo "Installing pre-commit hooks..."
 pre-commit install


### PR DESCRIPTION
## Summary

- Add golangci-lint v2 configuration with linters for unused code detection
- Integrate golangci-lint into pre-commit hooks and CI pipeline
- Fix existing lint violations found by the new linters

## Changes

### New Configuration
- **`.golangci.yml`**: v2 config enabling `unused`, `ineffassign`, `staticcheck`, and `goimports` formatters

### Pre-commit Updates
- Replace `go-fmt` with `goimports` (superset that also handles imports)
- Add `golangci-lint` hook
- Remove redundant `go-vet` (covered by staticcheck)

### CI Updates
- Add new `lint` job running `golangci-lint-action@v7`
- Runs in parallel with existing `build` job
- Added Go module caching for faster builds

### Code Fixes
- `cmd/workflow/main.go`: Fix ineffectual assignment to `statusStr`
- `internal/workflow/executor.go`: Simplify nil check (len() handles nil slices)
- `internal/workflow/orchestrator.go`: Remove dead code that generated unused prompts at end of CI retry loops

### Dev Setup
- `scripts/setup-dev.sh`: Added checks for `golangci-lint` and `goimports` installation

## Test plan

- [x] All existing tests pass
- [x] `golangci-lint run ./...` passes with 0 issues
- [x] Verify CI lint job runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)