### PR TITLE
feat: Add GitHub MCP server with tests and CI

### DIFF
--- a/.github/workflows/github-mcp.yml
+++ b/.github/workflows/github-mcp.yml
@@ -1,0 +1,88 @@
+name: GitHub MCP
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'github-mcp/**'
+      - 'docker/github-mcp/**'
+      - '.github/workflows/github-mcp.yml'
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'github-mcp/**'
+      - 'docker/github-mcp/**'
+      - '.github/workflows/github-mcp.yml'
+
+defaults:
+  run:
+    working-directory: github-mcp
+
+jobs:
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.26'
+        cache-dependency-path: github-mcp/go.sum
+
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v7
+      with:
+        version: v2.6.2
+        working-directory: github-mcp
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.26'
+        cache-dependency-path: github-mcp/go.sum
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
+
+    - name: Calculate coverage
+      run: go tool cover -func=coverage.txt
+
+    # NEVER lower this threshold. Coverage must stay at or above 90%.
+    - name: Check coverage threshold
+      run: |
+        grep -v "main.go" coverage.txt > coverage_filtered.txt
+        coverage=$(go tool cover -func=coverage_filtered.txt | grep total | awk '{print $3}' | sed 's/%//')
+        threshold=90.0
+        echo "Total coverage (excluding main.go): ${coverage}%"
+        echo "Threshold: ${threshold}%"
+        if (( $(echo "$coverage < $threshold" | bc -l) )); then
+          echo "Error: Coverage ${coverage}% is below threshold ${threshold}%"
+          exit 1
+        else
+          echo "Coverage ${coverage}% meets threshold ${threshold}%"
+        fi
+
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.26'
+        cache-dependency-path: github-mcp/go.sum
+
+    - name: Build Docker image
+      working-directory: .
+      run: docker build -t github-mcp-test -f docker/github-mcp/Dockerfile .

--- a/.github/workflows/github-mcp.yml
+++ b/.github/workflows/github-mcp.yml
@@ -31,11 +31,11 @@ jobs:
         go-version: '1.26'
         cache-dependency-path: github-mcp/go.sum
 
+    - name: Install golangci-lint
+      run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.6.2
+
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v7
-      with:
-        version: v2.6.2
-        working-directory: github-mcp
+      run: golangci-lint run ./...
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,6 +45,7 @@ jobs:
     - name: Calculate coverage
       run: go tool cover -func=coverage.txt
 
+    # NEVER lower this threshold. Coverage must stay at or above 90%.
     - name: Check coverage threshold
       run: |
         # Exclude generated mocks from coverage threshold.

--- a/docker/github-mcp/Dockerfile
+++ b/docker/github-mcp/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM golang:1.26-alpine AS build
+WORKDIR /src
+COPY github-mcp/go.mod github-mcp/go.sum ./
+RUN go mod download
+COPY github-mcp/ .
+RUN CGO_ENABLED=0 go build -o /github-mcp .
+
+# Runtime stage
+FROM alpine:3.21
+RUN apk add --no-cache bash
+COPY --from=build /github-mcp /usr/local/bin/github-mcp
+RUN adduser -D -s /bin/bash user
+USER user
+ENTRYPOINT ["github-mcp"]

--- a/github-mcp/.gitignore
+++ b/github-mcp/.gitignore
@@ -1,0 +1,2 @@
+# Compiled binary
+github-mcp

--- a/github-mcp/.golangci.yml
+++ b/github-mcp/.golangci.yml
@@ -1,0 +1,15 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: none
+  enable:
+    - unused
+    - ineffassign
+    - staticcheck
+
+formatters:
+  enable:
+    - goimports

--- a/github-mcp/github.go
+++ b/github-mcp/github.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// GitHubAuth handles GitHub authentication.
+// When backed by a hosts file, Token() re-reads the file on each call so the
+// server picks up refreshed tokens without requiring a restart.
+type GitHubAuth struct {
+	staticToken string
+	hostsPath   string
+}
+
+// NewGitHubAuth creates auth by trying methods in order:
+//  1. GITHUB_TOKEN env var
+//  2. Read PAT from ~/.config/gh/hosts.yml
+//  3. Error
+func NewGitHubAuth() (*GitHubAuth, error) {
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		return &GitHubAuth{staticToken: token}, nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("no GITHUB_TOKEN set and failed to get home directory: %w", err)
+	}
+
+	hostsPath := filepath.Join(homeDir, ".config", "gh", "hosts.yml")
+	// Validate that the file is readable and contains a token at startup.
+	if _, err := parseGHHostsFile(hostsPath); err != nil {
+		return nil, fmt.Errorf("no GITHUB_TOKEN set and failed to read gh hosts file: %w", err)
+	}
+
+	return &GitHubAuth{hostsPath: hostsPath}, nil
+}
+
+// NewGitHubAuthFromToken creates auth from an explicit token value.
+func NewGitHubAuthFromToken(token string) *GitHubAuth {
+	return &GitHubAuth{staticToken: token}
+}
+
+// Token returns the GitHub token. When backed by a hosts file, it re-reads the
+// file to pick up refreshed tokens.
+func (a *GitHubAuth) Token() string {
+	if a.staticToken != "" {
+		return a.staticToken
+	}
+	token, err := parseGHHostsFile(a.hostsPath)
+	if err != nil {
+		return ""
+	}
+	return token
+}
+
+// ghHostsFile represents the structure of ~/.config/gh/hosts.yml.
+type ghHostsFile map[string]struct {
+	OAuthToken string `yaml:"oauth_token"`
+	User       string `yaml:"user"`
+}
+
+// parseGHHostsFile reads the gh CLI hosts.yml config file and returns the
+// oauth_token for github.com.
+func parseGHHostsFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read hosts file %s: %w", path, err)
+	}
+
+	var hosts ghHostsFile
+	if err := yaml.Unmarshal(data, &hosts); err != nil {
+		return "", fmt.Errorf("failed to parse hosts file: %w", err)
+	}
+
+	gh, ok := hosts["github.com"]
+	if !ok {
+		return "", fmt.Errorf("no github.com entry found in hosts file")
+	}
+
+	if gh.OAuthToken == "" {
+		return "", fmt.Errorf("no oauth_token found for github.com in hosts file")
+	}
+
+	return gh.OAuthToken, nil
+}
+
+// defaultGitHubAPIBaseURL is the default upstream base URL for GitHub API.
+const defaultGitHubAPIBaseURL = "https://api.github.com"
+
+// GitHubClient sends requests to the GitHub API with auth headers injected.
+type GitHubClient struct {
+	baseURL    string
+	auth       *GitHubAuth
+	httpClient *http.Client
+}
+
+// NewGitHubClient creates a new GitHub API client.
+func NewGitHubClient(auth *GitHubAuth) *GitHubClient {
+	return &GitHubClient{
+		baseURL:    defaultGitHubAPIBaseURL,
+		auth:       auth,
+		httpClient: http.DefaultClient,
+	}
+}
+
+// Do sends a request to the GitHub API with auth headers injected.
+func (c *GitHubClient) Do(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+	url := c.baseURL + path
+
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.auth.Token())
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	return c.httpClient.Do(req)
+}

