### PR TITLE
feat: Increase workflow description limit from 1000 to 32768 characters

### DIFF
--- a/internal/workflow/limits.go
+++ b/internal/workflow/limits.go
@@ -1,0 +1,43 @@
+package workflow
+
+import (
+	"os"
+	"strconv"
+)
+
+const (
+	// DefaultMaxDescriptionLength sets the default maximum length for workflow descriptions.
+	// 32KB (32768 bytes) represents approximately 4% of Claude's 200K token context window (~8,000 tokens).
+	// This provides a reasonable limit for workflow descriptions while leaving ample room for:
+	// - System prompts and instructions
+	// - File contents and code context
+	// - Response generation and output
+	//
+	// The limit can be overridden via the CLAUDE_WORKFLOW_MAX_DESCRIPTION_LENGTH environment variable.
+	DefaultMaxDescriptionLength = 32768
+
+	// MinDescriptionLength defines the minimum acceptable description length
+	MinDescriptionLength = 1
+
+	// EnvMaxDescriptionLength is the environment variable name for configuring the maximum description length
+	EnvMaxDescriptionLength = "CLAUDE_WORKFLOW_MAX_DESCRIPTION_LENGTH"
+)
+
+// GetMaxDescriptionLength returns the configured maximum description length.
+// It checks the CLAUDE_WORKFLOW_MAX_DESCRIPTION_LENGTH environment variable.
+// If the environment variable is set and contains a valid positive integer, that value is returned.
+// Otherwise, it returns DefaultMaxDescriptionLength.
+// Invalid values (non-numeric, zero, or negative) silently fall back to the default.
+func GetMaxDescriptionLength() int {
+	envValue := os.Getenv(EnvMaxDescriptionLength)
+	if envValue == "" {
+		return DefaultMaxDescriptionLength
+	}
+
+	value, err := strconv.Atoi(envValue)
+	if err != nil || value <= 0 {
+		return DefaultMaxDescriptionLength
+	}
+
+	return value
+}

--- a/internal/workflow/limits_test.go
+++ b/internal/workflow/limits_test.go
@@ -1,0 +1,117 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMaxDescriptionLength(t *testing.T) {
+	tests := []struct {
+		name   string
+		envVal string
+		setEnv bool
+		want   int
+	}{
+		{
+			name:   "returns default when env var not set",
+			setEnv: false,
+			want:   DefaultMaxDescriptionLength,
+		},
+		{
+			name:   "returns valid env var override",
+			envVal: "65536",
+			setEnv: true,
+			want:   65536,
+		},
+		{
+			name:   "returns default for non-numeric env var",
+			envVal: "invalid",
+			setEnv: true,
+			want:   DefaultMaxDescriptionLength,
+		},
+		{
+			name:   "returns default for zero env var",
+			envVal: "0",
+			setEnv: true,
+			want:   DefaultMaxDescriptionLength,
+		},
+		{
+			name:   "returns default for negative env var",
+			envVal: "-100",
+			setEnv: true,
+			want:   DefaultMaxDescriptionLength,
+		},
+		{
+			name:   "returns default for empty string env var",
+			envVal: "",
+			setEnv: true,
+			want:   DefaultMaxDescriptionLength,
+		},
+		{
+			name:   "returns valid small positive value",
+			envVal: "1024",
+			setEnv: true,
+			want:   1024,
+		},
+		{
+			name:   "returns valid large positive value",
+			envVal: "1048576",
+			setEnv: true,
+			want:   1048576,
+		},
+		{
+			name:   "returns default for floating point value",
+			envVal: "123.45",
+			setEnv: true,
+			want:   DefaultMaxDescriptionLength,
+		},
+		{
+			name:   "returns default for value with whitespace",
+			envVal: " 1000 ",
+			setEnv: true,
+			want:   DefaultMaxDescriptionLength,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnv {
+				t.Setenv(EnvMaxDescriptionLength, tt.envVal)
+			}
+
+			got := GetMaxDescriptionLength()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestConstants(t *testing.T) {
+	tests := []struct {
+		name string
+		got  interface{}
+		want interface{}
+	}{
+		{
+			name: "DefaultMaxDescriptionLength is 32768",
+			got:  DefaultMaxDescriptionLength,
+			want: 32768,
+		},
+		{
+			name: "MinDescriptionLength is 1",
+			got:  MinDescriptionLength,
+			want: 1,
+		},
+		{
+			name: "EnvMaxDescriptionLength is correct",
+			got:  EnvMaxDescriptionLength,
+			want: "CLAUDE_WORKFLOW_MAX_DESCRIPTION_LENGTH",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.got)
+		})
+	}
+}

--- a/internal/workflow/validator.go
+++ b/internal/workflow/validator.go
@@ -48,15 +48,18 @@ func ValidateWorkflowType(wfType WorkflowType) error {
 
 // ValidateDescription validates a workflow description
 // Rules:
-// - 1-1000 characters
+// - Minimum MinDescriptionLength characters
+// - Maximum configurable length (default DefaultMaxDescriptionLength, override via CLAUDE_WORKFLOW_MAX_DESCRIPTION_LENGTH)
 // - Cannot be empty
 func ValidateDescription(desc string) error {
 	if desc == "" {
 		return fmt.Errorf("description cannot be empty")
 	}
 
-	if len(desc) > 1000 {
-		return fmt.Errorf("description too long (max 1000 characters)")
+	maxLength := GetMaxDescriptionLength()
+	if len(desc) > maxLength {
+		overLimit := len(desc) - maxLength
+		return fmt.Errorf("description too long: %d characters (max %d characters, %d over limit)", len(desc), maxLength, overLimit)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- Increase workflow description character limit from 1000 to 32768 (32KB)
- Add configurable limit via `CLAUDE_WORKFLOW_MAX_DESCRIPTION_LENGTH` environment variable
- Enhance error messages to show actual length, max length, and overage amount

## Why
The current 1000 character limit is too restrictive for detailed workflow descriptions. The new 32KB limit represents approximately 4% of Claude's 200K token context window (~8,000 tokens), leaving ample room for system prompts, file contents, and response generation.

## Changes
- **internal/workflow/limits.go** (NEW): Constants and `GetMaxDescriptionLength()` function with env var override
- **internal/workflow/limits_test.go** (NEW): Comprehensive tests for limit configuration
- **internal/workflow/validator.go**: Updated `ValidateDescription()` to use configurable limit
- **internal/workflow/validator_test.go**: Updated boundary tests and added env var override tests

## Test plan
- [x] All existing tests pass
- [x] New boundary tests at 32768/32769 characters
- [x] Environment variable override tests (valid, invalid, zero, negative values)
- [x] Error message format verification showing character counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)