### PR TITLE
docs: Add secure sandbox research and claude-forge architecture

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docs/themes/hugo-book"]
+	path = docs/themes/hugo-book
+	url = https://github.com/alex-shpak/hugo-book

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,3 @@
+public/
+resources/
+.hugo_build.lock

--- a/docs/archetypes/default.md
+++ b/docs/archetypes/default.md
@@ -1,0 +1,5 @@
+---
+date: '{{ .Date }}'
+draft: true
+title: '{{ replace .File.ContentBaseName "-" " " | title }}'
+---

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,0 +1,18 @@
+---
+title: Claude Code Tools
+type: docs
+---
+
+# Claude Code Tools
+
+Documentation and research for secure AI coding agent environments.
+
+## Secure Sandbox
+
+Research for securing AI coding agent environments.
+
+[Read the research →]({{< relref "/docs/secure-sandbox/secure-sandbox-environments" >}})
+
+## Getting Started
+
+Tools and configurations for running Claude Code securely in isolated environments.

--- a/docs/content/docs/secure-sandbox/_index.md
+++ b/docs/content/docs/secure-sandbox/_index.md
@@ -1,0 +1,9 @@
+---
+title: Secure Sandbox
+weight: 1
+bookCollapseSection: false
+---
+
+# Secure Sandbox
+
+Research for securing AI coding agent environments.