--- a/github-mcp/github_test.go
+++ b/github-mcp/github_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewGitHubAuth_FromEnv(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "test-token-123")
+	auth, err := NewGitHubAuth()
+	require.NoError(t, err)
+	assert.Equal(t, "test-token-123", auth.Token())
+}
+
+func TestNewGitHubAuth_FromHostsFile(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	ghDir := filepath.Join(homeDir, ".config", "gh")
+	require.NoError(t, os.MkdirAll(ghDir, 0o755))
+
+	hostsContent := `github.com:
+  oauth_token: gh-token-from-file
+  user: testuser
+`
+	require.NoError(t, os.WriteFile(filepath.Join(ghDir, "hosts.yml"), []byte(hostsContent), 0o644))
+
+	auth, err := NewGitHubAuth()
+	require.NoError(t, err)
+	assert.Equal(t, "gh-token-from-file", auth.Token())
+}
+
+func TestNewGitHubAuth_NoTokenAvailable(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("HOME", t.TempDir())
+
+	_, err := NewGitHubAuth()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no GITHUB_TOKEN set")
+}
+
+func TestNewGitHubAuthFromToken(t *testing.T) {
+	auth := NewGitHubAuthFromToken("explicit-token")
+	assert.Equal(t, "explicit-token", auth.Token())
+}
+
+func TestGitHubAuth_Token_HostsFileReread(t *testing.T) {
+	homeDir := t.TempDir()
+	ghDir := filepath.Join(homeDir, ".config", "gh")
+	require.NoError(t, os.MkdirAll(ghDir, 0o755))
+	hostsPath := filepath.Join(ghDir, "hosts.yml")
+
+	require.NoError(t, os.WriteFile(hostsPath, []byte("github.com:\n  oauth_token: token-v1\n"), 0o644))
+
+	auth := &GitHubAuth{hostsPath: hostsPath}
+	assert.Equal(t, "token-v1", auth.Token())
+
+	require.NoError(t, os.WriteFile(hostsPath, []byte("github.com:\n  oauth_token: token-v2\n"), 0o644))
+	assert.Equal(t, "token-v2", auth.Token())
+}
+
+func TestGitHubAuth_Token_HostsFileMissing(t *testing.T) {
+	auth := &GitHubAuth{hostsPath: "/nonexistent/hosts.yml"}
+	assert.Equal(t, "", auth.Token())
+}
+
+func TestParseGHHostsFile(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "hosts.yml")
+		require.NoError(t, os.WriteFile(f, []byte("github.com:\n  oauth_token: tok123\n"), 0o644))
+		token, err := parseGHHostsFile(f)
+		require.NoError(t, err)
+		assert.Equal(t, "tok123", token)
+	})
+
+	t.Run("no github.com entry", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "hosts.yml")
+		require.NoError(t, os.WriteFile(f, []byte("gitlab.com:\n  oauth_token: tok\n"), 0o644))
+		_, err := parseGHHostsFile(f)
+		assert.ErrorContains(t, err, "no github.com entry")
+	})
+
+	t.Run("empty token", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "hosts.yml")
+		require.NoError(t, os.WriteFile(f, []byte("github.com:\n  oauth_token: \"\"\n"), 0o644))
+		_, err := parseGHHostsFile(f)
+		assert.ErrorContains(t, err, "no oauth_token found")
+	})
+
+	t.Run("invalid yaml", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "hosts.yml")
+		require.NoError(t, os.WriteFile(f, []byte(":::invalid"), 0o644))
+		_, err := parseGHHostsFile(f)
+		assert.ErrorContains(t, err, "failed to parse")
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		_, err := parseGHHostsFile("/nonexistent")
+		assert.ErrorContains(t, err, "failed to read")
+	})
+}
+
+func TestGitHubClient_Do(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		assert.Equal(t, "application/vnd.github+json", r.Header.Get("Accept"))
+		assert.Equal(t, "2022-11-28", r.Header.Get("X-GitHub-Api-Version"))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	auth := NewGitHubAuthFromToken("test-token")
+	client := &GitHubClient{
+		baseURL:    srv.URL,
+		auth:       auth,
+		httpClient: http.DefaultClient,
+	}
+
+	resp, err := client.Do(context.Background(), http.MethodGet, "/repos/o/r", nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestGitHubClient_Do_WithBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	auth := NewGitHubAuthFromToken("tok")
+	client := &GitHubClient{baseURL: srv.URL, auth: auth, httpClient: http.DefaultClient}
+
+	resp, err := client.Do(context.Background(), http.MethodPost, "/x", http.NoBody)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+}

--- a/github-mcp/go.mod
+++ b/github-mcp/go.mod
@@ -1,0 +1,13 @@
+module github.com/michael-freling/claude-code-tools/github-mcp
+
+go 1.26.0
+
+require (
+	github.com/stretchr/testify v1.11.1
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+)

--- a/github-mcp/go.sum
+++ b/github-mcp/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/github-mcp/main.go
+++ b/github-mcp/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+func main() {
+	owner := flag.String("owner", "", "Allowed GitHub repository owner (required)")
+	repo := flag.String("repo", "", "Allowed GitHub repository name (required)")
+	addr := flag.String("addr", ":8083", "Listen address")
+	flag.Parse()
+
+	if *owner == "" || *repo == "" {
+		fmt.Fprintln(os.Stderr, "error: --owner and --repo are required")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	auth, err := NewGitHubAuth()
+	if err != nil {
+		log.Fatalf("Failed to initialize GitHub auth: %v", err)
+	}
+
+	client := NewGitHubClient(auth)
+	policy := &Policy{AllowedOwner: *owner, AllowedRepo: *repo}
+	server := NewServer(*owner, *repo, policy, client)
+
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", server)
+
+	httpServer := &http.Server{
+		Addr:    *addr,
+		Handler: mux,
+	}
+
+	// Graceful shutdown on SIGINT/SIGTERM.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		log.Printf("GitHub MCP starting: addr=%s owner=%s repo=%s", *addr, *owner, *repo)
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("Server error: %v", err)
+		}
+	}()
+
+	<-ctx.Done()
+	log.Println("Shutting down...")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := httpServer.Shutdown(shutdownCtx); err != nil {
+		log.Fatalf("Shutdown error: %v", err)
+	}
+
+	log.Println("Server stopped")
+}

--- a/github-mcp/policy.go
+++ b/github-mcp/policy.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Policy enforces owner/repo restrictions on tool calls.
+type Policy struct {
+	AllowedOwner string
+	AllowedRepo  string
+}
+
+// CheckTool validates whether a tool call is allowed based on the tool's
+// read/write classification and the target owner/repo.
+//
+// Rules:
+//   - Read operations: always allowed (any repo)
+//   - Write operations: only allowed if targetOwner/targetRepo matches
+//     AllowedOwner/AllowedRepo (case-insensitive)
+func (p *Policy) CheckTool(toolName string, isWrite bool, targetOwner, targetRepo string) error {
+	if !isWrite {
+		return nil
+	}
+
+	if !strings.EqualFold(targetOwner, p.AllowedOwner) || !strings.EqualFold(targetRepo, p.AllowedRepo) {
+		return fmt.Errorf("write access denied: tool %s targets %s/%s but only %s/%s is allowed",
+			toolName, targetOwner, targetRepo, p.AllowedOwner, p.AllowedRepo)
+	}
+
+	return nil
+}

--- a/github-mcp/policy_test.go
+++ b/github-mcp/policy_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPolicy_ReadAlwaysAllowed(t *testing.T) {
+	p := &Policy{AllowedOwner: "my-owner", AllowedRepo: "my-repo"}
+
+	tests := []struct {
+		name  string
+		tool  string
+		owner string
+		repo  string
+	}{
+		{"same repo", "github_pr_list", "my-owner", "my-repo"},
+		{"different repo", "github_pr_list", "other-owner", "other-repo"},
+		{"different owner same repo", "github_issue_get", "other-owner", "my-repo"},
+		{"same owner different repo", "github_repo_get", "my-owner", "other-repo"},
+		{"empty owner/repo", "github_pr_list", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := p.CheckTool(tt.tool, false, tt.owner, tt.repo)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestPolicy_WriteAllowedForMatchingRepo(t *testing.T) {
+	p := &Policy{AllowedOwner: "my-owner", AllowedRepo: "my-repo"}
+
+	err := p.CheckTool("github_pr_create", true, "my-owner", "my-repo")
+	assert.NoError(t, err)
+}
+
+func TestPolicy_WriteDeniedForDifferentRepo(t *testing.T) {
+	p := &Policy{AllowedOwner: "my-owner", AllowedRepo: "my-repo"}
+
+	tests := []struct {
+		name  string
+		owner string
+		repo  string
+	}{
+		{"different owner and repo", "other-owner", "other-repo"},
+		{"same owner different repo", "my-owner", "other-repo"},
+		{"different owner same repo", "other-owner", "my-repo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := p.CheckTool("github_pr_create", true, tt.owner, tt.repo)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "write access denied")
+		})
+	}
+}
+
+func TestPolicy_CaseInsensitiveMatching(t *testing.T) {
+	p := &Policy{AllowedOwner: "My-Owner", AllowedRepo: "My-Repo"}
+
+	tests := []struct {
+		name  string
+		owner string
+		repo  string
+	}{
+		{"lowercase", "my-owner", "my-repo"},
+		{"uppercase", "MY-OWNER", "MY-REPO"},
+		{"mixed case", "mY-oWnEr", "mY-rEpO"},
+		{"exact case", "My-Owner", "My-Repo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := p.CheckTool("github_pr_create", true, tt.owner, tt.repo)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestPolicy_GitHubApiReadVsWrite(t *testing.T) {
+	p := &Policy{AllowedOwner: "my-owner", AllowedRepo: "my-repo"}
+
+	// Read (isWrite=false) on different repo should be allowed
+	err := p.CheckTool("github_api", false, "other-owner", "other-repo")
+	assert.NoError(t, err)
+
+	// Write (isWrite=true) on different repo should be denied
+	err = p.CheckTool("github_api", true, "other-owner", "other-repo")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "write access denied")
+
+	// Write (isWrite=true) on allowed repo should be allowed
+	err = p.CheckTool("github_api", true, "my-owner", "my-repo")
+	assert.NoError(t, err)
+}

--- a/github-mcp/server.go
+++ b/github-mcp/server.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+)
+
+// jsonRPCRequest represents a JSON-RPC 2.0 request.
+type jsonRPCRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// jsonRPCResponse represents a JSON-RPC 2.0 response.
+type jsonRPCResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  any             `json:"result,omitempty"`
+	Error   *jsonRPCError   `json:"error,omitempty"`
+}
+
+// jsonRPCError represents a JSON-RPC 2.0 error.
+type jsonRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// MCP content types.
+type mcpContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type mcpToolResult struct {
+	Content []mcpContent `json:"content"`
+	IsError bool         `json:"isError,omitempty"`
+}
+
+// Server implements the MCP Streamable HTTP protocol for GitHub API operations.
+type Server struct {
+	owner  string
+	repo   string
+	policy *Policy
+	github *GitHubClient
+}
+
+// NewServer creates a new MCP server.
+func NewServer(owner, repo string, policy *Policy, github *GitHubClient) *Server {
+	return &Server{
+		owner:  owner,
+		repo:   repo,
+		policy: policy,
+		github: github,
+	}
+}
+
+// ServeHTTP handles HTTP requests to the MCP endpoint.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		json.NewEncoder(w).Encode(jsonRPCResponse{
+			JSONRPC: "2.0",
+			Error: &jsonRPCError{
+				Code:    -32600,
+				Message: "only POST is supported",
+			},
+		})
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(jsonRPCResponse{
+			JSONRPC: "2.0",
+			Error: &jsonRPCError{
+				Code:    -32700,
+				Message: "failed to read request body",
+			},
+		})
+		return
+	}
+
+	var req jsonRPCRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(jsonRPCResponse{
+			JSONRPC: "2.0",
+			Error: &jsonRPCError{
+				Code:    -32700,
+				Message: "parse error: invalid JSON",
+			},
+		})
+		return
+	}
+
+	resp := s.handleRequest(r, &req)
+	if resp == nil {
+		// Notification - no response needed (e.g., notifications/initialized)
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleRequest dispatches a JSON-RPC request to the appropriate handler.
+func (s *Server) handleRequest(r *http.Request, req *jsonRPCRequest) *jsonRPCResponse {
+	switch req.Method {
+	case "initialize":
+		return s.handleInitialize(req)
+	case "notifications/initialized":
+		// No-op notification, no response
+		return nil
+	case "tools/list":
+		return s.handleToolsList(req)
+	case "tools/call":
+		return s.handleToolsCall(r, req)
+	default:
+		return &jsonRPCResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error: &jsonRPCError{
+				Code:    -32601,
+				Message: "method not found",
+			},
+		}
+	}
+}
+
+// handleInitialize returns MCP server info and capabilities.
+func (s *Server) handleInitialize(req *jsonRPCRequest) *jsonRPCResponse {
+	return &jsonRPCResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Result: map[string]any{
+			"protocolVersion": "2025-03-26",
+			"capabilities":    map[string]any{"tools": map[string]any{}},
+			"serverInfo": map[string]any{
+				"name":    "github-mcp",
+				"version": "1.0.0",
+			},
+		},
+	}
+}
+
+// handleToolsList returns all available tool definitions.
+func (s *Server) handleToolsList(req *jsonRPCRequest) *jsonRPCResponse {
+	return &jsonRPCResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Result: map[string]any{
+			"tools": allToolDefinitions(),
+		},
+	}
+}
+
+// toolsCallParams represents the parameters for a tools/call request.
+type toolsCallParams struct {
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments"`
+}
+
+// handleToolsCall executes a tool and returns the result.
+func (s *Server) handleToolsCall(r *http.Request, req *jsonRPCRequest) *jsonRPCResponse {
+	var params toolsCallParams
+	if req.Params != nil {
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			return &jsonRPCResponse{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Error: &jsonRPCError{
+					Code:    -32602,
+					Message: "invalid params: " + err.Error(),
+				},
+			}
+		}
+	}
+
+	if params.Name == "" {
+		return &jsonRPCResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error: &jsonRPCError{
+				Code:    -32602,
+				Message: "missing tool name",
+			},
+		}
+	}
+
+	if params.Arguments == nil {
+		params.Arguments = map[string]any{}
+	}
+
+	result, isError, err := executeTool(r.Context(), params.Name, params.Arguments, s.owner, s.repo, s.policy, s.github)
+	if err != nil {
+		log.Printf("tool %s error: %v", params.Name, err)
+		return &jsonRPCResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Result: mcpToolResult{
+				Content: []mcpContent{{Type: "text", Text: err.Error()}},
+				IsError: true,
+			},
+		}
+	}
+
+	return &jsonRPCResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Result: mcpToolResult{
+			Content: []mcpContent{{Type: "text", Text: result}},
+			IsError: isError,
+		},
+	}
+}

