### PR TITLE
fix: Handle 'Prompt is too long' error with automatic retry

### DIFF
--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/michael-freling/claude-code-tools/internal/command"
@@ -155,7 +156,13 @@ func (e *claudeExecutor) Execute(ctx context.Context, config ExecuteConfig) (*Ex
 
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			result.ExitCode = exitErr.ExitCode()
-			result.Error = fmt.Errorf("%s", stderr.String())
+			stderrStr := stderr.String()
+			result.Error = fmt.Errorf("%s", stderrStr)
+
+			if strings.Contains(stderrStr, "Prompt is too long") {
+				return result, fmt.Errorf("claude execution failed with exit code %d: %w", result.ExitCode, ErrPromptTooLong)
+			}
+
 			return result, fmt.Errorf("claude execution failed with exit code %d: %w", result.ExitCode, ErrClaude)
 		}
 
@@ -329,7 +336,13 @@ func (e *claudeExecutor) ExecuteStreaming(ctx context.Context, config ExecuteCon
 
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			result.ExitCode = exitErr.ExitCode()
-			result.Error = fmt.Errorf("%s", stderr.String())
+			stderrStr := stderr.String()
+			result.Error = fmt.Errorf("%s", stderrStr)
+
+			if strings.Contains(stderrStr, "Prompt is too long") {
+				return result, fmt.Errorf("claude execution failed with exit code %d: %w", result.ExitCode, ErrPromptTooLong)
+			}
+
 			return result, fmt.Errorf("claude execution failed with exit code %d: %w", result.ExitCode, ErrClaude)
 		}
 

--- a/internal/workflow/types.go
+++ b/internal/workflow/types.go
@@ -224,6 +224,7 @@ var (
 	ErrClaudeTimeout       = errors.New("claude execution timeout")
 	ErrClaudeNotFound      = errors.New("claude CLI not found in PATH")
 	ErrClaude              = errors.New("claude execution failed")
+	ErrPromptTooLong       = errors.New("prompt is too long")
 	ErrParseJSON           = errors.New("failed to parse JSON output")
 	ErrUserCancelled       = errors.New("workflow cancelled by user")
 	ErrCICheckTimeout      = errors.New("CI check command timeout")


### PR DESCRIPTION
## Summary
- Add `ErrPromptTooLong` error detection when Claude CLI returns "Prompt is too long"
- Implement retry logic in all phase handlers to add feedback and retry instead of failing
- Save state before retry to preserve feedback for the next attempt

## Test plan
- [x] New table-driven tests for ErrPromptTooLong detection in executor
- [x] New table-driven tests for retry logic in all 5 orchestrator phase handlers
- [x] All existing tests pass
- [x] Manual verification that error detection works with strings.Contains

🤖 Generated with [Claude Code](https://claude.com/claude-code)