--- a/docs/content/docs/secure-sandbox/secure-sandbox-architecture.md
+++ b/docs/content/docs/secure-sandbox/secure-sandbox-architecture.md
@@ -1,0 +1,592 @@
+---
+title: "Secure Sandbox Architecture"
+weight: 2
+---
+
+# Secure Sandbox Architecture
+
+## 1. Overview
+
+`claude-forge` is a Go CLI that launches Claude Code inside an isolated Docker container, pre-authenticated and ready to work on the user's project. A companion gateway container mediates git and GitHub operations — allowing read access (clone, pull, fetch) to any repository but restricting push operations to only the current project's repository. Multiple instances can run in parallel across different project directories. The command installs locally via `go install` — container images are pulled from GHCR.io (nightly rebuilt with cosign signing for security verification).
+
+For the threat model and technology survey, see the [Secure Sandbox Environments Research]({{< relref "/docs/secure-sandbox/secure-sandbox-environments" >}}).
+
+---
+
+## 2. Architecture Diagram
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│  Host Machine (Linux only)                                               │
+│                                                                          │
+│  $ claude-forge start                (N instances in parallel)           │
+│                                                                          │
+│  ┌────────────────────────────────────────────────────────────────────┐  │
+│  │  Docker Networks (per-instance: forge-<project-id>-<session>)      │  │
+│  │                                                                    │  │
+│  │  ┌───────────────────────────────┐  ┌───────────────────────────┐  │  │
+│  │  │ Container: Agent              │  │ Container: Gateway        │  │  │
+│  │  │                               │  │                           │  │  │
+│  │  │ Claude Code                   │  │ HTTP proxy for            │  │  │
+│  │  │ --dangerously-skip-permissions│  │ github.com traffic        │  │  │
+│  │  │                               │  │                           │  │  │
+│  │  │ Git (HTTPS, via proxy):       │  │ git-upload-pack (read):   │  │  │
+│  │  │  fetch/clone/pull ──────────► │  │  → allowed, any repo     │  │  │
+│  │  │  push ──────────────────────► │  │                           │  │  │
+│  │  │                               │  │ git-receive-pack (push):  │  │  │
+│  │  │ GitHub API (via proxy):       │  │  → only project repo     │  │  │
+│  │  │  read ops ──────────────────► │  │                           │  │  │
+│  │  │  write ops ─────────────────► │  │ GitHub API:               │  │  │
+│  │  │                               │  │  read → any repo          │  │  │
+│  │  │ gh (→ forge-gh) via gateway:  │  │  write → only project repo│  │  │
+│  │  │  schema discovery ──────────► │  │                           │  │  │
+│  │  │                               │  │ Auth: host ~/.ssh/ (ro)   │  │  │
+│  │  │ Internet (direct):            │  │       + ~/.config/gh/ (ro)│  │  │
+│  │  │  npm, pip, go get ────────►   │  │                           │  │  │
+│  │  │  (no proxy)           internet│  │ forge-gh API (:8083)      │  │  │
+│  │  │                               │  │ + schema discovery        │  │  │
+│  │  │ No MCP servers                │  │                           │  │  │
+│  │  │ --privileged (for DinD)       │  │                           │  │  │
+│  │  │ non-root user                 │  │                           │  │  │
+│  │  └───────────────────────────────┘  └────────────┬──────────────┘  │  │
+│  │                                                   │                │  │
+│  │  forge_net (internal + internet for agent)        │                │  │
+│  └───────────────────────────────────────────────────┼────────────────┘  │
+│                                                      │                  │
+│  Host state:                                         ▼                  │
+│  ~/.config/claude-forge/config.yaml                 GitHub              │
+│  ~/.config/claude-forge/settings.json              (project repo only   │
+│  ~/.config/claude-forge/gitconfig                   for push/write)     │
+│  ~/.claude-forge/<project-id>/ (history)                                 │
+│  ~/.claude/.credentials.json (read at startup)                           │
+│  ~/.claude/ (skills, agents, rules, commands)                            │
+│                                                                          │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. Command Interface
+
+The command lives at `cmd/claude-forge/main.go`.
+
+```
+claude-forge
+├── start         Start a new Claude Code session in the sandbox
+├── resume        Resume a past session or list available sessions
+├── stop          Stop running instance(s) for this project
+├── status        Show running instances across all projects
+├── build         Force pull/rebuild the agent image
+├── auth          Verify Claude Code authentication is available
+└── version       Print version
+```
+
+### Primary Usage
+
+```bash
+# Common case: zero config, launches immediately
+$ cd ~/projects/my-app
+$ claude-forge start
+Starting gateway... ok
+Starting agent... ok
+Claude Code is ready.
+
+# With a worktree (Claude Code's built-in --worktree)
+$ claude-forge start --worktree
+
+# With a prompt
+$ claude-forge start --prompt "Fix the failing tests in pkg/auth/"
+
+# Opt out of --dangerously-skip-permissions
+$ claude-forge start --no-skip-permissions
+
+# List past sessions for this project
+$ claude-forge resume --list
+SESSION ID    CREATED              FIRST MESSAGE
+abc123        2026-05-08 14:30     "Fix auth middleware..."
+def456        2026-05-07 09:15     "Add unit tests for..."
+
+# Resume a specific session
+$ claude-forge resume abc123
+
+# Resume most recent session
+$ claude-forge resume
+
+# Verify auth
+$ claude-forge auth
+✓ Found credentials at ~/.claude/.credentials.json
+✓ Token valid (expires 2027-04-15)
+
+# Stop instance for this project
+$ claude-forge stop
+
+# Show all running instances
+$ claude-forge status
+PROJECT                        CONTAINER        STATUS    UPTIME
+~/projects/my-app              forge-a1b2c3     running   15m
+~/projects/other-project       forge-d4e5f6     running   3h
+```
+
+### Flags for `start`
+
+| Flag | Default | Description |
+|---|---|---|
+| `--worktree` | `false` | Pass `--worktree` to Claude Code (creates isolated git worktree) |
+| `--no-skip-permissions` | `false` | Don't pass `--dangerously-skip-permissions` |
+| `--prompt` | `""` | Pass a prompt to Claude Code |
+
+### Flags for `resume`
+
+| Flag | Default | Description |
+|---|---|---|
+| `--list` | `false` | List available sessions instead of resuming |
+
+---
+
+## 4. Authentication
+
+Claude-forge reuses the user's existing Claude Code credentials. It does NOT generate separate tokens.
+
+### Token Resolution Order
+
+```
+1. Check: ANTHROPIC_API_KEY in environment?
+   ├── Yes → use it
+   └── No ──▼
+
+2. Check: CLAUDE_CODE_OAUTH_TOKEN in environment?
+   ├── Yes → use it
+   └── No ──▼
+
+3. Check: ~/.claude/.credentials.json exists?
+   ├── Yes → read access_token and refresh_token
+   │         Pass access_token as CLAUDE_CODE_OAUTH_TOKEN to container
+   │         Store refresh_token for token refresh
+   └── No ──▼
+
+4. Error: "No Claude Code credentials found.
+          Run 'claude' on the host to log in first, or set ANTHROPIC_API_KEY."
+```
+
+Claude-forge does NOT run `claude setup-token` itself. The user must have authenticated with Claude Code on the host first (by running `claude` normally). This avoids generating extra tokens and the associated refresh-token race conditions.
+
+### Refresh Token Handling
+
+When reading `~/.claude/.credentials.json`, claude-forge extracts both the `access_token` and `refresh_token`. If the access token is expired, claude-forge uses the refresh token to obtain a new one before starting the container. The refreshed tokens are written back to `~/.claude/.credentials.json`.
+
+Each container instance receives only the access token at startup via environment variable. The credential file itself is NOT mounted into containers.
+
+---
+
+## 5. Container 1: Agent
+
+| Attribute | Value |
+|---|---|
+| **Image** | `ghcr.io/michael-freling/claude-forge-agent:latest` |
+| **Security** | `--privileged` (required for DinD), non-root user |
+| **Network** | `forge_net_<id>` — has direct internet access for package downloads. GitHub traffic (github.com, api.github.com) routes through gateway via git proxy config. |
+| **Name** | `forge-agent-<project-id>-<session-id>` (unique per instance) |
+
+### Volumes
+
+| Host path | Container path | Mode | Purpose |
+|---|---|---|---|
+| Project dir | `/work` | `rw` | Workspace |
+| `~/.claude-forge/<project-id>/` | `/home/user/.claude/projects/<project-id>/` | `rw` | Per-project session history and memory |
+| `~/CLAUDE.md` | `/home/user/CLAUDE.md` | `ro` | User-level instructions (if exists) |
+| `~/.claude/CLAUDE.md` | `/home/user/.claude/CLAUDE.md` | `ro` | User-level instructions (if exists) |
+| `~/.claude/rules/` | `/home/user/.claude/rules/` | `ro` | User-level rules |
+| `~/.claude/agents/` | `/home/user/.claude/agents/` | `ro` | User-level sub-agents |
+| `~/.claude/commands/` | `/home/user/.claude/commands/` | `ro` | User-level commands |
+| `~/.claude/skills/` | `/home/user/.claude/skills/` | `ro` | User-level skills |
+| `~/.config/claude-forge/settings.json` | `/home/user/.claude/settings.json` | `ro` | Claude Code config (if exists) |
+| `~/.config/claude-forge/gitconfig` | `/home/user/.gitconfig` | `ro` | Git config (user identity + proxy routing) |
+
+### Environment Variables
+
+```yaml
+environment:
+  CLAUDE_CODE_OAUTH_TOKEN: "<from credentials>"
+  # or: ANTHROPIC_API_KEY: "<from host env>"
+  HOME: "/home/user"
+  GIT_TERMINAL_PROMPT: "0"
+```
+
+### Git Configuration
+
+The git configuration is stored at `~/.config/claude-forge/gitconfig` on the host and mounted into the container as `/home/user/.gitconfig`. It routes GitHub traffic through the gateway:
+
+```ini
+[http "https://github.com"]
+    proxy = http://gateway:8080
+
+[http "https://api.github.com"]
+    proxy = http://gateway:8080
+
+[user]
+    name = <from host git config>
+    email = <from host git config>
+```
+
+This means:
+- `git clone https://github.com/any/repo` → routed through gateway (gateway adds auth, allows read)
+- `git push origin main` → routed through gateway (gateway validates target repo)
+- `npm install` / `pip install` / `go get` → direct internet (no proxy)
+
+### Claude Code Startup Command
+
+```bash
+claude --dangerously-skip-permissions [--worktree] [--resume <id>] [-p "<prompt>"]
+```
+
+### What is NOT in this Container
+
+- No host SSH keys (`~/.ssh/`)
+- No host `~/.claude/.credentials.json` (token passed via env var at startup)
+- No host git credentials (PAT, credential stores)
+- No MCP server configurations
+- No `~/.kube/config`, `~/.config/gcloud/`, or cloud credentials
+- No host Docker socket
+
+`gh` is available in the container as an alias for `forge-gh`, which communicates with the gateway API for all GitHub operations.
+
+---
+
+## 6. Container 2: Gateway
+
+| Attribute | Value |
+|---|---|
+| **Image** | `ghcr.io/michael-freling/claude-forge-gateway:latest` |
+| **Purpose** | HTTP proxy for github.com (git + API) with repo-scoped push enforcement |
+| **Network** | `forge_net_<id>` (internal, shared with agent) + direct internet |
+| **Name** | `forge-gateway-<project-id>-<session-id>` |
+| **Ports** | `8080` (HTTP proxy for git), `8083` (GitHub API server) |
+
+### HTTP Proxy (Port 8080): Git Operation Enforcement
+
+The gateway acts as an HTTP proxy specifically for github.com traffic. Agent's git is configured to route github.com requests through this proxy. The gateway inspects the git smart HTTP protocol (recent versions only; no backwards compatibility with legacy protocols):
+
+| Git operation | HTTP endpoint | Gateway behavior |
+|---|---|---|
+| `git clone` / `git fetch` / `git pull` | `POST /repo.git/git-upload-pack` | **Allowed for any repo.** Gateway injects auth and forwards. |
+| `git push` | `POST /repo.git/git-receive-pack` | **Allowed only for project repo.** Otherwise returns 403. |
+| Info/refs discovery | `GET /repo.git/info/refs?service=...` | Allowed for any repo (read) or project-only (push). |
+
+The gateway authenticates with GitHub on behalf of the agent using the host's credentials. It supports:
+- SSH key-based auth (translates to HTTPS using SSH-based credential lookup)
+- PAT from `~/.config/gh/hosts.yml`
+- OAuth token from `gh auth`
+
+### GitHub API Server (Port 8083): Schema Discovery and `forge-gh` Interface
+
+The gateway exposes a REST API with an OpenAPI-style schema discovery endpoint. The `forge-gh` binary in the agent container (aliased as `gh`) queries this endpoint to self-discover available operations.
+
+**Schema discovery:**
+
+```
+GET /api/schema
+```
+
+Returns an OpenAPI-style response describing all available endpoints, their methods, parameters, and whether they are read or write operations. When `forge-gh` is called with any command, it:
+
+1. Queries `GET /api/schema` from the gateway to discover available operations.
+2. Maps the requested command to the appropriate API endpoint.
+3. Executes the request against the gateway, which enforces read/write policies.
+
+This approach means:
+- New GitHub operations can be added to the gateway without updating the `forge-gh` binary.
+- The agent can discover what operations are available at runtime.
+- The gateway remains the single source of truth for what is allowed.
+
+**Policy enforcement:**
+
+- **Read operations** (list PRs, view issues, repo metadata, CI status, etc.) are allowed for any repository.
+- **Write operations** (create PR, comment, merge, create issue, etc.) are allowed only when the target matches the project's repository.
+
+The gateway enforces this policy regardless of how the operation is discovered or invoked.
+
+### Allowed Repository Identification
+
+At startup, claude-forge reads:
+
+```bash
+git remote get-url origin
+# → git@github.com:michael-freling/claude-code-tools.git
+# or: https://github.com/michael-freling/claude-code-tools.git
+```
+
+Normalized to `owner=michael-freling`, `repo=claude-code-tools`. Passed to gateway at startup.
+
+### Volumes
+
+| Host path | Container path | Mode | Purpose |
+|---|---|---|---|
+| `~/.ssh/` | `/home/user/.ssh/` | `ro` | SSH keys (for authenticating with GitHub) |
+| `~/.config/gh/` | `/home/user/.config/gh/` | `ro` | GitHub CLI auth config (tokens, hosts) |
+
+---
+
+## 7. Host-Side State
+
+### Per-Project Session Storage
+
+```
+~/.claude-forge/
+└── <project-id>/
+    ├── <session-id>.jsonl        ← conversation transcript
+    ├── <session-id>/
+    │   └── tool-results/         ← large tool outputs
+    └── memory/
+        ├── MEMORY.md             ← auto memory
+        └── *.md                  ← topic files
+```
+
+**Project ID** is derived from the container's workspace path (`/work`), not the host path. Since the workspace is always mounted at `/work`, the project-id is always `-work`.
+
+This directory is mounted into the container at `/home/user/.claude/projects/-work/` so Claude Code finds its sessions in the expected location.
+
+### Session Listing for `resume`
+
+`claude-forge resume --list` reads `.jsonl` files from `~/.claude-forge/-work/`:
+- Parses each file for session ID (filename), creation timestamp (first entry), and first user message
+- Displays as a table sorted by recency
+
+`claude-forge resume <id>` starts the container with `claude --resume <id>`.
+
+`claude-forge resume` (no argument) starts with `claude --continue` (most recent session).
+
+### Config Files
+
+**1. `~/.config/claude-forge/config.yaml`** — claude-forge settings:
+
+```yaml
+# All fields optional — zero config for common case.
+
+# Override container images
+images:
+  agent: "ghcr.io/michael-freling/claude-forge-agent:latest"
+  gateway: "ghcr.io/michael-freling/claude-forge-gateway:latest"
+
+# Default behavior
+defaults:
+  skip_permissions: true    # pass --dangerously-skip-permissions
+  worktree: false
+```
+
+**2. `~/.config/claude-forge/settings.json`** — Claude Code config for container:
+
+```json
+{
+  "hasCompletedOnboarding": true,
+  "autoUpdaterStatus": "disabled"
+}
+```
+
+Mounted as `/home/user/.claude/settings.json`. Optional — if absent, Claude Code uses defaults.
+
+**3. `~/.config/claude-forge/gitconfig`** — Git configuration for container:
+
+```ini
+[http "https://github.com"]
+    proxy = http://gateway:8080
+
+[http "https://api.github.com"]
+    proxy = http://gateway:8080
+
+[user]
+    name = Michael Freling
+    email = user@example.com
+```
+
+Mounted as `/home/user/.gitconfig`. Contains user identity and proxy routing for GitHub traffic. The user should configure their name and email here (or claude-forge can auto-populate from the host's `git config` on first run).
+
+---
+
+## 8. Worktree Mode
+
+`claude-forge start --worktree` passes `--worktree` to Claude Code inside the container. Claude Code handles everything:
+
+1. Creates a worktree at `/work/.claude/worktrees/<name>/` (which is on the host filesystem via bind mount).
+2. Works in the worktree — isolated from the main branch.
+3. On interactive exit: auto-removes worktree if no uncommitted changes.
+
+### Orphaned Worktree Cleanup
+
+Claude Code cleans orphaned worktrees automatically on startup:
+- Checks `.claude/worktrees/` in the project directory.
+- Worktrees older than 30 days (`cleanupPeriodDays`) with no uncommitted changes, untracked files, or unpushed commits → removed.
+- Worktrees with changes → kept, listed in session picker.
+
+Since worktrees live in the host project directory (via bind mount), this cleanup happens whether or not the container is running — next time the user runs `claude` on the host or `claude-forge start`, orphans are cleaned.
+
+---
+
+## 9. Multi-Instance Support
+
+Multiple `claude-forge start` in different directories run in parallel:
+
+| Resource | Naming | Isolation |
+|---|---|---|
+| Docker network | `forge_net_<project-id>_<session-id>` | Separate per instance |
+| Agent container | `forge-agent-<project-id>-<session-id>` | Unique name |
+| Gateway container | `forge-gateway-<project-id>-<session-id>` | Unique name |
+| Session history | `~/.claude-forge/<project-id>/<session-id>.jsonl` | Per-project, per-session |
+
+`claude-forge status` lists all running instances across projects.
+
+---
+
+## 10. Container Images
+
+### Image Strategy
+
+The **agent image** is published on GHCR.io with everything included (runtimes, Claude Code, forge-gh, tools). The CLI pulls this image and rebuilds locally only when the remote image digest changes or on explicit `claude-forge build`.
+
+The **gateway image** is also published on GHCR.io (Go binary + SSH/git tooling).
+
+Published on GHCR.io (free for public repos, unlimited storage and pulls):
+
+- `ghcr.io/michael-freling/claude-forge-agent:latest` — full agent image with Claude Code + runtimes + tools
+- `ghcr.io/michael-freling/claude-forge-gateway:latest` — gateway binary
+
+### Agent Image
+
+```dockerfile
+FROM ubuntu:24.04
+
+# Node.js LTS (via nodesource)
+RUN apt-get update && apt-get install -y nodejs npm \
+    && rm -rf /var/lib/apt/lists/*
+
+# Python 3
+RUN apt-get update && apt-get install -y \
+    python3 python3-pip python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+# Go (latest)
+COPY --from=golang:1.26 /usr/local/go /usr/local/go
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# Docker daemon + CLI
+RUN apt-get update && apt-get install -y docker.io \
+    && rm -rf /var/lib/apt/lists/*
+
+# Common CLIs used by Claude Code
+RUN apt-get update && apt-get install -y \
+    bash git curl jq make ripgrep \
+    tar unzip openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Claude Code
+RUN npm install -g @anthropic-ai/claude-code
+
+# forge-gh (aliased as gh)
+COPY forge-gh /usr/local/bin/forge-gh
+RUN ln -s /usr/local/bin/forge-gh /usr/local/bin/gh
+
+RUN useradd -m -s /bin/bash user
+USER user
+WORKDIR /work
+ENTRYPOINT ["claude"]
+```
+
+Includes: Node.js LTS, Python 3, Go 1.26, Docker (daemon + CLI), and common CLIs (ripgrep, git, jq, curl, make, tar, unzip, ssh-client, bash). `gh` is symlinked to `forge-gh` so Claude Code's natural `gh` commands work transparently through the gateway.
+
+Docker daemon (`dockerd`) runs inside the agent container for `docker build` and similar operations. The host Docker socket is NOT mounted.
+
+### Gateway Image (Multi-Stage)
+
+```dockerfile
+# Build stage
+FROM golang:1.26-alpine AS build
+COPY . /src
+WORKDIR /src
+RUN go build -o /gateway ./cmd/claude-forge-gateway/
+
+# Runtime stage
+FROM alpine:3.21
+RUN apk add --no-cache bash openssh-client git
+COPY --from=build /gateway /usr/local/bin/gateway
+RUN adduser -D -s /bin/bash user
+USER user
+ENTRYPOINT ["gateway"]
+```
+
+Includes `bash` and `ssh` for debugging and for SSH-based GitHub auth.
+
+### CI Workflow
+
+GitHub Actions on push to main: build both images, push to GHCR.io with `latest` + version tag. Cost: $0.
+
+### Nightly Rebuild and Security
+
+A scheduled nightly CI job rebuilds both images to pick up:
+- Claude Code releases (agent image)
+- OS security patches
+- Runtime version updates (Go, Node.js LTS, Python)
+- Dependency updates
+
+Security verification for published images:
+- **Cosign signing**: All images are signed with cosign. Users can verify image provenance before pulling.
+- **SHA256 checksums**: Published alongside each release for offline verification.
+
+### Local Image Management
+
+The CLI manages the local agent image:
+- **(b) Auto-rebuild**: On `claude-forge start`, checks if the local image digest matches the remote. Pulls/rebuilds if the remote has updated.
+- **(c) Manual rebuild**: `claude-forge build` forces a pull of the latest image regardless of digest match.
+
+---
+
+## 11. Security Model
+
+### What the Agent Can Do
+
+- Read and write files in the project workspace
+- Run any shell command (`--dangerously-skip-permissions`)
+- Git clone/fetch/pull from any repository (via gateway, which adds auth)
+- Git push to the project's own repository only (via gateway)
+- GitHub API read operations on any repo (via `gh` / `forge-gh`)
+- GitHub API write operations on project repo only (via `gh` / `forge-gh`)
+- Direct internet access for package installation (npm, pip, go get, cargo, etc.)
+
+### What the Agent Cannot Do
+
+| Blocked action | Enforcement |
+|---|---|
+| Git push to other repos | Gateway rejects `git-receive-pack` for non-project repos |
+| GitHub write ops on other repos | Gateway API server rejects non-project write requests |
+| Read host SSH keys | Not mounted in agent container — only gateway has them |
+| Read host git credentials | Not mounted in agent container |
+| Send Slack/email/calendar | No MCP servers configured |
+| Access host Docker socket | Not mounted |
+| Escape container | Non-root user, no host socket mounts, network isolation |
+| Modify user's Claude Code config | Config mounted read-only |
+| Access credentials file | Not mounted; only the token is passed via env var |
+
+### Why `--dangerously-skip-permissions` Is Safe
+
+Claude Code's permission system protects the host machine. Inside the container:
+- File destruction is limited to the mounted workspace (recoverable via git).
+- Git writes are gateway-scoped to one repo.
+- No SSH keys, git credentials, or cloud config accessible.
+- No MCP servers to abuse.
+- `--privileged` is required for DinD but the container has no host socket mounts — the Docker daemon inside is isolated from the host.
+
+The container IS the permission boundary.
+
+---
+
+## 12. Design Decisions
+
+Resolved questions from earlier iterations:
+
+1. **GitHub auth strategy for gateway.** The gateway uses ALL available auth methods: SSH keys from `~/.ssh/`, PAT from `~/.config/gh/hosts.yml`, and OAuth token from `gh auth`. It tries them in order and uses whatever succeeds.
+
+2. **`forge-gh` schema discovery.** Supports all `gh` subcommands via schema discovery. Does NOT support `gh api` style raw API access — only structured commands. If a command isn't in the schema, it returns an error.
+
+3. **Credential refresh race condition.** Not an issue — `~/.claude/.credentials.json` is NOT mounted into containers. Each instance receives only the access token via env var at startup. The CLI reads the credential file on the host at startup time; file locking on the host handles the narrow window where multiple simultaneous starts might race on token refresh.
+
+4. **Agent image management.** Auto-rebuild when remote digest changes (b) + explicit `claude-forge build` command (c).
+
+5. **Docker daemon.** Runs `dockerd` inside the agent container (DinD). Requires relaxed security: the agent container runs with `--privileged` (or equivalent capabilities) to support the Docker daemon. The host Docker socket is still NOT mounted — isolation is maintained because the in-container daemon has no access to host containers or images.

--- a/docs/content/docs/secure-sandbox/secure-sandbox-environments.md
+++ b/docs/content/docs/secure-sandbox/secure-sandbox-environments.md
@@ -1,0 +1,506 @@
+---
+title: Secure Sandbox Environments for AI Coding Agents
+weight: 1
+---
+
+# Secure Sandbox Environments for AI Coding Agents
+
+This document surveys existing technologies, products, and approaches for securing AI coding agents (Claude Code, OpenAI Codex, Cursor, GitHub Copilot, etc.) across four layers: container/VM isolation, command-level security policies, network egress control (preventing unauthorized external service interactions), and secret/credential protection.
+
+**Design constraint**: The agent must run **fully autonomously without human approval prompts**. All protection must come from automated guardrails — sandboxing, command policy, network filtering, credential proxies — not from human-in-the-loop approval workflows.
+
+## 1. Container and VM Isolation
+
+### What Major AI Agents Use
+
+| Agent | Sandbox Approach |
+|---|---|
+| **OpenAI Codex** | Firecracker micro-VMs. Network disabled by default; user can allowlist specific domains. |
+| **GitHub Copilot Coding Agent** | Ephemeral GitHub Actions runners (Azure VMs). Fresh VM per task. |
+| **Google Jules** | Google Cloud sandboxed VMs, isolated per-session. |
+| **Amazon Q Developer** | AWS-managed environments with scoped IAM permissions. |
+| **Claude Code** | No built-in sandbox. Runs directly on the host machine. Anthropic recommends Docker with restricted permissions for CI/automated use. |
+
+### Purpose-Built Sandbox Products
+
+| Product | Type | Pricing | How It Works |
+|---|---|---|---|
+| **[E2B](https://e2b.dev)** | Cloud micro-VMs for AI agents | Freemium — free 100 hrs/mo, Pro $45/mo, Enterprise custom | Firecracker-based. Per-session sandboxes with filesystem, network, and process isolation. Purpose-built for AI code execution. |
+| **[Daytona](https://daytona.io)** | Dev environment manager | Free (Apache 2.0 self-hosted), cloud has paid plans | Standardized dev environments via Docker/devcontainers. Positioning for AI agent workloads. |
+| **[Modal](https://modal.com)** | Serverless containers | Freemium — $30/mo free credits, pay-per-use after | Not agent-specific but widely used for AI workloads. Fast cold starts, GPU support. |
+| **[Fly Machines](https://fly.io)** | Micro-VM platform | Freemium — free small allowance, pay-per-use after | Firecracker-based. Some AI agent platforms use these as execution backends. |
+
+### Underlying Isolation Technologies
+
+| Technology | Type | Pricing | Who Uses It |
+|---|---|---|---|
+| **[Firecracker](https://firecracker-microvm.github.io/)** (AWS) | Micro-VMs, sub-second boot | Free (Apache 2.0) | E2B, Fly.io, OpenAI Codex |
+| **[gVisor](https://gvisor.dev)** (Google) | User-space kernel, syscall interception | Free (Apache 2.0) | GKE, cloud sandboxes |
+| **[Kata Containers](https://katacontainers.io)** | Lightweight VMs via OCI | Free (Apache 2.0) | Enterprise Kubernetes |
+| **WebAssembly (Wasm)** | Instruction-level sandbox | Free (various) | Emerging; limited POSIX support for agent workloads |
+
+**Key takeaway**: Firecracker micro-VMs are the dominant pattern for production AI agent sandboxing. E2B is the most purpose-built open-source option. Docker containers are the most common DIY approach but provide weaker isolation boundaries than micro-VMs.
+
+---
+
+## 2. Destructive Command Blocking
+
+Container isolation prevents escape to the host, but does not prevent an AI agent from running destructive commands *within* the sandbox (deleting repos, force-pushing, dropping databases, destroying cloud resources). A second layer is needed.
+
+### Open Source Tools
+
+#### Destructive Command Guard (DCG)
+
+**Repository**: [github.com/Dicklesworthstone/destructive_command_guard](https://github.com/Dicklesworthstone/destructive_command_guard)
+**Language**: Rust
+**Stars**: 872+
+**Status**: Most mature tool in this space
+
+DCG uses a four-stage pipeline:
+1. JSON parsing of the command
+2. Path normalization
+3. O(n) quick-reject substring search
+4. Pattern matching (safe patterns first, then destructive)
+
+Ships with 49+ rule packs covering:
+- **git**: `git push --force`, `git reset --hard`, `git clean -fd`
+- **filesystem**: `rm -rf /`, `rm -rf ~`, `chmod -R 777 /`
+- **database**: `DROP DATABASE`, `DROP TABLE`, `TRUNCATE`
+- **Kubernetes**: `kubectl delete namespace`, `kubectl delete node`
+- **cloud (GCP)**: `gcloud container clusters delete`, `gcloud projects delete`
+- **Docker**: `docker system prune`, `docker rm -f $(docker ps -aq)`
+- **Terraform**: `terraform destroy`
+
+Integrates with Claude Code, Gemini CLI, and GitHub Copilot CLI via PreToolUse hooks. Whitelist-first architecture with `fail_open = false` to block unparseable commands.
+
+#### Other Tools
+
+All free and open source:
+
+| Tool | Description | Maturity |
+|---|---|---|
+| **[agent-guardrails](https://github.com/roboticforce/agent-guardrails)** | Shell-based, focuses on terraform/database/k8s/cloud commands | Very early (2 stars) |
+| **[pi-guardrails](https://github.com/aliou/pi-guardrails)** | TypeScript hooks for Pi IDE. Prevents dangerous operations, protects env files. | 58 stars |
+| **[anywhere-agents](https://github.com/yzhao062/anywhere-agents)** | Portable agent configuration with built-in destructive-command guard. One config across all agents. | 155 stars |
+
+### Native Agent Permission Systems
+
+| Agent | How It Works | Limitations |
+|---|---|---|
+| **Claude Code** | Three-tier model: Allow (auto-approve), Ask (prompt user — **not applicable for autonomous execution**), Deny (block, always wins). Configured in `.claude/settings.json`. Supports glob patterns for Bash commands. PreToolUse hooks allow external tools like DCG. | Deny rules can be bypassed via token-budget attacks ([reported by Adversa AI](https://adversa.ai/blog/claude-code-security-bypass-deny-rules-disabled/)). |
+| **OpenAI Codex** | OS-enforced sandbox. Approval policies: untrusted, on-request, never, or granular. Supports deny-read glob policies. | Has a `danger-full-access` escape hatch — **violates both invariants, must not be used**. |
+| **Cursor** | Curated safe tools by default. Auto-run mode can be disabled org-wide. | CVE-2026-22708: shell built-ins (`export`, `typeset`) bypass command allowlists entirely. |
+| **GitHub Copilot** | Organization/enterprise policies via admin dashboard. MCP server allowlists. | No granular shell command policy. |
+
+---
+
+## 3. Network Egress Control and External Service Prevention
+
+Even within a sandboxed container, an AI agent with network access can interact with external services in unintended ways — posting comments on GitHub PRs, sending Slack messages, creating issues, triggering CI pipelines, commenting on Jira tickets, or calling arbitrary APIs. This section covers tools and approaches for restricting what external services an agent can reach and how it can interact with them.
+
+### Threat Vectors
+
+1. **Unintended PR/issue comments**: Agent uses `gh pr comment`, `gh issue comment`, or the GitHub API to post on public repositories
+2. **Messaging services**: Agent sends Slack messages via webhook URLs, emails via SMTP, or posts to Discord/Teams
+3. **CI/CD triggers**: Agent triggers deployments via API calls to allowed domains (e.g., GitHub Actions workflow dispatch on `api.github.com`)
+4. **Data posting to allowed APIs**: Even with a domain allowlist, an agent can POST arbitrary data to allowed domains (e.g., creating gists on `api.github.com`, uploading files to `googleapis.com`)
+5. **MCP server abuse**: Agent uses connected MCP servers (Slack, Gmail, Google Calendar) to send messages or create events as the user
+
+### Network-Level Egress Filtering Tools
+
+| Tool | Type | Pricing | How It Works |
+|---|---|---|---|
+| **[Squid](http://www.squid-cache.org/)** | HTTP forward proxy | Free (GPL) | Domain allowlist via ACLs. Supports HTTPS via CONNECT tunneling. Cannot inspect encrypted payloads but can restrict which domains are reachable. |
+| **[mitmproxy](https://mitmproxy.org/)** | HTTPS-intercepting proxy | Free (MIT) | Can inspect and filter HTTPS traffic by URL path, HTTP method, and request body. Enables fine-grained rules like "allow GET to api.github.com but block POST to /repos/*/comments". Requires CA certificate trust in the sandbox. |
+| **[Cilium](https://cilium.io/)** / eBPF | Kernel-level network policy | Free (Apache 2.0), Isovalent Enterprise (paid, now Cisco) | Fine-grained per-pod network policies in Kubernetes. Can restrict egress by domain, port, and protocol. Works at L3/L4/L7. |
+| **[Envoy Proxy](https://www.envoyproxy.io/)** | L7 proxy | Free (Apache 2.0) | Can enforce per-route policies including HTTP method restrictions, rate limiting, and request body inspection. Used as a sidecar in service mesh architectures. |
+| **Docker `--network=none`** | Built-in Docker flag | Free | Completely disables networking. Simplest option when the agent needs no internet at all. |
+| **E2B network controls** | Built-in to E2B platform | Included in E2B pricing | Configurable per-sandbox network access with domain-level restrictions. |
+
+### HTTP Method-Level Filtering
+
+Domain allowlists alone are insufficient — an agent allowed to reach `api.github.com` for `git clone` can also POST comments, create issues, or delete branches on the same domain. Finer-grained filtering is needed:
+
+**mitmproxy with scripted rules** is the most practical open-source approach for HTTP method + path filtering:
+
+```python
+# Example mitmproxy addon: allow reads, block writes to GitHub API
+from mitmproxy import http
+
+BLOCKED_PATTERNS = [
+    ("POST",   "/repos/*/issues/*/comments"),
+    ("POST",   "/repos/*/pulls/*/comments"),
+    ("POST",   "/repos/*/issues"),
+    ("POST",   "/repos/*/dispatches"),
+    ("DELETE", "/repos/*"),
+    ("PUT",    "/repos/*/pulls/*/merge"),
+    ("POST",   "/gists"),
+]
+
+def request(flow: http.HTTPFlow) -> None:
+    for method, pattern in BLOCKED_PATTERNS:
+        if flow.request.method == method and matches(flow.request.path, pattern):
+            flow.response = http.Response.make(403, b"Blocked by sandbox policy")
+```
+
+**Envoy with route-level config** can achieve similar results declaratively via YAML route rules.
+
+### MCP Server Restrictions
+
+AI coding agents increasingly connect to external services via MCP (Model Context Protocol) servers — Slack, Gmail, Google Calendar, GitHub, etc. An agent with access to the Slack MCP server can send messages as the user.
+
+| Approach | How It Works |
+|---|---|
+| **Claude Code MCP allowlists** | In `.claude/settings.json`, configure which MCP servers are available. Deny-list specific MCP tools (e.g., allow `slack_read_channel` but deny `slack_send_message`). |
+| **Don't mount MCP servers in sandbox** | Simply don't configure MCP server connections in the sandbox environment. The agent can only use CLI tools. |
+| **Read-only MCP wrappers** | Wrap MCP servers in a proxy that strips write operations, only exposing read/search tools. |
+
+### How Major Agents Handle Egress
+
+| Agent | Network Policy |
+|---|---|
+| **OpenAI Codex** | Network disabled by default. User explicitly allowlists domains. Even when enabled, only outbound HTTPS is permitted. No fine-grained method filtering. |
+| **GitHub Copilot Coding Agent** | Runs in Actions runners with standard GitHub Actions network access. No additional egress restrictions beyond what the runner provides. |
+| **Claude Code** | No network restrictions by default — runs on host. In Docker, relies on user-configured network policies. |
+| **E2B** | Configurable per-sandbox. Can be fully isolated or allowlist-based. |
+
+### Recommended Layered Approach
+
+| Layer | Tool | What It Blocks |
+|---|---|---|
+| Domain allowlist | Squid proxy | All traffic to non-approved domains |
+| HTTP method + path filtering | mitmproxy or Envoy | Write operations to approved domains (commenting, posting, deleting) |
+| MCP server restriction | Claude Code settings / don't mount | Agent access to messaging, email, calendar services |
+| Token scoping | Fine-grained GitHub PATs, read-only GCP service accounts | Blast radius even if write requests get through |
+| CLI tool restriction | Claude Code Deny rules, DCG | `gh pr comment`, `gh issue create`, `curl -X POST`, `slack` CLI |
+
+---
+
+## 4. Secret and Credential Isolation
+
+The agent must run authenticated CLI tools (kubectl, gcloud, git push, gh), but **must never have access to the underlying credentials** (Invariant 1). This is a hard architectural constraint — the agent cannot read any secrets, period. This section covers how to make CLI tools work without giving the agent credential access.
+
+### The Core Problem
+
+```
+The agent needs to run:    kubectl get pods
+Which requires:            ~/.kube/config (contains cluster CA, auth token)
+The agent CANNOT:          cat ~/.kube/config → credential files must not exist in the sandbox
+```
+
+This is why credential files must never be mounted in the sandbox. If they were, the agent could encode them (`base64`), embed them in a git commit, POST them to an allowed API, or include them in a subsequent prompt. Network filtering and command blocking don't help once the agent already has the secret.
+
+### Approach 1: Credential Proxies — Never Give the Agent the Secret
+
+Instead of mounting credential files into the sandbox, run a proxy *outside* the sandbox that injects authentication on behalf of the agent. The agent makes unauthenticated requests; the proxy adds credentials before forwarding.
+
+| Tool | What It Does | Pricing |
+|---|---|---|
+| **[Infisical Agent Vault](https://github.com/Infisical/agent-vault)** | HTTP credential proxy purpose-built for AI agents. Agent routes requests through localhost proxy; proxy injects vault-stored credentials. Agent never possesses them. | Free (open source) |
+| **`kubectl proxy`** | Binds to `127.0.0.1:8001`, forwards requests to K8s API using kubeconfig credentials. Agent talks to localhost; never reads kubeconfig. Scope down with RBAC. | Free (built into kubectl) |
+| **SSH agent forwarding** | Agent inherits `$SSH_AUTH_SOCK` (Unix socket). Can request signing operations but cannot extract the private key. Socket only works while session is alive. | Free (built into OpenSSH) |
+| **Git credential helpers** | Git's credential helper protocol serves tokens on demand via stdin/stdout without storing them in a file the agent can read. | Free (built into git) |
+| **[abox](https://github.com/X-McKay/abox)** | MicroVM sandbox with policy-enforcing credential proxy (Rust). Credentials injected at the proxy layer, not inside the VM. | Free (open source) |
+| **[botbox](https://github.com/reoring/botbox)** | K8s sidecar with deny-by-default egress and credential injection. | Free (open source) |
+| **GCP metadata server emulator** | For gcloud inside containers, emulate the GCE metadata server to serve short-lived access tokens via GCP Workload Identity Federation. The agent calls `gcloud` normally; the metadata server provides tokens without a service account key file. Alternatively, inject a short-lived access token as an env var and configure `gcloud auth activate-service-account` with it in the entrypoint (before the agent starts). | Free (GCP feature) |
+
+**How it works with kubectl proxy:**
+```
+┌─────────────────────────┐    ┌──────────────────────────────────┐
+│  Sandbox (no kubeconfig) │    │  Host / Sidecar                  │
+│                          │    │                                  │
+│  Agent runs:             │    │  kubectl proxy --port=8001       │
+│  curl localhost:8001/    │───▶│  (has kubeconfig, adds auth)     │
+│    api/v1/pods           │    │         │                        │
+│                          │    │         ▼                        │
+│  Agent CANNOT:           │    │  K8s API server (production)     │
+│  cat ~/.kube/config      │    │                                  │
+│  (file doesn't exist)    │    │  RBAC limits what agent can do   │
+└─────────────────────────┘    └──────────────────────────────────┘
+```
+
+### Approach 2: Filesystem-Level Secret Hiding (Weaker Alternative)
+
+Make credential files usable by CLI tools but not readable by the agent process. **Note**: This approach relies on correct filesystem permission configuration rather than the absence of secrets. A misconfigured ACL or privilege escalation exposes the credential. The architecture in Section 7 prefers not mounting credential files at all (Approach 1). Use this only when credential proxies are not feasible.
+
+| Tool | What It Does | Pricing |
+|---|---|---|
+| **[SecretFS](https://github.com/obormot/secretfs)** | FUSE filesystem with per-process ACLs. Credential file exists but returns `EACCES` to unauthorized processes. Can restrict by binary name, user, group, and time window. | Free (open source) |
+| **Separate user + `sudo`** | Run CLI tools under a different user that owns the credential files. The agent's user cannot read them. Tools are invoked via `sudo -u creduser kubectl ...` | Free (OS-level) |
+| **`/proc` hardening** | Mount procfs with `hidepid=2` so the agent cannot read `/proc/PID/environ` of other processes (which would reveal injected env vars). | Free (Linux kernel) |
+
+### Approach 3: Short-Lived Credential Injection
+
+Instead of mounting long-lived credentials (service account keys, SSH keys, PATs), generate short-lived tokens that auto-expire.
+
+| Tool | What It Does | Pricing |
+|---|---|---|
+| **[ghtkn](https://github.com/suzuki-shunsuke/ghtkn)** | Generates GitHub App installation tokens (1-hour TTL, per-repo scope). No long-lived PAT needed. | Free (open source) |
+| **GCP Workload Identity Federation** | Exchange an OIDC token for a 1-hour GCP access token via STS. No service account key file ever exists. | Free (GCP feature) |
+| **HashiCorp Vault** | Issues short-lived dynamic credentials for databases, cloud providers, SSH certificates. Auto-expires. | Free (open source), Enterprise paid |
+| **AWS STS `AssumeRole`** | Generate temporary credentials (15 min to 12 hours) with scoped permissions. | Free (AWS feature) |
+
+**Why short-lived credentials help**: Even if the agent reads and exfiltrates a token, it expires in minutes/hours. Combined with network egress filtering, the window for exfiltration is extremely narrow.
+
+### Approach 4: Secret Cloaking — Defense-in-Depth
+
+Under Invariant 1, credentials should not be present in the sandbox in the first place (see Approach 1). However, short-lived tokens may appear in command stdout (e.g., `gcloud auth print-access-token`). Cloaking addresses this residual risk by scrubbing secret values before they reach the LLM's context.
+
+| Tool | What It Does | Pricing |
+|---|---|---|
+| **[immunity-agent](https://github.com/PrismorSec/immunity-agent)** | Auto-cloaks secrets in prompts (replaces with hashed placeholders). Substitutes real values only at execution time. Scrubs stdout before model sees output. Works across Claude Code, Codex, Cursor, Windsurf. | Free (open source) |
+| **[agent-env](https://agent-env.com/)** | Injects secrets via `exec` (process replacement) so they never touch shell history, `.env` files, or disk. Supports SOPS encryption. | Free (open source) |
+
+### Approach 5: Exfiltration Prevention (Last Line of Defense)
+
+If the agent does read a secret, prevent it from sending it anywhere.
+
+| Layer | Tool | What It Prevents | Pricing |
+|---|---|---|---|
+| Network egress filtering | Squid proxy with domain allowlist | Exfiltration to arbitrary servers | Free |
+| Git-level scanning | gitleaks, truffleHog pre-commit hooks | Secrets committed to repos | Free |
+| Output scanning | Nightfall AI | ML-based secret detection in agent output | Freemium, paid from ~$10k+/yr |
+| Credential scoping | Fine-grained GitHub PATs, GCP service accounts | Blast radius if exfiltration succeeds | Free |
+
+### Established Credential Managers with Agent Patterns
+
+- **Bitwarden Secrets Manager**: Agent-specific integration for injecting secrets without writing to disk. Freemium — free for personal use, Teams $4/user/mo, Enterprise $6/user/mo.
+- **1Password `op-env`**: Wraps agent processes to inject secrets from 1Password vaults at runtime. Paid — Individual $2.99/mo, Teams $19.95/mo (up to 10 users), Business $7.99/user/mo.
+
+### What OpenAI Codex Does
+
+Codex uses a **two-phase runtime model**:
+1. **Setup phase** (has network, can install dependencies, accesses secrets) — runs before the agent
+2. **Agent phase** (network-isolated, secrets removed) — the AI runs here
+
+Secrets are removed before the agent starts. Exfiltration is blocked because the agent has neither the secrets nor network egress. When sandbox restrictions are weakened (`--sandbox danger-full-access`), OpenAI explicitly warns that exfiltration becomes possible. **This mode violates both invariants and must not be used.**
+
+### Recommended Approach
+
+All layers are required for defense-in-depth. The numbering indicates protection strength, not an adoption order — all must be implemented to satisfy Invariant 1.
+
+| Layer | Approach | What It Does |
+|---|---|---|
+| **Credential proxies** (primary) | kubectl proxy, SSH agent forwarding, git credential helpers, Infisical | Agent never has the secret — enforces Invariant 1 at the architectural boundary |
+| **Short-lived tokens** (primary) | ghtkn, GCP Workload Identity, Vault | Where proxies aren't feasible, tokens expire in minutes/hours |
+| **Secret cloaking** (defense-in-depth) | immunity-agent | Scrubs residual secrets (e.g., tokens in stdout) before they reach the LLM |
+| **Egress filtering** (defense-in-depth) | Squid + mitmproxy | Even if a secret is read, limits where it can be sent |
+| **Git scanning** (defense-in-depth) | gitleaks pre-commit | Catches secrets before they're pushed to repos |
+
+---
+
+## 5. Comprehensive Policy Engines
+
+These tools attempt to provide a unified governance layer across all three concerns.
+
+### Microsoft Agent Governance Toolkit
+
+**Repository**: [github.com/microsoft/agent-governance-toolkit](https://github.com/microsoft/agent-governance-toolkit)
+**License**: MIT
+**Released**: April 2026
+
+The most ambitious open-source entry in this space. Seven packages spanning Python, TypeScript, Rust, Go, and .NET.
+
+Key components:
+- **Agent OS**: Stateless policy engine intercepting every agent action before execution at sub-millisecond latency (p99 < 0.1ms)
+- **Execution rings**: Modeled on CPU privilege levels for graduated permission escalation
+- **Saga orchestration**: For multi-step agent workflows with rollback
+- **Kill switches**: Emergency halt of agent execution
+- Covers all 10 OWASP Agentic AI Top 10 risks
+- Integrates with LangChain, CrewAI, and Microsoft Agent Framework
+
+### Oktsec
+
+**Repository**: [github.com/oktsec/oktsec](https://github.com/oktsec/oktsec)
+
+Single-binary security layer for agent-to-agent communication:
+- Ed25519 message signing for authenticity
+- 175 detection rules aligned with OWASP Top 10 for Agentic Applications
+- SQLite audit logging — every tool call produces an immutable audit entry
+
+### Enterprise/Commercial Solutions
+
+| Product | Focus | Pricing | Notes |
+|---|---|---|---|
+| **[Pillar Security](https://pillar.security)** | Agentic AI governance | Paid — enterprise pricing, contact sales | Gartner 2026 Representative Vendor. Maps agent/tool/permission graphs, runs adversarial tests, enforces data privacy at runtime. |
+| **[Lakera](https://lakera.ai)** | Prompt injection defense + data protection | Freemium — free developer tier (limited calls), paid scales with usage, enterprise custom | Real-time guard via single API call. |
+| **[Galileo Agent Control](https://galileo.ai)** | Control plane for agent governance | Freemium — free tier available, paid for production scale | Partners: AWS, CrewAI, Glean. Centralized policy with runtime updates. |
+| **[Nightfall AI](https://nightfall.ai)** | DLP for AI agent output | Freemium — free tier for limited scanning, paid from ~$10k+/yr | AI-native classifiers (95% accuracy) for detecting secrets in output across SaaS, endpoints, and AI apps. |
+
+---
+
+## 6. Scalability: Boundaries Over Enumerations
+
+Sections 2–5 describe tools that rely on enumerating what to block: lists of dangerous commands, domain allowlists, per-MCP-tool deny rules, URL path patterns. This approach has a fundamental scalability problem — every new tool, API, or MCP server requires manual configuration updates. The ecosystem is converging on a different model: **define a boundary, not an enumeration**.
+
+### Pattern 1: Default-Deny with Opt-In Capabilities
+
+Start with nothing allowed. The agent has no network, no filesystem access beyond its workspace, no credentials. Capabilities are granted explicitly and narrowly.
+
+**Who does this**: OpenAI Codex runs agents in OS-enforced sandboxes with network disabled and filesystem writes restricted to the workspace by default. Users opt into network access per-domain. Web search uses a pre-indexed cache rather than live fetches.
+
+**Trade-off**: High friction for workflows requiring `npm install`, API calls, or external tools. Every project needs explicit opt-in configuration. But the security surface stays small by default, and you never have to maintain a blocklist.
+
+**Analogy**: iOS app permissions. Apps start with nothing. Each capability (camera, location, contacts) requires an explicit user grant. You don't enumerate what apps can't do.
+
+### Pattern 2: Capability-Based Sandboxing (WASI Model)
+
+Every tool call runs inside a sandbox that only has the capabilities explicitly granted to it. The tool declares what it needs; the runtime grants exactly that and nothing more.
+
+**Who does this**: Microsoft's [Wassette](https://opensource.microsoft.com/blog/2025/08/06/introducing-wassette-webassembly-based-tools-for-ai-agents/) wraps every AI agent tool call in a WebAssembly (WASI) module. The module's accessible operations — file paths, network endpoints, environment variables — are described entirely by its capability grants. No capability grant means the tool physically cannot access the resource, enforced at the sandbox boundary.
+
+**Why it scales**: You don't maintain a list of blocked actions. You maintain a small set of granted capabilities. The boundary enforces everything else. Adding a new MCP server or CLI tool doesn't require updating a blocklist — it just starts with zero capabilities.
+
+**Analogy**: Unix file descriptors. A process can only access file descriptors passed to it. It cannot open arbitrary files — the capability must be explicitly granted by the parent.
+
+### Pattern 3: Automated Risk Classification (No Human Approval)
+
+Instead of pre-configuring every possible action, classify actions by risk at runtime. High-risk actions are **automatically blocked** (not paused for human approval). Novel or unrecognized actions default to deny.
+
+**Risk dimensions for automated classification**:
+- Read vs. write
+- Internal (workspace) vs. external (network/API)
+- Data sensitivity (credentials, PII vs. source code)
+- Reversibility (git commit vs. git push --force)
+- Audience (local file vs. public PR comment)
+
+**Who does this**:
+- **Microsoft Agent Governance Toolkit** — stateless policy engine that auto-blocks actions based on declarative rules at sub-millisecond latency, no human in the loop
+- **DCG** — automatically blocks destructive commands without prompting, using pattern matching and quick-reject
+
+**Why it scales**: No need to pre-enumerate every dangerous URL or command. The system classifies actions dynamically and blocks automatically. New tools and APIs are handled by the classification engine, not by manual config updates. No human is required to be watching.
+
+**Note**: Human-in-the-loop approval patterns (Claude Code Ask mode, LangGraph interrupt(), Codex suggest mode) exist but are **not applicable** when the agent must run fully autonomously. All protection must come from automated guardrails.
+
+### Pattern 4: Narrow Roles with Just-in-Time Credentials
+
+Define agent roles like `code_reviewer`, `ci_runner`, or `deploy_agent` that bundle specific, time-limited permissions. Agents request credentials at runtime (just-in-time); credentials are discarded after the task completes.
+
+**Who does this**:
+- **[Oso](https://www.osohq.com/learn/ai-agent-permissions-delegated-access)** — delegated authorization for AI agents with policy-as-code. Library is free (Apache 2.0); Oso Cloud freemium from ~$149/mo.
+- **[WorkOS](https://workos.com/blog/ai-agent-access-control)** — agent access control with fine-grained authorization. Freemium — free up to 1M MAUs (AuthKit), SSO/SCIM from ~$125/mo per connection.
+- **[Auth0](https://auth0.com/blog/access-control-in-the-era-of-ai-agents/)** — identity-based agent permissions. Freemium — free up to 25k MAUs, paid from $35/mo (Essentials), enterprise custom.
+
+**Why it scales**: Permissions are defined at the role level, not the action level. A `code_reviewer` role can read repos and post review comments but cannot merge, deploy, or access production secrets. Adding a new tool doesn't require updating the role definition unless the tool needs a capability the role doesn't have.
+
+**Anti-pattern**: Long-lived service account tokens. An agent with a permanent GitHub PAT retains access to everything the token allows, indefinitely, regardless of what task it's performing.
+
+### Comparison of Approaches
+
+### Comparison of Approaches
+
+| Approach | Scales to new tools? | Maintenance burden | Autonomous? | Security strength |
+|---|---|---|---|---|
+| Blocklist enumeration (DCG, allowlists) | No — each new tool needs rules | High | Yes | Medium — bypasses via unknown tools |
+| Default-deny + opt-in (Codex) | Yes — new tools start blocked | Low | Yes | High |
+| Capability-based sandbox (WASI) | Yes — boundary enforces | Low | Yes | Very high |
+| Automated risk classification | Yes — classification handles novel actions | Low | Yes | High |
+| Role-based + JIT credentials | Yes — roles abstract over actions | Medium — roles need design | Yes | High |
+| Human-in-the-loop (Ask mode) | Yes | Low | **No — requires human** | High |
+
+### Practical Recommendation
+
+For fully autonomous agent execution, the most practical architecture combines these patterns:
+
+1. **Start with default-deny**: network off, no MCP servers, workspace-only filesystem, no credential files. This is the boundary — everything is blocked by default.
+2. **Grant capabilities per-project** via a config file: "this project needs GitHub API (read + push), npm registry, and Google Cloud APIs." This is the small opt-in surface.
+3. **Use credential proxies** instead of mounting credential files: kubectl proxy, SSH agent forwarding, git credential helpers. The agent never possesses the secret.
+4. **Issue JIT credentials** scoped to the task: a GitHub App installation token that expires in 1 hour, scoped to a single repo, with no `admin` permissions. **Residual risk**: JIT tokens may appear in command stdout (e.g., from a credential helper). Mitigate with secret cloaking (immunity-agent) + egress filtering + short expiry.
+5. **Automatically block destructive commands** via DCG or similar policy engine — no human confirmation, just deny.
+
+This eliminates the need for human approval while maintaining strong security guarantees. The agent runs at full speed; the guardrails are infrastructure, not prompts.
+
+---
+
+## 7. Recommendations
+
+The sandbox runs locally but connects to production services (GitHub, GCP, Kubernetes clusters, etc.). Security must protect real production environments, not just the local machine.
+
+### Recommended Stack (All Free / Open Source)
+
+All components are required to satisfy both invariants. This is not an incremental adoption list.
+
+| Layer | Tool | Enforces | Cost |
+|---|---|---|---|
+| Process isolation | Docker container with `no-new-privileges`, `cap_drop: ALL` | Both | Free |
+| Credential proxies | **kubectl proxy**, **SSH agent forwarding**, **git credential helpers**, **Infisical Agent Vault** — run on host, outside sandbox. No credential files mounted in sandbox. | Invariant 1 | Free |
+| Short-lived tokens | **ghtkn** (1-hr GitHub App tokens), **GCP Workload Identity Federation** (1-hr access tokens) | Invariant 1 | Free |
+| Command policy | **DCG** as PreToolUse hook — automatic, no human prompts | Invariant 2 | Free |
+| Domain-level egress | **Squid proxy** with domain allowlist | Invariant 1 | Free |
+| Method-level egress | **mitmproxy** with scripted rules (block POST to comment/issue/gist endpoints) | Invariant 2 | Free |
+| MCP restriction | Don't mount MCP servers (Slack, Gmail, etc.) in sandbox | Both | Free |
+| Secret cloaking (defense-in-depth) | **immunity-agent** — scrubs short-lived tokens from command stdout before they reach the LLM | Invariant 1 | Free |
+| Git scanning (defense-in-depth) | **gitleaks** pre-commit hook — catches secrets before they're pushed | Invariant 1 | Free |
+
+All components are free and open source.
+
+### Stronger Isolation (When Needed)
+
+If Docker container isolation is insufficient (e.g., running untrusted agent code), consider upgrading the isolation layer:
+
+| Option | Cost | What It Adds |
+|---|---|---|
+| **Firecracker** micro-VMs | Free (Apache 2.0) | Hardware-level isolation, sub-second boot, used by Codex |
+| **E2B** | Free up to 100 hrs/mo, Pro $45/mo | Managed Firecracker sandboxes purpose-built for AI agents |
+| **gVisor** | Free (Apache 2.0) | Syscall-level interception without full VM overhead |
+
+### Stronger Policy Enforcement (When Needed)
+
+If DCG's static rule packs are insufficient (e.g., needing runtime classification or multi-agent governance):
+
+| Option | Cost | What It Adds |
+|---|---|---|
+| **Microsoft Agent Governance Toolkit** | Free (MIT) | Stateless policy engine, execution rings, kill switches, OWASP coverage |
+| **Galileo Agent Control** | Free tier, paid for scale | Centralized policy control plane |
+| **Pillar Security** | Enterprise pricing (contact sales) | Full agent governance with adversarial testing |
+
+### Secret Detection in Outputs (When Needed)
+
+| Option | Cost | What It Adds |
+|---|---|---|
+| **gitleaks** / **truffleHog** pre-commit hooks | Free | Catch secrets before they're committed |
+| **Nightfall AI** | Free tier, paid from ~$10k+/yr | ML-based secret detection in agent output streams |
+
+### Known Gaps in the Ecosystem
+
+1. **No unified solution** covers all four layers (isolation + command policy + network egress + secret prevention) today
+2. **Bypass vectors exist** in every native permission system tested (Claude Code deny-rule bypass, Cursor CVE-2026-22708)
+3. **Domain allowlists are too coarse** — allowing `api.github.com` for git operations also allows commenting, creating issues, and dispatching workflows on the same domain. Method+path filtering (mitmproxy/Envoy) is required but adds operational complexity and TLS interception
+4. **Exfiltration via allowed channels** (pushing secrets to permitted Git repos) remains fundamentally hard to prevent without restricting write access
+5. **MCP servers are an unguarded channel** — most sandbox approaches focus on CLI/network but don't address MCP server tools that can send messages, create events, or post comments as the user
+6. **Policy-as-code standards** are not yet established — each tool has its own configuration format
+
+---
+
+## References
+
+- [Destructive Command Guard (DCG)](https://github.com/Dicklesworthstone/destructive_command_guard)
+- [immunity-agent](https://github.com/PrismorSec/immunity-agent)
+- [Microsoft Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit)
+- [E2B Sandbox](https://e2b.dev)
+- [Claude Code Permissions](https://code.claude.com/docs/en/permissions)
+- [OpenAI Codex Security](https://developers.openai.com/codex/security)
+- [Oktsec](https://github.com/oktsec/oktsec)
+- [Pillar Security](https://pillar.security)
+- [Lakera AI Agent Security](https://lakera.ai/ai-agent-security)
+- [Galileo Agent Control](https://galileo.ai)
+- [Nightfall AI](https://nightfall.ai)
+- [Squid Proxy](http://www.squid-cache.org/)
+- [mitmproxy](https://mitmproxy.org/)
+- [Envoy Proxy](https://www.envoyproxy.io/)
+- [Cilium — eBPF-based Networking](https://cilium.io/)
+- [CVE-2026-22708 — Cursor Safe Mode Bypass](https://dev.to/cverports/cve-2026-22708-trust-issues-bypassing-cursor-ais-safe-mode-via-shell-built-ins-55ao)
+- [Claude Code Deny Rule Bypass (Adversa AI)](https://adversa.ai/blog/claude-code-security-bypass-deny-rules-disabled/)
+- [Wassette: WebAssembly-based Tools for AI Agents (Microsoft)](https://opensource.microsoft.com/blog/2025/08/06/introducing-wassette-webassembly-based-tools-for-ai-agents/)
+- [Codex Agent Approvals & Security](https://developers.openai.com/codex/agent-approvals-security)
+- [Human-in-the-Loop AI Agents (StackAI)](https://www.stackai.com/insights/human-in-the-loop-ai-agents-how-to-design-approval-workflows-for-safe-and-scalable-automation)
+- [AI Agent Permissions — Delegated Access (Oso)](https://www.osohq.com/learn/ai-agent-permissions-delegated-access)
+- [AI Agent Access Control (WorkOS)](https://workos.com/blog/ai-agent-access-control)
+- [Access Control in the Era of AI Agents (Auth0)](https://auth0.com/blog/access-control-in-the-era-of-ai-agents/)
+- [Infisical Agent Vault](https://github.com/Infisical/agent-vault)
+- [SecretFS — FUSE Filesystem with Per-Process ACLs](https://github.com/obormot/secretfs)
+- [ghtkn — Short-Lived GitHub App Tokens](https://github.com/suzuki-shunsuke/ghtkn)
+- [abox — MicroVM Sandbox with Credential Proxy](https://github.com/X-McKay/abox)
+- [botbox — K8s Sidecar with Credential Injection](https://github.com/reoring/botbox)
+- [Using Proxies to Hide Secrets from Claude Code (Formal)](https://www.formal.ai/blog/using-proxies-claude-code/)
+- [GCP Workload Identity Federation](https://docs.google.com/iam/docs/workload-identity-federation)

--- a/docs/hugo.yaml
+++ b/docs/hugo.yaml
@@ -1,0 +1,21 @@
+baseURL: https://michael-freling.github.io/claude-code-tools/
+languageCode: en-us
+title: Claude Code Tools
+theme: hugo-book
+
+params:
+  BookTheme: auto
+  BookToC: true
+  BookSection: docs
+  BookRepo: https://github.com/michael-freling/claude-code-tools
+
+menu:
+  before: []
+
+markup:
+  goldmark:
+    renderer:
+      unsafe: true
+  tableOfContents:
+    startLevel: 2
+    endLevel: 4

--- a/prompt.md
+++ b/prompt.md
@@ -1,0 +1,373 @@
+# Claude Code Secure Sandbox — Implementation Prompt
+
+Build a secure, isolated sandbox for running Claude Code with full network tool access (git, gh, kubectl, docker, gcloud) while blocking destructive commands and preventing secret exfiltration. All tools must be free/open-source. The sandbox must preserve Claude Code's conversation history and configuration from the host.
+
+## Architecture Overview
+
+Two Docker containers on an internal network (no direct internet):
+1. **sandbox**: Runs Claude Code with all CLI tools and DCG hook
+2. **proxy**: Squid forward proxy with domain allowlist — the sandbox's only path to the internet
+
+Host credentials are bind-mounted read-only. Claude Code config/history is bind-mounted read-write at the same absolute path so project history is preserved across sessions.
+
+```
+Host
+├── ~/.claude/              → same path in container (rw)
+├── ~/src/.../project/      → same path in container (rw)
+├── ~/.config/gcloud/       → /creds/gcloud (ro)
+├── ~/.kube/config          → /creds/kube/config (ro)
+├── ~/.ssh/                 → /creds/ssh (ro)
+├── ~/.gitconfig            → /creds/.gitconfig (ro)
+├── ~/.config/gh/           → /creds/gh (ro)
+│
+└── Docker internal network (no direct internet)
+    ├── [proxy]  Squid — allowlist-only egress to internet
+    └── [sandbox] Claude Code + DCG — routes all traffic through proxy
+```
+
+## Files to Create
+
+### 1. `Dockerfile`
+
+Base: `ubuntu:24.04`
+
+Install:
+- `git`, `gh` (GitHub CLI), `curl`, `wget`, `jq`, `unzip`, `openssh-client`
+- `kubectl` (latest stable from dl.k8s.io)
+- `gcloud` CLI (from cloud.google.com/sdk)
+- `docker` CLI only (not the daemon — just the client binary from download.docker.com)
+- Node.js 22 LTS (from nodesource or official)
+- Claude Code via `npm install -g @anthropic-ai/claude-code`
+- Destructive Command Guard (DCG) — clone from `https://github.com/Dicklesworthstone/destructive_command_guard` and build with cargo (install Rust toolchain, build release binary, copy to /usr/local/bin, then remove Rust toolchain to keep image small)
+
+Create a non-root user matching the host user:
+```dockerfile
+ARG USER_NAME=michael
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+RUN groupadd -g $GROUP_ID $USER_NAME && useradd -u $USER_ID -g $GROUP_ID -m -s /bin/bash $USER_NAME
+USER $USER_NAME
+```
+
+### 2. `entrypoint.sh`
+
+Runs as the container entrypoint. Does the following:
+
+1. Symlink read-only credentials to expected locations:
+   ```bash
+   mkdir -p ~/.config ~/.kube
+   ln -sf /creds/gcloud ~/.config/gcloud
+   ln -sf /creds/kube/config ~/.kube/config
+   ln -sf /creds/ssh ~/.ssh
+   ln -sf /creds/.gitconfig ~/.gitconfig
+   ln -sf /creds/gh ~/.config/gh
+   ```
+
+2. Configure proxy environment variables so all CLI tools route through the squid proxy:
+   ```bash
+   export http_proxy=http://proxy:3128
+   export https_proxy=http://proxy:3128
+   export HTTP_PROXY=http://proxy:3128
+   export HTTPS_PROXY=http://proxy:3128
+   export no_proxy=localhost,127.0.0.1
+   ```
+
+3. Configure git to use the proxy:
+   ```bash
+   git config --global http.proxy http://proxy:3128
+   git config --global https.proxy http://proxy:3128
+   ```
+
+4. Exec into bash or claude (depending on args):
+   ```bash
+   exec "$@"
+   ```
+
+### 3. `proxy/Dockerfile`
+
+Base: `ubuntu:24.04`
+Install: `squid`
+Copy in `squid.conf` and `allowed-domains.txt`
+Expose port 3128
+CMD: `squid -N` (foreground mode)
+
+### 4. `proxy/allowed-domains.txt`
+
+One domain per line. These are the ONLY domains the sandbox can reach:
+
+```
+# GitHub
+.github.com
+.githubusercontent.com
+.githubassets.com
+
+# Container registries
+.gcr.io
+.docker.io
+.docker.com
+registry.hub.docker.com
+ghcr.io
+.pkg.dev
+
+# Google Cloud APIs
+.googleapis.com
+accounts.google.com
+oauth2.googleapis.com
+.cloud.google.com
+
+# Package registries
+.npmjs.org
+.npmjs.com
+registry.npmjs.org
+.pypi.org
+files.pythonhosted.org
+
+# Claude Code / Anthropic
+.anthropic.com
+.claude.ai
+
+# System
+.ubuntu.com
+.debian.org
+```
+
+Also add a placeholder section for user-specific additions:
+```
+# Add your K8s API server here:
+# k8s-api.example.com
+
+# Add other allowed domains below:
+```
+
+### 5. `proxy/squid.conf`
+
+```squid
+# Squid config for Claude Code sandbox egress filtering
+http_port 3128
+
+# Load allowed domains
+acl allowed_domains dstdomain "/etc/squid/allowed-domains.txt"
+
+# Allow CONNECT (HTTPS) to allowed domains only
+acl SSL_ports port 443
+acl CONNECT method CONNECT
+http_access allow CONNECT allowed_domains
+http_access allow allowed_domains
+
+# Deny everything else
+http_access deny all
+
+# Logging
+access_log stdio:/dev/stdout
+cache_log stdio:/dev/stderr
+
+# No caching — just proxy
+cache deny all
+
+# Security
+via off
+forwarded_for delete
+reply_header_access X-Forwarded-For deny all
+```
+
+### 6. `dcg/config.toml`
+
+DCG configuration. Enable these security packs (blocking destructive commands):
+
+```toml
+[general]
+fail_open = false  # IMPORTANT: deny on parse errors, not allow
+log_level = "info"
+
+[security_packs]
+git = true         # blocks: git push --force, git reset --hard, git clean -fd
+cloud_gcp = true   # blocks: gcloud container clusters delete, gcloud projects delete, gcloud compute instances delete
+kubernetes = true   # blocks: kubectl delete namespace, kubectl delete node, kubectl delete clusterrole
+docker = true       # blocks: docker system prune, docker rm -f $(docker ps -aq), docker rmi -f
+filesystem = true   # blocks: rm -rf /, rm -rf ~, chmod -R 777 /
+database = true     # blocks: DROP DATABASE, DROP TABLE, TRUNCATE
+terraform = true    # blocks: terraform destroy
+
+[custom_rules]
+# Add project-specific blocked commands here:
+# [[custom_rules.deny]]
+# pattern = "gcloud sql instances delete"
+# reason = "production database protection"
+```
+
+### 7. `claude-settings.json`
+
+Claude Code settings to install inside the container at `~/.claude/settings.json` (merge with existing if present, don't overwrite user's existing settings):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "dcg check --config /etc/dcg/config.toml"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Note: The DCG hook receives the command as JSON on stdin from Claude Code and exits non-zero to block it. Check DCG docs for exact integration syntax — the above is the general pattern. Adapt the command and config path based on how DCG actually accepts input.
+
+### 8. `docker-compose.yml`
+
+```yaml
+services:
+  proxy:
+    build: ./proxy
+    container_name: claude-sandbox-proxy
+    networks:
+      sandbox-net:
+    restart: unless-stopped
+
+  sandbox:
+    build: .
+    container_name: claude-sandbox
+    entrypoint: ["/entrypoint.sh"]
+    command: ["bash"]  # or "claude" to launch directly
+    stdin_open: true
+    tty: true
+    working_dir: "${PROJECT_DIR}"
+    environment:
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+    volumes:
+      # Claude Code config and history (rw — must persist)
+      - ${HOME}/.claude:${HOME}/.claude
+      # Project directory at SAME PATH for history consistency
+      - ${PROJECT_DIR}:${PROJECT_DIR}
+      # Credentials (read-only)
+      - ${HOME}/.config/gcloud:/creds/gcloud:ro
+      - ${HOME}/.kube/config:/creds/kube/config:ro
+      - ${HOME}/.ssh:/creds/ssh:ro
+      - ${HOME}/.gitconfig:/creds/.gitconfig:ro
+      - ${HOME}/.config/gh:/creds/gh:ro
+    networks:
+      sandbox-net:
+    security_opt:
+      - no-new-privileges
+    cap_drop:
+      - ALL
+    depends_on:
+      - proxy
+    # No ports exposed — sandbox has no direct internet access
+    # Docker-in-Docker: if needed, add a dind sidecar or use sysbox runtime
+
+  # Optional: Docker-in-Docker sidecar
+  # Uncomment if you need `docker build` / `docker run` inside the sandbox
+  # dind:
+  #   image: docker:dind
+  #   container_name: claude-sandbox-dind
+  #   privileged: true
+  #   environment:
+  #     - DOCKER_TLS_CERTDIR=""
+  #   networks:
+  #     sandbox-net:
+  #   # Then in sandbox, set DOCKER_HOST=tcp://dind:2375
+
+networks:
+  sandbox-net:
+    driver: bridge
+    internal: true  # NO direct internet access for containers on this network
+    # The proxy container needs internet — it gets a second network:
+
+  # Proxy's external network
+  proxy-external:
+    driver: bridge
+```
+
+**Important**: The proxy container needs to be on BOTH networks — `sandbox-net` (internal, to receive requests from sandbox) and `proxy-external` (to reach the internet). Update the proxy service:
+
+```yaml
+  proxy:
+    networks:
+      sandbox-net:
+      proxy-external:
+```
+
+The sandbox container is ONLY on `sandbox-net` (internal) so it has zero direct internet access.
+
+### 9. `sandbox.sh`
+
+Launcher script. Usage: `./sandbox.sh [project-directory] [--claude]`
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="${1:-$(pwd)}"
+PROJECT_DIR="$(cd "$PROJECT_DIR" && pwd)"  # resolve to absolute path
+
+LAUNCH_CLAUDE=false
+if [[ "${2:-}" == "--claude" ]] || [[ "${1:-}" == "--claude" ]]; then
+    LAUNCH_CLAUDE=true
+    if [[ "${1:-}" == "--claude" ]]; then
+        PROJECT_DIR="$(pwd)"
+    fi
+fi
+
+# Validate required env var
+if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+    echo "Error: ANTHROPIC_API_KEY environment variable is required"
+    exit 1
+fi
+
+export PROJECT_DIR
+export ANTHROPIC_API_KEY
+
+CMD="bash"
+if $LAUNCH_CLAUDE; then
+    CMD="claude"
+fi
+
+cd "$SCRIPT_DIR"
+
+docker compose run --rm \
+    -e PROJECT_DIR="$PROJECT_DIR" \
+    -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+    sandbox $CMD
+```
+
+Make it executable: `chmod +x sandbox.sh`
+
+## Build and run
+
+```bash
+# Build
+docker compose build
+
+# Launch interactive shell in sandbox
+./sandbox.sh /home/michael/src/github.com/my-project
+
+# Launch Claude Code directly in sandbox
+./sandbox.sh /home/michael/src/github.com/my-project --claude
+```
+
+## Security layers summary
+
+| Layer | Component | What it prevents |
+|---|---|---|
+| Process isolation | Docker container, `no-new-privileges`, `cap_drop: ALL` | Sandbox escape to host |
+| Network isolation | Docker `internal` network | Direct internet access from sandbox |
+| Egress filtering | Squid proxy with domain allowlist | Secret exfiltration to arbitrary servers |
+| Command policy | DCG PreToolUse hook | Destructive commands (delete cluster, force push, rm -rf) |
+| Credential protection | Read-only bind mounts | Modification/deletion of host credentials |
+| History preservation | Same-path bind mount of `~/.claude/` | Claude Code sees same project history as host |
+
+## Known limitations and mitigations
+
+1. **Exfil via allowed channels**: Claude could push secrets to a GitHub repo. Mitigation: use a fine-grained GitHub token scoped to specific repos only.
+2. **DCG bypass via obfuscation**: Encoding commands in base64 or using aliases might bypass DCG pattern matching. Mitigation: DCG's `fail_open = false` setting blocks unparseable commands. Additionally, the egress proxy limits where data can go even if a command executes.
+3. **gcloud token refresh**: gcloud credentials mounted read-only means token refresh writes may fail. Mitigation: run `gcloud auth print-access-token` on the host and pass the short-lived token as an env var instead, or mount just the credentials JSON read-only and let gcloud cache tokens in a writable tmpdir inside the container.
+4. **Docker-in-Docker**: If using the DinD sidecar, it runs privileged. Mitigation: it's on the internal network with no direct internet, and DCG blocks destructive docker commands. For stronger isolation, use Sysbox runtime instead.
+5. **Claude Code settings merge**: The DCG hook configuration needs to be merged with any existing user settings in `~/.claude/settings.json`, not overwrite them. The entrypoint should handle this (read existing, merge hooks, write back).


### PR DESCRIPTION
## Summary

- Add Hugo documentation site (`docs/`) with hugo-book theme for rendering
- Add research survey on securing AI coding agents (30+ tools across container isolation, command blocking, network egress, secret isolation, policy engines)
- Add `claude-forge` architecture design — a Go CLI that runs Claude Code in isolated Docker containers with a gateway for git/GitHub operation enforcement
- Include `prompt.md` — the original implementation spec

## Architecture Highlights (claude-forge)

- **Agent container**: Claude Code with `--dangerously-skip-permissions`, DinD support, Node.js/Go/Python runtimes
- **Gateway container**: HTTP proxy enforcing repo-scoped git push + GitHub API write operations via schema discovery
- **Security model**: agent cannot push to other repos, cannot access host SSH keys/credentials, GitHub write ops scoped to project repo only
- **Session management**: per-project history stored on host, resume/continue past sessions
- **Image publishing**: nightly GHCR.io rebuilds with cosign signing, auto-pull on digest change

## Test plan

- [x] Hugo site builds cleanly (`hugo --minify`)
- [ ] Verify site renders correctly at `http://localhost:1313/claude-code-tools/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)