--- a/github-mcp/server_test.go
+++ b/github-mcp/server_test.go
@@ -1,0 +1,464 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestServer creates an MCP Server with its GitHub client pointed at the
+// given test server URL.
+func newTestServer(ghURL string) *Server {
+	auth := NewGitHubAuthFromToken("test-token")
+	client := NewGitHubClient(auth)
+	client.baseURL = ghURL
+	policy := &Policy{AllowedOwner: "my-owner", AllowedRepo: "my-repo"}
+	return NewServer("my-owner", "my-repo", policy, client)
+}
+
+// mcpCall sends a JSON-RPC request to the MCP server and returns the response.
+func mcpCall(t *testing.T, server *Server, method string, params any) *jsonRPCResponse {
+	t.Helper()
+	reqBody := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  method,
+	}
+	if params != nil {
+		reqBody["params"] = params
+	}
+	body, err := json.Marshal(reqBody)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	server.ServeHTTP(w, req)
+
+	if w.Code == http.StatusNoContent {
+		return nil
+	}
+
+	var resp jsonRPCResponse
+	err = json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	return &resp
+}
+
+func TestInitialize(t *testing.T) {
+	server := newTestServer("http://unused")
+	resp := mcpCall(t, server, "initialize", nil)
+
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.Error)
+	assert.Equal(t, "2.0", resp.JSONRPC)
+
+	result, ok := resp.Result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "2025-03-26", result["protocolVersion"])
+
+	serverInfo, ok := result["serverInfo"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "github-mcp", serverInfo["name"])
+	assert.Equal(t, "1.0.0", serverInfo["version"])
+
+	capabilities, ok := result["capabilities"].(map[string]any)
+	require.True(t, ok)
+	_, hasTools := capabilities["tools"]
+	assert.True(t, hasTools)
+}
+
+func TestToolsList(t *testing.T) {
+	server := newTestServer("http://unused")
+	resp := mcpCall(t, server, "tools/list", nil)
+
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.Error)
+
+	result, ok := resp.Result.(map[string]any)
+	require.True(t, ok)
+
+	toolsRaw, ok := result["tools"]
+	require.True(t, ok)
+
+	// Re-marshal and unmarshal to get proper types
+	toolsJSON, err := json.Marshal(toolsRaw)
+	require.NoError(t, err)
+
+	var tools []ToolDefinition
+	err = json.Unmarshal(toolsJSON, &tools)
+	require.NoError(t, err)
+
+	// Verify we have at least 15 tools
+	assert.GreaterOrEqual(t, len(tools), 15)
+
+	// Check expected tool names exist
+	toolNames := make(map[string]bool)
+	for _, tool := range tools {
+		toolNames[tool.Name] = true
+		assert.NotEmpty(t, tool.Description)
+		assert.NotNil(t, tool.InputSchema)
+	}
+
+	expectedTools := []string{
+		"github_pr_list", "github_pr_get", "github_pr_create",
+		"github_pr_update", "github_pr_merge", "github_pr_comment",
+		"github_pr_reviews", "github_issue_list", "github_issue_get",
+		"github_issue_create", "github_issue_comment", "github_repo_get",
+		"github_release_list", "github_checks_list", "github_api",
+	}
+	for _, name := range expectedTools {
+		assert.True(t, toolNames[name], "missing tool: %s", name)
+	}
+}
+
+func TestToolsCall_ReadAllowed(t *testing.T) {
+	ghAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		assert.Equal(t, "application/vnd.github+json", r.Header.Get("Accept"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[{"number":1,"title":"Test PR"}]`))
+	}))
+	defer ghAPI.Close()
+
+	server := newTestServer(ghAPI.URL)
+
+	// Read from a different repo should be allowed
+	resp := mcpCall(t, server, "tools/call", map[string]any{
+		"name": "github_pr_list",
+		"arguments": map[string]any{
+			"owner": "other-owner",
+			"repo":  "other-repo",
+			"state": "open",
+		},
+	})
+
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.Error)
+
+	resultJSON, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+
+	var result mcpToolResult
+	err = json.Unmarshal(resultJSON, &result)
+	require.NoError(t, err)
+
+	assert.False(t, result.IsError)
+	assert.Len(t, result.Content, 1)
+	assert.Equal(t, "text", result.Content[0].Type)
+	assert.Contains(t, result.Content[0].Text, "Test PR")
+}
+
+func TestToolsCall_WriteAllowed(t *testing.T) {
+	var capturedPath string
+	var capturedMethod string
+	var capturedBody string
+
+	ghAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedMethod = r.Method
+		body := make([]byte, r.ContentLength)
+		r.Body.Read(body)
+		capturedBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"number":42,"title":"New PR"}`))
+	}))
+	defer ghAPI.Close()
+
+	server := newTestServer(ghAPI.URL)
+
+	resp := mcpCall(t, server, "tools/call", map[string]any{
+		"name": "github_pr_create",
+		"arguments": map[string]any{
+			"title": "New PR",
+			"head":  "feature-branch",
+			"base":  "main",
+		},
+	})
+
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.Error)
+
+	resultJSON, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+
+	var result mcpToolResult
+	err = json.Unmarshal(resultJSON, &result)
+	require.NoError(t, err)
+
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Content[0].Text, "New PR")
+	assert.Equal(t, "/repos/my-owner/my-repo/pulls", capturedPath)
+	assert.Equal(t, http.MethodPost, capturedMethod)
+	assert.Contains(t, capturedBody, `"title":"New PR"`)
+}
+
+func TestToolsCall_WriteDenied(t *testing.T) {
+	// No GitHub API server needed - request should be denied before making the call
+	server := newTestServer("http://unused")
+
+	// github_pr_create is a write tool and always uses the configured owner/repo,
+	// so it will always target my-owner/my-repo. To test denial, we need a tool
+	// that could target a different repo. Use github_api with POST method.
+	resp := mcpCall(t, server, "tools/call", map[string]any{
+		"name": "github_api",
+		"arguments": map[string]any{
+			"method": "POST",
+			"path":   "/repos/other-owner/other-repo/pulls",
+			"body":   `{"title":"hack"}`,
+		},
+	})
+
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.Error) // JSON-RPC level OK, but tool result has error
+
+	resultJSON, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+
+	var result mcpToolResult
+	err = json.Unmarshal(resultJSON, &result)
+	require.NoError(t, err)
+
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content[0].Text, "write access denied")
+}
+
+func TestToolsCall_GitHubAPIError(t *testing.T) {
+	ghAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		w.Write([]byte(`{"message":"Validation Failed","errors":[{"resource":"PullRequest","code":"custom","message":"No commits between main and main"}]}`))
+	}))
+	defer ghAPI.Close()
+
+	server := newTestServer(ghAPI.URL)
+
+	resp := mcpCall(t, server, "tools/call", map[string]any{
+		"name": "github_pr_create",
+		"arguments": map[string]any{
+			"title": "Bad PR",
+			"head":  "main",
+			"base":  "main",
+		},
+	})
+
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.Error)
+
+	resultJSON, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+
+	var result mcpToolResult
+	err = json.Unmarshal(resultJSON, &result)
+	require.NoError(t, err)
+
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content[0].Text, "Validation Failed")
+}
+
+func TestToolsCall_UnknownTool(t *testing.T) {
+	server := newTestServer("http://unused")
+
+	resp := mcpCall(t, server, "tools/call", map[string]any{
+		"name":      "nonexistent_tool",
+		"arguments": map[string]any{},
+	})
+
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.Error) // JSON-RPC level OK
+
+	resultJSON, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+
+	var result mcpToolResult
+	err = json.Unmarshal(resultJSON, &result)
+	require.NoError(t, err)
+
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content[0].Text, "unknown tool")
+}
+
+func TestToolsCall_GitHubApi_ReadAllowed(t *testing.T) {
+	ghAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"full_name":"other-owner/other-repo"}`))
+	}))
+	defer ghAPI.Close()
+
+	server := newTestServer(ghAPI.URL)
+
+	resp := mcpCall(t, server, "tools/call", map[string]any{
+		"name": "github_api",
+		"arguments": map[string]any{
+			"method": "GET",
+			"path":   "/repos/other-owner/other-repo",
+		},
+	})
+
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.Error)
+
+	resultJSON, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+
+	var result mcpToolResult
+	err = json.Unmarshal(resultJSON, &result)
+	require.NoError(t, err)
+
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Content[0].Text, "other-owner/other-repo")
+}
+
+func TestToolsCall_GitHubApi_WriteDenied(t *testing.T) {
+	server := newTestServer("http://unused")
+
+	resp := mcpCall(t, server, "tools/call", map[string]any{
+		"name": "github_api",
+		"arguments": map[string]any{
+			"method": "POST",
+			"path":   "/repos/other-owner/other-repo/issues",
+			"body":   `{"title":"test"}`,
+		},
+	})
+
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.Error)
+
+	resultJSON, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+
+	var result mcpToolResult
+	err = json.Unmarshal(resultJSON, &result)
+	require.NoError(t, err)
+
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content[0].Text, "write access denied")
+}
+
+func TestInvalidMethod(t *testing.T) {
+	server := newTestServer("http://unused")
+
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	w := httptest.NewRecorder()
+	server.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+
+	var resp jsonRPCResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.NotNil(t, resp.Error)
+	assert.Equal(t, -32600, resp.Error.Code)
+}
+
+func TestInvalidJSON(t *testing.T) {
+	server := newTestServer("http://unused")
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader("this is not json{{{"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	server.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp jsonRPCResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.NotNil(t, resp.Error)
+	assert.Equal(t, -32700, resp.Error.Code)
+	assert.Contains(t, resp.Error.Message, "parse error")
+}
+
+func TestNotificationsInitialized(t *testing.T) {
+	server := newTestServer("http://unused")
+
+	reqBody := `{"jsonrpc":"2.0","method":"notifications/initialized"}`
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	server.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+func TestUnknownMethod(t *testing.T) {
+	server := newTestServer("http://unused")
+
+	resp := mcpCall(t, server, "unknown/method", nil)
+	require.NotNil(t, resp)
+	assert.NotNil(t, resp.Error)
+	assert.Equal(t, -32601, resp.Error.Code)
+	assert.Contains(t, resp.Error.Message, "method not found")
+}
+
+func TestToolsCall_MissingName(t *testing.T) {
+	server := newTestServer("http://unused")
+	resp := mcpCall(t, server, "tools/call", map[string]any{"arguments": map[string]any{}})
+	require.NotNil(t, resp)
+	assert.NotNil(t, resp.Error)
+	assert.Equal(t, -32602, resp.Error.Code)
+	assert.Contains(t, resp.Error.Message, "missing tool name")
+}
+
+func TestToolsCall_NilArguments(t *testing.T) {
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[]`))
+	}))
+	defer gh.Close()
+
+	server := newTestServer(gh.URL)
+	resp := mcpCall(t, server, "tools/call", map[string]any{
+		"name": "github_pr_list",
+	})
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.Error)
+}
+
+func TestToolsCall_BuildRequestError(t *testing.T) {
+	server := newTestServer("http://unused")
+	resp := mcpCall(t, server, "tools/call", map[string]any{
+		"name":      "github_pr_get",
+		"arguments": map[string]any{},
+	})
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.Error)
+	result, ok := resp.Result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, result["isError"])
+}
+
+func TestServeHTTP_GETMethodNotAllowed(t *testing.T) {
+	server := newTestServer("http://unused")
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	w := httptest.NewRecorder()
+	server.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+func TestToolsCall_GitHubAPIReturnsError(t *testing.T) {
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+	defer gh.Close()
+
+	server := newTestServer(gh.URL)
+	resp := mcpCall(t, server, "tools/call", map[string]any{
+		"name":      "github_repo_get",
+		"arguments": map[string]any{},
+	})
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.Error)
+	result, ok := resp.Result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, result["isError"])
+}

--- a/github-mcp/tools.go
+++ b/github-mcp/tools.go
@@ -1,0 +1,714 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// ToolDefinition is the MCP tool definition returned by tools/list.
+type ToolDefinition struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	InputSchema any    `json:"inputSchema"`
+}
+
+// toolDef is the internal tool definition that includes execution metadata.
+type toolDef struct {
+	Definition ToolDefinition
+	Method     string // HTTP method (GET, POST, PATCH, PUT, DELETE)
+	PathTmpl   string // URL path template with {owner}, {repo}, {number}, etc.
+	IsWrite    bool   // whether this is a write operation
+
+	// buildRequest constructs the GitHub API method, path, and body from the
+	// tool arguments and the server's configured owner/repo.
+	buildRequest func(args map[string]any, owner, repo string) (method, path string, body io.Reader, err error)
+}
+
+// jsonSchema is a helper for building JSON Schema objects.
+type jsonSchema struct {
+	Type       string              `json:"type"`
+	Properties map[string]property `json:"properties,omitempty"`
+	Required   []string            `json:"required,omitempty"`
+}
+
+type property struct {
+	Type        string   `json:"type"`
+	Description string   `json:"description,omitempty"`
+	Enum        []string `json:"enum,omitempty"`
+}
+
+// toolRegistry is the registry of all available MCP tools.
+var toolRegistry map[string]*toolDef
+
+func init() {
+	toolRegistry = map[string]*toolDef{
+		"github_pr_list":       prListTool(),
+		"github_pr_get":        prGetTool(),
+		"github_pr_create":     prCreateTool(),
+		"github_pr_update":     prUpdateTool(),
+		"github_pr_merge":      prMergeTool(),
+		"github_pr_comment":    prCommentTool(),
+		"github_pr_reviews":    prReviewsTool(),
+		"github_issue_list":    issueListTool(),
+		"github_issue_get":     issueGetTool(),
+		"github_issue_create":  issueCreateTool(),
+		"github_issue_comment": issueCommentTool(),
+		"github_repo_get":      repoGetTool(),
+		"github_release_list":  releaseListTool(),
+		"github_checks_list":   checksListTool(),
+		"github_api":           apiTool(),
+	}
+}
+
+// allToolDefinitions returns all tool definitions for the tools/list response.
+func allToolDefinitions() []ToolDefinition {
+	defs := make([]ToolDefinition, 0, len(toolRegistry))
+	for _, td := range toolRegistry {
+		defs = append(defs, td.Definition)
+	}
+	return defs
+}
+
+// executeTool runs a tool call against the GitHub API.
+func executeTool(ctx context.Context, name string, args map[string]any, owner, repo string, policy *Policy, client *GitHubClient) (string, bool, error) {
+	td, ok := toolRegistry[name]
+	if !ok {
+		return "", false, fmt.Errorf("unknown tool: %s", name)
+	}
+
+	method, path, body, err := td.buildRequest(args, owner, repo)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to build request: %w", err)
+	}
+
+	// Determine target owner/repo for policy check.
+	targetOwner, targetRepo := extractOwnerRepo(path)
+	isWrite := td.IsWrite
+	// For github_api, determine read/write from the method.
+	if name == "github_api" {
+		isWrite = method != http.MethodGet && method != http.MethodHead
+	}
+
+	if err := policy.CheckTool(name, isWrite, targetOwner, targetRepo); err != nil {
+		return "", false, err
+	}
+
+	resp, err := client.Do(ctx, method, path, body)
+	if err != nil {
+		return "", false, fmt.Errorf("GitHub API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return string(respBody), true, nil
+	}
+
+	return string(respBody), false, nil
+}
+
+// extractOwnerRepo extracts the owner and repo from a GitHub API path.
+func extractOwnerRepo(path string) (string, string) {
+	path = strings.TrimPrefix(path, "/")
+	parts := strings.Split(path, "/")
+	for i := 0; i < len(parts)-2; i++ {
+		if parts[i] == "repos" {
+			return parts[i+1], parts[i+2]
+		}
+	}
+	return "", ""
+}
+
+// resolveOwnerRepo returns the owner/repo to use for a read-only tool call.
+// If the args contain owner/repo overrides, those are used; otherwise the
+// server's configured owner/repo is used.
+func resolveOwnerRepo(args map[string]any, defaultOwner, defaultRepo string) (string, string) {
+	owner := defaultOwner
+	repo := defaultRepo
+	if v, ok := args["owner"]; ok {
+		if s, ok := v.(string); ok && s != "" {
+			owner = s
+		}
+	}
+	if v, ok := args["repo"]; ok {
+		if s, ok := v.(string); ok && s != "" {
+			repo = s
+		}
+	}
+	return owner, repo
+}
+
+// getString safely extracts a string from the args map.
+func getString(args map[string]any, key string) string {
+	if v, ok := args[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// getNumber safely extracts a number (as int) from the args map.
+// JSON numbers are unmarshaled as float64.
+func getNumber(args map[string]any, key string) (int, bool) {
+	if v, ok := args[key]; ok {
+		switch n := v.(type) {
+		case float64:
+			return int(n), true
+		case int:
+			return n, true
+		case json.Number:
+			i, err := n.Int64()
+			if err == nil {
+				return int(i), true
+			}
+		}
+	}
+	return 0, false
+}
+
+// addQueryParam adds a query parameter to a path if the value is non-empty.
+func addQueryParam(path, key, value string) string {
+	if value == "" {
+		return path
+	}
+	sep := "?"
+	if strings.Contains(path, "?") {
+		sep = "&"
+	}
+	return path + sep + url.QueryEscape(key) + "=" + url.QueryEscape(value)
+}
+
+// addQueryParamInt adds an integer query parameter to a path if present in args.
+func addQueryParamInt(path string, args map[string]any, key string) string {
+	if n, ok := getNumber(args, key); ok {
+		return addQueryParam(path, key, fmt.Sprintf("%d", n))
+	}
+	return path
+}
+
+// jsonBody creates a JSON body from a map.
+func jsonBody(m map[string]any) io.Reader {
+	data, _ := json.Marshal(m)
+	return strings.NewReader(string(data))
+}
+
+// --- Read tools (allow owner/repo override) ---
+
+func prListTool() *toolDef {
+	return &toolDef{
+		Definition: ToolDefinition{
+			Name:        "github_pr_list",
+			Description: "List pull requests",
+			InputSchema: jsonSchema{
+				Type: "object",
+				Properties: map[string]property{
+					"owner":     {Type: "string", Description: "Repository owner (optional, overrides default)"},
+					"repo":      {Type: "string", Description: "Repository name (optional, overrides default)"},
+					"state":     {Type: "string", Description: "Filter by state", Enum: []string{"open", "closed", "all"}},
+					"per_page":  {Type: "number", Description: "Results per page (max 100)"},
+					"sort":      {Type: "string", Description: "Sort field", Enum: []string{"created", "updated", "popularity", "long-running"}},
+					"direction": {Type: "string", Description: "Sort direction", Enum: []string{"asc", "desc"}},
+					"page":      {Type: "number", Description: "Page number"},
+				},
+			},
+		},
+		Method:   http.MethodGet,
+		PathTmpl: "/repos/{owner}/{repo}/pulls",
+		IsWrite:  false,
+		buildRequest: func(args map[string]any, owner, repo string) (string, string, io.Reader, error) {
+			o, r := resolveOwnerRepo(args, owner, repo)
+			path := fmt.Sprintf("/repos/%s/%s/pulls", o, r)
+			path = addQueryParam(path, "state", getString(args, "state"))
+			path = addQueryParamInt(path, args, "per_page")
+			path = addQueryParam(path, "sort", getString(args, "sort"))
+			path = addQueryParam(path, "direction", getString(args, "direction"))
+			path = addQueryParamInt(path, args, "page")
+			return http.MethodGet, path, nil, nil
+		},
+	}
+}
+
+func prGetTool() *toolDef {
+	return &toolDef{
+		Definition: ToolDefinition{
+			Name:        "github_pr_get",
+			Description: "Get a pull request",
+			InputSchema: jsonSchema{
+				Type: "object",
+				Properties: map[string]property{
+					"owner":  {Type: "string", Description: "Repository owner (optional, overrides default)"},
+					"repo":   {Type: "string", Description: "Repository name (optional, overrides default)"},
+					"number": {Type: "number", Description: "Pull request number"},
+				},
+				Required: []string{"number"},
+			},
+		},
+		Method:   http.MethodGet,
+		PathTmpl: "/repos/{owner}/{repo}/pulls/{number}",
+		IsWrite:  false,
+		buildRequest: func(args map[string]any, owner, repo string) (string, string, io.Reader, error) {
+			num, ok := getNumber(args, "number")
+			if !ok {
+				return "", "", nil, fmt.Errorf("missing required parameter: number")
+			}
+			o, r := resolveOwnerRepo(args, owner, repo)
+			path := fmt.Sprintf("/repos/%s/%s/pulls/%d", o, r, num)
+			return http.MethodGet, path, nil, nil
+		},
+	}
+}
+
+func prReviewsTool() *toolDef {
+	return &toolDef{
+		Definition: ToolDefinition{
+			Name:        "github_pr_reviews",
+			Description: "List PR reviews",
+			InputSchema: jsonSchema{
+				Type: "object",
+				Properties: map[string]property{
+					"owner":  {Type: "string", Description: "Repository owner (optional, overrides default)"},
+					"repo":   {Type: "string", Description: "Repository name (optional, overrides default)"},
+					"number": {Type: "number", Description: "Pull request number"},
+				},
+				Required: []string{"number"},
+			},
+		},
+		Method:   http.MethodGet,
+		PathTmpl: "/repos/{owner}/{repo}/pulls/{number}/reviews",
+		IsWrite:  false,
+		buildRequest: func(args map[string]any, owner, repo string) (string, string, io.Reader, error) {
+			num, ok := getNumber(args, "number")
+			if !ok {
+				return "", "", nil, fmt.Errorf("missing required parameter: number")
+			}
+			o, r := resolveOwnerRepo(args, owner, repo)
+			path := fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews", o, r, num)
+			return http.MethodGet, path, nil, nil
+		},
+	}
+}
+
+func issueListTool() *toolDef {
+	return &toolDef{
+		Definition: ToolDefinition{
+			Name:        "github_issue_list",
+			Description: "List issues",
+			InputSchema: jsonSchema{
+				Type: "object",
+				Properties: map[string]property{
+					"owner":    {Type: "string", Description: "Repository owner (optional, overrides default)"},
+					"repo":     {Type: "string", Description: "Repository name (optional, overrides default)"},
+					"state":    {Type: "string", Description: "Filter by state", Enum: []string{"open", "closed", "all"}},
+					"per_page": {Type: "number", Description: "Results per page (max 100)"},
+					"labels":   {Type: "string", Description: "Comma-separated list of label names"},
+					"page":     {Type: "number", Description: "Page number"},
+				},
+			},
+		},
+		Method:   http.MethodGet,
+		PathTmpl: "/repos/{owner}/{repo}/issues",
+		IsWrite:  false,
+		buildRequest: func(args map[string]any, owner, repo string) (string, string, io.Reader, error) {
+			o, r := resolveOwnerRepo(args, owner, repo)
+			path := fmt.Sprintf("/repos/%s/%s/issues", o, r)
+			path = addQueryParam(path, "state", getString(args, "state"))
+			path = addQueryParamInt(path, args, "per_page")
+			path = addQueryParam(path, "labels", getString(args, "labels"))
+			path = addQueryParamInt(path, args, "page")
+			return http.MethodGet, path, nil, nil
+		},
+	}
+}
+
+func issueGetTool() *toolDef {
+	return &toolDef{
+		Definition: ToolDefinition{
+			Name:        "github_issue_get",
+			Description: "Get an issue",
+			InputSchema: jsonSchema{
+				Type: "object",
+				Properties: map[string]property{
+					"owner":  {Type: "string", Description: "Repository owner (optional, overrides default)"},
+					"repo":   {Type: "string", Description: "Repository name (optional, overrides default)"},
+					"number": {Type: "number", Description: "Issue number"},
+				},
+				Required: []string{"number"},
+			},
+		},
+		Method:   http.MethodGet,
+		PathTmpl: "/repos/{owner}/{repo}/issues/{number}",
+		IsWrite:  false,
+		buildRequest: func(args map[string]any, owner, repo string) (string, string, io.Reader, error) {
+			num, ok := getNumber(args, "number")
+			if !ok {
+				return "", "", nil, fmt.Errorf("missing required parameter: number")
+			}
+			o, r := resolveOwnerRepo(args, owner, repo)
+			path := fmt.Sprintf("/repos/%s/%s/issues/%d", o, r, num)
+			return http.MethodGet, path, nil, nil
+		},
+	}
+}
+
+func repoGetTool() *toolDef {
+	return &toolDef{
+		Definition: ToolDefinition{
+			Name:        "github_repo_get",
+			Description: "Get repository info",
+			InputSchema: jsonSchema{
+				Type: "object",
+				Properties: map[string]property{
+					"owner": {Type: "string", Description: "Repository owner (optional, overrides default)"},
+					"repo":  {Type: "string", Description: "Repository name (optional, overrides default)"},
+				},
+			},
+		},
+		Method:   http.MethodGet,
+		PathTmpl: "/repos/{owner}/{repo}",
+		IsWrite:  false,
+		buildRequest: func(args map[string]any, owner, repo string) (string, string, io.Reader, error) {
+			o, r := resolveOwnerRepo(args, owner, repo)
+			path := fmt.Sprintf("/repos/%s/%s", o, r)
+			return http.MethodGet, path, nil, nil
+		},
+	}
+}
+
+func releaseListTool() *toolDef {
+	return &toolDef{
+		Definition: ToolDefinition{
+			Name:        "github_release_list",
+			Description: "List releases",
+			InputSchema: jsonSchema{
+				Type: "object",
+				Properties: map[string]property{
+					"owner":    {Type: "string", Description: "Repository owner (optional, overrides default)"},
+					"repo":     {Type: "string", Description: "Repository name (optional, overrides default)"},
+					"per_page": {Type: "number", Description: "Results per page (max 100)"},
+				},
+			},
+		},
+		Method:   http.MethodGet,
+		PathTmpl: "/repos/{owner}/{repo}/releases",
+		IsWrite:  false,
+		buildRequest: func(args map[string]any, owner, repo string) (string, string, io.Reader, error) {
+			o, r := resolveOwnerRepo(args, owner, repo)
+			path := fmt.Sprintf("/repos/%s/%s/releases", o, r)
+			path = addQueryParamInt(path, args, "per_page")
+			return http.MethodGet, path, nil, nil
+		},
+	}
+}
+
+func checksListTool() *toolDef {
+	return &toolDef{
+		Definition: ToolDefinition{
+			Name:        "github_checks_list",
+			Description: "List check runs for a ref",
+			InputSchema: jsonSchema{
+				Type: "object",
+				Properties: map[string]property{
+					"owner": {Type: "string", Description: "Repository owner (optional, overrides default)"},
+					"repo":  {Type: "string", Description: "Repository name (optional, overrides default)"},
+					"ref":   {Type: "string", Description: "Git ref (branch, tag, or SHA)"},
+				},
+				Required: []string{"ref"},
+			},
+		},
+		Method:   http.MethodGet,
+		PathTmpl: "/repos/{owner}/{repo}/commits/{ref}/check-runs",
+		IsWrite:  false,
+		buildRequest: func(args map[string]any, owner, repo string) (string, string, io.Reader, error) {
+			ref := getString(args, "ref")
+			if ref == "" {
+				return "", "", nil, fmt.Errorf("missing required parameter: ref")
+			}
+			o, r := resolveOwnerRepo(args, owner, repo)
+			path := fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs", o, r, ref)
+			return http.MethodGet, path, nil, nil
+		},
+	}
+}
+
+// --- Write tools (always use configured owner/repo) ---
+
+func prCreateTool() *toolDef {
+	return &toolDef{
+		Definition: ToolDefinition{
+			Name:        "github_pr_create",
+			Description: "Create a pull request",
+			InputSchema: jsonSchema{
+				Type: "object",
+				Properties: map[string]property{
+					"title": {Type: "string", Description: "PR title"},
+					"head":  {Type: "string", Description: "Branch containing changes"},
+					"body":  {Type: "string", Description: "PR description"},
+					"base":  {Type: "string", Description: "Branch to merge into (default: repo default branch)"},
+				},
+				Required: []string{"title", "head"},
+			},
+		},
+		Method:   http.MethodPost,
+		PathTmpl: "/repos/{owner}/{repo}/pulls",
+		IsWrite:  true,
+		buildRequest: func(args map[string]any, owner, repo string) (string, string, io.Reader, error) {
+			title := getString(args, "title")
+			if title == "" {
+				return "", "", nil, fmt.Errorf("missing required parameter: title")
+			}
+			head := getString(args, "head")
+			if head == "" {
+				return "", "", nil, fmt.Errorf("missing required parameter: head")
+			}
+			path := fmt.Sprintf("/repos/%s/%s/pulls", owner, repo)
+			bodyMap := map[string]any{"title": title, "head": head}
+			if v := getString(args, "body"); v != "" {
+				bodyMap["body"] = v
+			}
+			if v := getString(args, "base"); v != "" {
+				bodyMap["base"] = v
+			}
+			return http.MethodPost, path, jsonBody(bodyMap), nil
+		},
+	}
+}
+
+func prUpdateTool() *toolDef {
+	return &toolDef{
+		Definition: ToolDefinition{
+			Name:        "github_pr_update",
+			Description: "Update a pull request",
+			InputSchema: jsonSchema{
+				Type: "object",
+				Properties: map[string]property{
+					"number": {Type: "number", Description: "Pull request number"},
+					"title":  {Type: "string", Description: "New title"},
+					"body":   {Type: "string", Description: "New description"},
+					"state":  {Type: "string", Description: "New state", Enum: []string{"open", "closed"}},
+					"base":   {Type: "string", Description: "New base branch"},
+				},
+				Required: []string{"number"},
+			},
+		},
+		Method:   http.MethodPatch,
+		PathTmpl: "/repos/{owner}/{repo}/pulls/{number}",
+		IsWrite:  true,
+		buildRequest: func(args map[string]any, owner, repo string) (string, string, io.Reader, error) {
+			num, ok := getNumber(args, "number")
+			if !ok {
+				return "", "", nil, fmt.Errorf("missing required parameter: number")
+			}
+			path := fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, num)
+			bodyMap := map[string]any{}
+			if v := getString(args, "title"); v != "" {
+				bodyMap["title"] = v
+			}
+			if v := getString(args, "body"); v != "" {
+				bodyMap["body"] = v
+			}
+			if v := getString(args, "state"); v != "" {
+				bodyMap["state"] = v
+			}
+			if v := getString(args, "base"); v != "" {
+				bodyMap["base"] = v
+			}
+			return http.MethodPatch, path, jsonBody(bodyMap), nil
+		},
+	}
+}
+
+func prMergeTool() *toolDef {
+	return &toolDef{
+		Definition: ToolDefinition{
+			Name:        "github_pr_merge",
+			Description: "Merge a pull request",
+			InputSchema: jsonSchema{
+				Type: "object",
+				Properties: map[string]property{
+					"number":       {Type: "number", Description: "Pull request number"},
+					"merge_method": {Type: "string", Description: "Merge method", Enum: []string{"merge", "squash", "rebase"}},
+					"commit_title": {Type: "string", Description: "Custom merge commit title"},
+				},
+				Required: []string{"number"},
+			},
+		},
+		Method:   http.MethodPut,
+		PathTmpl: "/repos/{owner}/{repo}/pulls/{number}/merge",
+		IsWrite:  true,
+		buildRequest: func(args map[string]any, owner, repo string) (string, string, io.Reader, error) {
+			num, ok := getNumber(args, "number")
+			if !ok {
+				return "", "", nil, fmt.Errorf("missing required parameter: number")
+			}
+			path := fmt.Sprintf("/repos/%s/%s/pulls/%d/merge", owner, repo, num)
+			bodyMap := map[string]any{}
+			if v := getString(args, "merge_method"); v != "" {
+				bodyMap["merge_method"] = v
+			}
+			if v := getString(args, "commit_title"); v != "" {
+				bodyMap["commit_title"] = v
+			}
+			return http.MethodPut, path, jsonBody(bodyMap), nil
+		},
+	}
+}
+
+func prCommentTool() *toolDef {
+	return &toolDef{
+		Definition: ToolDefinition{
+			Name:        "github_pr_comment",
+			Description: "Comment on a PR",
+			InputSchema: jsonSchema{
+				Type: "object",
+				Properties: map[string]property{
+					"number": {Type: "number", Description: "Pull request number"},
+					"body":   {Type: "string", Description: "Comment body"},
+				},
+				Required: []string{"number", "body"},
+			},
+		},
+		Method:   http.MethodPost,
+		PathTmpl: "/repos/{owner}/{repo}/issues/{number}/comments",
+		IsWrite:  true,
+		buildRequest: func(args map[string]any, owner, repo string) (string, string, io.Reader, error) {
+			num, ok := getNumber(args, "number")
+			if !ok {
+				return "", "", nil, fmt.Errorf("missing required parameter: number")
+			}
+			body := getString(args, "body")
+			if body == "" {
+				return "", "", nil, fmt.Errorf("missing required parameter: body")
+			}
+			path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, repo, num)
+			return http.MethodPost, path, jsonBody(map[string]any{"body": body}), nil
+		},
+	}
+}
+
+func issueCreateTool() *toolDef {
+	return &toolDef{
+		Definition: ToolDefinition{
+			Name:        "github_issue_create",
+			Description: "Create an issue",
+			InputSchema: jsonSchema{
+				Type: "object",
+				Properties: map[string]property{
+					"title":  {Type: "string", Description: "Issue title"},
+					"body":   {Type: "string", Description: "Issue body"},
+					"labels": {Type: "string", Description: "Comma-separated list of label names"},
+				},
+				Required: []string{"title"},
+			},
+		},
+		Method:   http.MethodPost,
+		PathTmpl: "/repos/{owner}/{repo}/issues",
+		IsWrite:  true,
+		buildRequest: func(args map[string]any, owner, repo string) (string, string, io.Reader, error) {
+			title := getString(args, "title")
+			if title == "" {
+				return "", "", nil, fmt.Errorf("missing required parameter: title")
+			}
+			path := fmt.Sprintf("/repos/%s/%s/issues", owner, repo)
+			bodyMap := map[string]any{"title": title}
+			if v := getString(args, "body"); v != "" {
+				bodyMap["body"] = v
+			}
+			if v := getString(args, "labels"); v != "" {
+				labels := strings.Split(v, ",")
+				trimmed := make([]string, 0, len(labels))
+				for _, l := range labels {
+					l = strings.TrimSpace(l)
+					if l != "" {
+						trimmed = append(trimmed, l)
+					}
+				}
+				bodyMap["labels"] = trimmed
+			}
+			return http.MethodPost, path, jsonBody(bodyMap), nil
+		},
+	}
+}
+
+func issueCommentTool() *toolDef {
+	return &toolDef{
+		Definition: ToolDefinition{
+			Name:        "github_issue_comment",
+			Description: "Comment on an issue",
+			InputSchema: jsonSchema{
+				Type: "object",
+				Properties: map[string]property{
+					"number": {Type: "number", Description: "Issue number"},
+					"body":   {Type: "string", Description: "Comment body"},
+				},
+				Required: []string{"number", "body"},
+			},
+		},
+		Method:   http.MethodPost,
+		PathTmpl: "/repos/{owner}/{repo}/issues/{number}/comments",
+		IsWrite:  true,
+		buildRequest: func(args map[string]any, owner, repo string) (string, string, io.Reader, error) {
+			num, ok := getNumber(args, "number")
+			if !ok {
+				return "", "", nil, fmt.Errorf("missing required parameter: number")
+			}
+			body := getString(args, "body")
+			if body == "" {
+				return "", "", nil, fmt.Errorf("missing required parameter: body")
+			}
+			path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, repo, num)
+			return http.MethodPost, path, jsonBody(map[string]any{"body": body}), nil
+		},
+	}
+}
+
+// --- Catch-all tool ---
+
+func apiTool() *toolDef {
+	return &toolDef{
+		Definition: ToolDefinition{
+			Name:        "github_api",
+			Description: "Raw GitHub API call (catch-all for any endpoint)",
+			InputSchema: jsonSchema{
+				Type: "object",
+				Properties: map[string]property{
+					"method": {Type: "string", Description: "HTTP method (GET, POST, PUT, PATCH, DELETE)"},
+					"path":   {Type: "string", Description: "GitHub API path (e.g. /repos/owner/repo/pulls)"},
+					"body":   {Type: "string", Description: "Request body (JSON string)"},
+				},
+				Required: []string{"method", "path"},
+			},
+		},
+		Method:   "",    // determined at runtime
+		PathTmpl: "",    // determined at runtime
+		IsWrite:  false, // determined at runtime based on method
+		buildRequest: func(args map[string]any, owner, repo string) (string, string, io.Reader, error) {
+			method := strings.ToUpper(getString(args, "method"))
+			if method == "" {
+				return "", "", nil, fmt.Errorf("missing required parameter: method")
+			}
+			path := getString(args, "path")
+			if path == "" {
+				return "", "", nil, fmt.Errorf("missing required parameter: path")
+			}
+			// Ensure path starts with /
+			if !strings.HasPrefix(path, "/") {
+				path = "/" + path
+			}
+			var body io.Reader
+			if b := getString(args, "body"); b != "" {
+				body = strings.NewReader(b)
+			}
+			return method, path, body, nil
+		},
+	}
+}

--- a/github-mcp/tools_test.go
+++ b/github-mcp/tools_test.go
@@ -1,0 +1,447 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllToolDefinitions(t *testing.T) {
+	defs := allToolDefinitions()
+	assert.Len(t, defs, len(toolRegistry))
+
+	names := make(map[string]bool)
+	for _, d := range defs {
+		assert.NotEmpty(t, d.Name)
+		assert.NotEmpty(t, d.Description)
+		assert.False(t, names[d.Name], "duplicate tool name: %s", d.Name)
+		names[d.Name] = true
+	}
+}
+
+func TestPRListTool_BuildRequest(t *testing.T) {
+	td := prListTool()
+
+	t.Run("defaults", func(t *testing.T) {
+		method, path, body, err := td.buildRequest(map[string]any{}, "owner", "repo")
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodGet, method)
+		assert.Equal(t, "/repos/owner/repo/pulls", path)
+		assert.Nil(t, body)
+	})
+
+	t.Run("with query params", func(t *testing.T) {
+		args := map[string]any{
+			"state":     "open",
+			"per_page":  float64(50),
+			"sort":      "updated",
+			"direction": "desc",
+			"page":      float64(2),
+		}
+		method, path, body, err := td.buildRequest(args, "owner", "repo")
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodGet, method)
+		assert.Contains(t, path, "state=open")
+		assert.Contains(t, path, "per_page=50")
+		assert.Contains(t, path, "sort=updated")
+		assert.Contains(t, path, "direction=desc")
+		assert.Contains(t, path, "page=2")
+		assert.Nil(t, body)
+	})
+
+	t.Run("owner/repo override", func(t *testing.T) {
+		args := map[string]any{"owner": "other", "repo": "thing"}
+		_, path, _, err := td.buildRequest(args, "default-owner", "default-repo")
+		require.NoError(t, err)
+		assert.Contains(t, path, "/repos/other/thing/pulls")
+	})
+}
+
+func TestPRGetTool_BuildRequest(t *testing.T) {
+	td := prGetTool()
+
+	t.Run("valid", func(t *testing.T) {
+		method, path, body, err := td.buildRequest(map[string]any{"number": float64(42)}, "o", "r")
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodGet, method)
+		assert.Equal(t, "/repos/o/r/pulls/42", path)
+		assert.Nil(t, body)
+	})
+
+	t.Run("missing number", func(t *testing.T) {
+		_, _, _, err := td.buildRequest(map[string]any{}, "o", "r")
+		assert.ErrorContains(t, err, "missing required parameter: number")
+	})
+}
+
+func TestPRReviewsTool_BuildRequest(t *testing.T) {
+	td := prReviewsTool()
+
+	t.Run("valid", func(t *testing.T) {
+		method, path, _, err := td.buildRequest(map[string]any{"number": float64(10)}, "o", "r")
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodGet, method)
+		assert.Equal(t, "/repos/o/r/pulls/10/reviews", path)
+	})
+
+	t.Run("missing number", func(t *testing.T) {
+		_, _, _, err := td.buildRequest(map[string]any{}, "o", "r")
+		assert.ErrorContains(t, err, "missing required parameter: number")
+	})
+}
+
+func TestIssueListTool_BuildRequest(t *testing.T) {
+	td := issueListTool()
+
+	t.Run("defaults", func(t *testing.T) {
+		method, path, _, err := td.buildRequest(map[string]any{}, "o", "r")
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodGet, method)
+		assert.Equal(t, "/repos/o/r/issues", path)
+	})
+
+	t.Run("with filters", func(t *testing.T) {
+		args := map[string]any{
+			"state":    "closed",
+			"labels":   "bug,critical",
+			"per_page": float64(25),
+			"page":     float64(3),
+		}
+		_, path, _, err := td.buildRequest(args, "o", "r")
+		require.NoError(t, err)
+		assert.Contains(t, path, "state=closed")
+		assert.Contains(t, path, "labels=bug%2Ccritical")
+		assert.Contains(t, path, "per_page=25")
+		assert.Contains(t, path, "page=3")
+	})
+}
+
+func TestIssueGetTool_BuildRequest(t *testing.T) {
+	td := issueGetTool()
+
+	t.Run("valid", func(t *testing.T) {
+		method, path, _, err := td.buildRequest(map[string]any{"number": float64(7)}, "o", "r")
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodGet, method)
+		assert.Equal(t, "/repos/o/r/issues/7", path)
+	})
+
+	t.Run("missing number", func(t *testing.T) {
+		_, _, _, err := td.buildRequest(map[string]any{}, "o", "r")
+		assert.ErrorContains(t, err, "missing required parameter: number")
+	})
+}
+
+func TestRepoGetTool_BuildRequest(t *testing.T) {
+	td := repoGetTool()
+	method, path, _, err := td.buildRequest(map[string]any{}, "o", "r")
+	require.NoError(t, err)
+	assert.Equal(t, http.MethodGet, method)
+	assert.Equal(t, "/repos/o/r", path)
+}
+
+func TestReleaseListTool_BuildRequest(t *testing.T) {
+	td := releaseListTool()
+
+	t.Run("defaults", func(t *testing.T) {
+		_, path, _, err := td.buildRequest(map[string]any{}, "o", "r")
+		require.NoError(t, err)
+		assert.Equal(t, "/repos/o/r/releases", path)
+	})
+
+	t.Run("with per_page", func(t *testing.T) {
+		_, path, _, err := td.buildRequest(map[string]any{"per_page": float64(10)}, "o", "r")
+		require.NoError(t, err)
+		assert.Contains(t, path, "per_page=10")
+	})
+}
+
+func TestChecksListTool_BuildRequest(t *testing.T) {
+	td := checksListTool()
+
+	t.Run("valid", func(t *testing.T) {
+		method, path, _, err := td.buildRequest(map[string]any{"ref": "main"}, "o", "r")
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodGet, method)
+		assert.Equal(t, "/repos/o/r/commits/main/check-runs", path)
+	})
+
+	t.Run("missing ref", func(t *testing.T) {
+		_, _, _, err := td.buildRequest(map[string]any{}, "o", "r")
+		assert.ErrorContains(t, err, "missing required parameter: ref")
+	})
+}
+
+func TestPRCreateTool_BuildRequest(t *testing.T) {
+	td := prCreateTool()
+
+	t.Run("minimal", func(t *testing.T) {
+		args := map[string]any{"title": "feat: add X", "head": "my-branch"}
+		method, path, body, err := td.buildRequest(args, "o", "r")
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodPost, method)
+		assert.Equal(t, "/repos/o/r/pulls", path)
+		assert.NotNil(t, body)
+	})
+
+	t.Run("with optional fields", func(t *testing.T) {
+		args := map[string]any{
+			"title": "feat: add X",
+			"head":  "my-branch",
+			"body":  "description",
+			"base":  "main",
+		}
+		_, _, body, err := td.buildRequest(args, "o", "r")
+		require.NoError(t, err)
+		data, _ := io.ReadAll(body)
+		assert.Contains(t, string(data), `"body":"description"`)
+		assert.Contains(t, string(data), `"base":"main"`)
+	})
+
+	t.Run("missing title", func(t *testing.T) {
+		_, _, _, err := td.buildRequest(map[string]any{"head": "b"}, "o", "r")
+		assert.ErrorContains(t, err, "missing required parameter: title")
+	})
+
+	t.Run("missing head", func(t *testing.T) {
+		_, _, _, err := td.buildRequest(map[string]any{"title": "t"}, "o", "r")
+		assert.ErrorContains(t, err, "missing required parameter: head")
+	})
+}
+
+func TestPRUpdateTool_BuildRequest(t *testing.T) {
+	td := prUpdateTool()
+
+	t.Run("valid with fields", func(t *testing.T) {
+		args := map[string]any{
+			"number": float64(5),
+			"title":  "new title",
+			"body":   "new body",
+			"state":  "closed",
+			"base":   "develop",
+		}
+		method, path, body, err := td.buildRequest(args, "o", "r")
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodPatch, method)
+		assert.Equal(t, "/repos/o/r/pulls/5", path)
+		data, _ := io.ReadAll(body)
+		assert.Contains(t, string(data), `"title":"new title"`)
+		assert.Contains(t, string(data), `"state":"closed"`)
+	})
+
+	t.Run("missing number", func(t *testing.T) {
+		_, _, _, err := td.buildRequest(map[string]any{}, "o", "r")
+		assert.ErrorContains(t, err, "missing required parameter: number")
+	})
+}
+
+func TestPRMergeTool_BuildRequest(t *testing.T) {
+	td := prMergeTool()
+
+	t.Run("valid with options", func(t *testing.T) {
+		args := map[string]any{
+			"number":       float64(3),
+			"merge_method": "squash",
+			"commit_title": "custom title",
+		}
+		method, path, body, err := td.buildRequest(args, "o", "r")
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodPut, method)
+		assert.Equal(t, "/repos/o/r/pulls/3/merge", path)
+		data, _ := io.ReadAll(body)
+		assert.Contains(t, string(data), `"merge_method":"squash"`)
+		assert.Contains(t, string(data), `"commit_title":"custom title"`)
+	})
+
+	t.Run("missing number", func(t *testing.T) {
+		_, _, _, err := td.buildRequest(map[string]any{}, "o", "r")
+		assert.ErrorContains(t, err, "missing required parameter: number")
+	})
+}
+
+func TestPRCommentTool_BuildRequest(t *testing.T) {
+	td := prCommentTool()
+
+	t.Run("valid", func(t *testing.T) {
+		args := map[string]any{"number": float64(1), "body": "LGTM"}
+		method, path, body, err := td.buildRequest(args, "o", "r")
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodPost, method)
+		assert.Equal(t, "/repos/o/r/issues/1/comments", path)
+		data, _ := io.ReadAll(body)
+		assert.Contains(t, string(data), `"body":"LGTM"`)
+	})
+
+	t.Run("missing number", func(t *testing.T) {
+		_, _, _, err := td.buildRequest(map[string]any{"body": "x"}, "o", "r")
+		assert.ErrorContains(t, err, "missing required parameter: number")
+	})
+
+	t.Run("missing body", func(t *testing.T) {
+		_, _, _, err := td.buildRequest(map[string]any{"number": float64(1)}, "o", "r")
+		assert.ErrorContains(t, err, "missing required parameter: body")
+	})
+}
+
+func TestIssueCreateTool_BuildRequest(t *testing.T) {
+	td := issueCreateTool()
+
+	t.Run("minimal", func(t *testing.T) {
+		args := map[string]any{"title": "bug report"}
+		method, path, body, err := td.buildRequest(args, "o", "r")
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodPost, method)
+		assert.Equal(t, "/repos/o/r/issues", path)
+		data, _ := io.ReadAll(body)
+		assert.Contains(t, string(data), `"title":"bug report"`)
+	})
+
+	t.Run("with body and labels", func(t *testing.T) {
+		args := map[string]any{
+			"title":  "bug",
+			"body":   "description",
+			"labels": "bug, critical",
+		}
+		_, _, body, err := td.buildRequest(args, "o", "r")
+		require.NoError(t, err)
+		data, _ := io.ReadAll(body)
+		assert.Contains(t, string(data), `"title":"bug"`)
+		assert.Contains(t, string(data), `"body":"description"`)
+		assert.Contains(t, string(data), `"labels"`)
+	})
+
+	t.Run("missing title", func(t *testing.T) {
+		_, _, _, err := td.buildRequest(map[string]any{}, "o", "r")
+		assert.ErrorContains(t, err, "missing required parameter: title")
+	})
+}
+
+func TestIssueCommentTool_BuildRequest(t *testing.T) {
+	td := issueCommentTool()
+
+	t.Run("valid", func(t *testing.T) {
+		args := map[string]any{"number": float64(5), "body": "comment"}
+		method, path, _, err := td.buildRequest(args, "o", "r")
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodPost, method)
+		assert.Equal(t, "/repos/o/r/issues/5/comments", path)
+	})
+
+	t.Run("missing number", func(t *testing.T) {
+		_, _, _, err := td.buildRequest(map[string]any{"body": "x"}, "o", "r")
+		assert.ErrorContains(t, err, "missing required parameter: number")
+	})
+
+	t.Run("missing body", func(t *testing.T) {
+		_, _, _, err := td.buildRequest(map[string]any{"number": float64(1)}, "o", "r")
+		assert.ErrorContains(t, err, "missing required parameter: body")
+	})
+}
+
+func TestAPITool_BuildRequest(t *testing.T) {
+	td := apiTool()
+
+	t.Run("GET request", func(t *testing.T) {
+		args := map[string]any{"method": "GET", "path": "/repos/o/r/pulls"}
+		method, path, body, err := td.buildRequest(args, "o", "r")
+		require.NoError(t, err)
+		assert.Equal(t, "GET", method)
+		assert.Equal(t, "/repos/o/r/pulls", path)
+		assert.Nil(t, body)
+	})
+
+	t.Run("POST with body", func(t *testing.T) {
+		args := map[string]any{
+			"method": "post",
+			"path":   "/repos/o/r/issues",
+			"body":   `{"title":"test"}`,
+		}
+		method, path, body, err := td.buildRequest(args, "o", "r")
+		require.NoError(t, err)
+		assert.Equal(t, "POST", method)
+		assert.Equal(t, "/repos/o/r/issues", path)
+		assert.NotNil(t, body)
+	})
+
+	t.Run("path without leading slash", func(t *testing.T) {
+		args := map[string]any{"method": "GET", "path": "repos/o/r"}
+		_, path, _, err := td.buildRequest(args, "o", "r")
+		require.NoError(t, err)
+		assert.Equal(t, "/repos/o/r", path)
+	})
+
+	t.Run("missing method", func(t *testing.T) {
+		_, _, _, err := td.buildRequest(map[string]any{"path": "/x"}, "o", "r")
+		assert.ErrorContains(t, err, "missing required parameter: method")
+	})
+
+	t.Run("missing path", func(t *testing.T) {
+		_, _, _, err := td.buildRequest(map[string]any{"method": "GET"}, "o", "r")
+		assert.ErrorContains(t, err, "missing required parameter: path")
+	})
+}
+
+func TestExtractOwnerRepo(t *testing.T) {
+	tests := []struct {
+		path      string
+		wantOwner string
+		wantRepo  string
+	}{
+		{"/repos/alice/bob/pulls", "alice", "bob"},
+		{"/repos/alice/bob", "alice", "bob"},
+		{"/user", "", ""},
+		{"/repos/alice", "", ""},
+		{"/repos/alice/bob/pulls/1/reviews", "alice", "bob"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			o, r := extractOwnerRepo(tt.path)
+			assert.Equal(t, tt.wantOwner, o)
+			assert.Equal(t, tt.wantRepo, r)
+		})
+	}
+}
+
+func TestHelperFunctions(t *testing.T) {
+	t.Run("getString", func(t *testing.T) {
+		assert.Equal(t, "hello", getString(map[string]any{"k": "hello"}, "k"))
+		assert.Equal(t, "", getString(map[string]any{"k": 42}, "k"))
+		assert.Equal(t, "", getString(map[string]any{}, "k"))
+	})
+
+	t.Run("getNumber", func(t *testing.T) {
+		n, ok := getNumber(map[string]any{"k": float64(42)}, "k")
+		assert.True(t, ok)
+		assert.Equal(t, 42, n)
+
+		_, ok = getNumber(map[string]any{"k": "not a number"}, "k")
+		assert.False(t, ok)
+
+		_, ok = getNumber(map[string]any{}, "k")
+		assert.False(t, ok)
+	})
+
+	t.Run("addQueryParam", func(t *testing.T) {
+		assert.Equal(t, "/path?key=val", addQueryParam("/path", "key", "val"))
+		assert.Equal(t, "/path", addQueryParam("/path", "key", ""))
+		assert.Equal(t, "/path?a=1&b=2", addQueryParam("/path?a=1", "b", "2"))
+	})
+
+	t.Run("addQueryParamInt", func(t *testing.T) {
+		assert.Equal(t, "/path?n=10", addQueryParamInt("/path", map[string]any{"n": float64(10)}, "n"))
+		assert.Equal(t, "/path", addQueryParamInt("/path", map[string]any{}, "n"))
+	})
+
+	t.Run("resolveOwnerRepo", func(t *testing.T) {
+		o, r := resolveOwnerRepo(map[string]any{"owner": "a", "repo": "b"}, "x", "y")
+		assert.Equal(t, "a", o)
+		assert.Equal(t, "b", r)
+
+		o, r = resolveOwnerRepo(map[string]any{}, "x", "y")
+		assert.Equal(t, "x", o)
+		assert.Equal(t, "y", r)
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `github-mcp/` standalone MCP server implementing Streamable HTTP protocol for GitHub API operations with policy enforcement (writes restricted to configured repo, reads allowed anywhere)
- Includes comprehensive test suite achieving 95.6% coverage (excluding main.go) with tests for tools, server, GitHub client, and policy enforcement
- Creates separate `.github/workflows/github-mcp.yml` CI workflow with lint, build, test, 90% coverage threshold, and Docker build (using Go 1.26)
- Adds "NEVER lower this threshold" comment on both go.yml and github-mcp.yml coverage checks
- Excludes accidentally committed 10MB binary via .gitignore

## Test plan
- [ ] `cd github-mcp && go test -v -race -coverprofile=coverage.txt ./...` passes with 95.6% coverage
- [ ] `github-mcp.yml` workflow triggers on PR changes to `github-mcp/`, `docker/github-mcp/`, or the workflow itself
- [ ] Docker image builds: `docker build -t github-mcp-test -f docker/github-mcp/Dockerfile .`
- [ ] Main `go.yml` workflow still passes with 90%+ coverage
- [ ] No 10MB binary included in the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)