### PR TITLE
feat: Add custom MCP server support with project-level config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,15 @@ A collection of CLI tools for working with Claude Code.
 
 - Runs Claude Code in Docker with `--dangerously-skip-permissions` by default
 - Gateway proxy mediates all GitHub traffic (git + API) with per-repo write restrictions
+- Built-in GitHub MCP server for issue/PR operations from inside the sandbox
+- Custom MCP servers — add your own MCP servers as sidecar containers or external URLs
+- Project-level configuration via `.claude-forge.yaml`
 - Multiple instances can run in parallel across different projects
 - Session persistence — resume previous sessions by ID
 - Automatic auth detection from `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, or `~/.claude/.credentials.json`
 - Dependency caching for Go, npm, pnpm, and pip
 - Host git identity and Claude Code configuration carried into the container
+- Optional Kubernetes MCP integration for cluster access
 
 ### Prerequisites
 
@@ -107,19 +111,100 @@ claude-forge version
 
 ### Configuration
 
-Configuration is stored in `~/.config/claude-forge/config.yaml`:
+#### Global Config
+
+`~/.config/claude-forge/config.yaml` — applies to all projects:
 
 ```yaml
 # Override Docker images (defaults to GHCR.io images)
 images:
   agent: ghcr.io/michael-freling/claude-forge-agent:latest
   gateway: ghcr.io/michael-freling/claude-forge-gateway:latest
+  github_mcp: ghcr.io/michael-freling/claude-forge-github-mcp:latest
 
 # Default flags
 defaults:
   skip_permissions: true
   worktree: false
+
+# Custom MCP servers
+mcp_servers:
+  # Container-based: forge runs this as a sidecar
+  linear:
+    image: ghcr.io/org/linear-mcp:latest
+    port: 8080
+    path: /mcp                            # optional, default: /mcp
+    env:
+      LINEAR_API_KEY: ${LINEAR_API_KEY}   # expanded from host env at runtime
+    cmd: ["--workspace", "my-team"]       # optional
+    mounts:                               # optional
+      - source: ~/.config/linear-mcp
+        target: /config
+        read_only: true
+
+  # Shared singleton: one instance across all sessions
+  sentry:
+    image: ghcr.io/org/sentry-mcp:latest
+    port: 9090
+    shared: true
+    env:
+      SENTRY_DSN: ${SENTRY_DSN}
+
+  # URL-only: no container managed, just register the URL
+  internal-api:
+    url: http://host.docker.internal:3000/mcp
+
+# Kubernetes MCP integration (optional)
+kubernetes:
+  enabled: false
+  read_only: false
+  image: ghcr.io/containers/kubernetes-mcp-server:latest
+  contexts:
+    - host_context: my-cluster
+      service_account_name: claude-forge-agent
+      service_account_namespace: default
+  default_context: my-cluster
 ```
+
+#### Project Config
+
+`.claude-forge.yaml` in the project root — overrides global config per project. Safe to commit since secrets use `${VAR}` placeholders.
+
+```yaml
+mcp_servers:
+  # Override a global MCP for this project
+  linear:
+    image: ghcr.io/org/linear-mcp:latest
+    port: 8080
+    env:
+      LINEAR_API_KEY: ${LINEAR_API_KEY}
+      LINEAR_TEAM_ID: ${MY_PROJECT_TEAM_ID}
+
+  # Add a project-specific MCP
+  my-db:
+    image: ghcr.io/org/db-mcp:latest
+    port: 5432
+    env:
+      DATABASE_URL: ${DATABASE_URL}
+
+  # Disable a global MCP for this project
+  sentry:
+    enabled: false
+```
+
+Project entries take priority over global entries with the same name. Entries with `enabled: false` disable a globally-defined MCP for that project.
+
+#### Custom MCP Server Types
+
+| Type | Config | Lifecycle |
+|------|--------|-----------|
+| **Per-session** (default) | `image` + `port` | Created per session, cleaned up on stop |
+| **Shared** | `image` + `port` + `shared: true` | Singleton, survives session cleanup |
+| **URL-only** | `url` | No container — registers an external URL |
+
+Container-based MCPs communicate with the agent over the Docker bridge network using streamable HTTP. The agent reaches them at `http://{name}:{port}{path}`.
+
+For URL-only MCPs, the URL must be reachable from inside the Docker container (e.g., `http://host.docker.internal:<port>/mcp` for services on the host).
 
 ### Authentication
 
@@ -137,12 +222,45 @@ When you run `claude-forge start`, it:
 
 1. Detects the current project (git remote, directory)
 2. Resolves authentication credentials
-3. Creates a Docker network for the session
-4. Starts a **gateway** container that proxies GitHub traffic with write restrictions
-5. Starts an **agent** container running Claude Code with your project mounted at `/work`
-6. Attaches your terminal (interactive) or waits for completion (with `-p`)
+3. Loads global config (`~/.config/claude-forge/config.yaml`) and project config (`.claude-forge.yaml`)
+4. Creates a Docker network for the session
+5. Starts a **gateway** container that proxies GitHub traffic with write restrictions
+6. Starts the **GitHub MCP** sidecar for issue/PR operations
+7. Starts any **custom MCP** containers defined in config
+8. Starts the **agent** container running Claude Code with your project mounted at `/work`
+9. Attaches your terminal (interactive) or waits for completion (with `-p`)
 
 The gateway ensures Claude Code can freely read from any GitHub repository but can only push to or create PRs on the current project's repository.
+
+### Plugins
+
+Host Claude Code plugins can be synced into the forge environment:
+
+```bash
+# Sync host plugins into forge's plugin directory
+claude-forge plugins sync
+```
+
+Plugins persist in `~/.claude-forge/plugins/` across sessions.
+
+### Kubernetes Integration
+
+To give Claude Code access to Kubernetes clusters:
+
+```bash
+# Generate RBAC manifests for a cluster
+claude-forge kube render --context my-cluster | kubectl apply -f -
+```
+
+Then enable Kubernetes in your config and restart. See the `kubernetes` section in the global config example above.
+
+### Extra Mounts
+
+Mount additional host directories into the container:
+
+```bash
+claude-forge start --mount /path/on/host:/path/in/container
+```
 
 ## License
 

--- a/cmd/claude-forge/main.go
+++ b/cmd/claude-forge/main.go
@@ -300,6 +300,9 @@ func newBuildCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "build",
 		Short: "Pull or rebuild Claude Code Docker images",
+		Long: `Pull the latest Docker images for the agent, gateway, and MCP servers.
+When run from a project directory with a .claude-forge.yaml file,
+also pulls images for project-level custom MCP servers.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			orch, cleanup, err := createOrchestrator()
 			if err != nil {
@@ -307,7 +310,8 @@ func newBuildCmd() *cobra.Command {
 			}
 			defer cleanup()
 
-			return orch.Build(context.Background())
+			projectDir, _ := os.Getwd()
+			return orch.BuildForProject(context.Background(), projectDir)
 		},
 	}
 }

--- a/internal/forge/config/config.go
+++ b/internal/forge/config/config.go
@@ -24,9 +24,10 @@ const (
 
 // Config holds the claude-forge configuration.
 type Config struct {
-	Images     ImagesConfig     `yaml:"images"`
-	Defaults   DefaultsConfig   `yaml:"defaults"`
-	Kubernetes KubernetesConfig `yaml:"kubernetes"`
+	Images     ImagesConfig              `yaml:"images"`
+	Defaults   DefaultsConfig            `yaml:"defaults"`
+	Kubernetes KubernetesConfig          `yaml:"kubernetes"`
+	MCPServers map[string]MCPServerEntry `yaml:"mcp_servers"`
 }
 
 // ImagesConfig holds Docker image configuration.
@@ -58,6 +59,36 @@ type KubeContextEntry struct {
 	ServiceAccountNamespace string `yaml:"service_account_namespace"`
 }
 
+// MCPServerEntry configures a custom MCP server.
+// Either Image+Port (container-based) or URL (external) must be set, not both.
+type MCPServerEntry struct {
+	Image   string            `yaml:"image"`
+	Port    int               `yaml:"port"`
+	Path    string            `yaml:"path"`
+	Env     map[string]string `yaml:"env"`
+	Cmd     []string          `yaml:"cmd"`
+	Shared  bool              `yaml:"shared"`
+	Mounts  []MCPMountEntry   `yaml:"mounts"`
+	URL     string            `yaml:"url"`
+	Enabled *bool             `yaml:"enabled"`
+}
+
+// IsEnabled returns whether this MCP server entry is enabled.
+// Defaults to true when the field is not set.
+func (e MCPServerEntry) IsEnabled() bool {
+	if e.Enabled == nil {
+		return true
+	}
+	return *e.Enabled
+}
+
+// MCPMountEntry represents a bind mount for a custom MCP container.
+type MCPMountEntry struct {
+	Source   string `yaml:"source"`
+	Target  string `yaml:"target"`
+	ReadOnly bool   `yaml:"read_only"`
+}
+
 // DefaultConfig returns a Config with all defaults applied.
 func DefaultConfig() *Config {
 	return &Config{
@@ -70,6 +101,90 @@ func DefaultConfig() *Config {
 			Image: DefaultKubernetesMCPImage,
 		},
 	}
+}
+
+// reservedMCPNames are names reserved for built-in MCP servers.
+var reservedMCPNames = map[string]bool{
+	"github":     true,
+	"kubernetes": true,
+}
+
+// ProjectConfig holds the project-level claude-forge configuration.
+type ProjectConfig struct {
+	MCPServers map[string]MCPServerEntry `yaml:"mcp_servers"`
+}
+
+// LoadProject reads project config from projectDir/.claude-forge.yaml.
+// Returns nil (no error) if the file doesn't exist.
+func LoadProject(projectDir string) (*ProjectConfig, error) {
+	configPath := filepath.Join(projectDir, ".claude-forge.yaml")
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read project config: %w", err)
+	}
+
+	var cfg ProjectConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse project config: %w", err)
+	}
+
+	return &cfg, nil
+}
+
+// ResolveMCPServers merges global and project MCP server configurations.
+// Project entries take priority over global entries with the same name.
+// Entries with enabled:false are removed from the result.
+func ResolveMCPServers(global map[string]MCPServerEntry, project *ProjectConfig) (map[string]MCPServerEntry, error) {
+	result := make(map[string]MCPServerEntry)
+
+	for name, entry := range global {
+		result[name] = entry
+	}
+
+	if project != nil {
+		for name, entry := range project.MCPServers {
+			result[name] = entry
+		}
+	}
+
+	// Remove disabled entries and validate the rest
+	for name, entry := range result {
+		if !entry.IsEnabled() {
+			delete(result, name)
+			continue
+		}
+		if err := validateMCPEntry(name, entry); err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
+}
+
+// validateMCPEntry checks that an MCP server entry is valid.
+func validateMCPEntry(name string, entry MCPServerEntry) error {
+	if reservedMCPNames[name] {
+		return fmt.Errorf("MCP server name %q is reserved", name)
+	}
+
+	hasImage := entry.Image != ""
+	hasURL := entry.URL != ""
+
+	if hasImage && hasURL {
+		return fmt.Errorf("MCP server %q: cannot set both image and url", name)
+	}
+	if !hasImage && !hasURL {
+		return fmt.Errorf("MCP server %q: must set either image or url", name)
+	}
+	if hasImage && entry.Port == 0 {
+		return fmt.Errorf("MCP server %q: port is required when image is set", name)
+	}
+
+	return nil
 }
 
 // Load reads config from configDir/config.yaml.

--- a/internal/forge/config/config.go
+++ b/internal/forge/config/config.go
@@ -85,7 +85,7 @@ func (e MCPServerEntry) IsEnabled() bool {
 // MCPMountEntry represents a bind mount for a custom MCP container.
 type MCPMountEntry struct {
 	Source   string `yaml:"source"`
-	Target  string `yaml:"target"`
+	Target   string `yaml:"target"`
 	ReadOnly bool   `yaml:"read_only"`
 }
 

--- a/internal/forge/config/config_test.go
+++ b/internal/forge/config/config_test.go
@@ -188,3 +188,227 @@ func TestLoad_PartialGatewayOnly(t *testing.T) {
 	assert.Equal(t, DefaultAgentImage, got.Images.Agent)
 	assert.Equal(t, "my-gateway:latest", got.Images.Gateway)
 }
+
+func TestLoad_WithMCPServers(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	configYAML := `mcp_servers:
+  linear:
+    image: ghcr.io/org/linear-mcp:latest
+    port: 8080
+    env:
+      LINEAR_API_KEY: "${LINEAR_API_KEY}"
+  external:
+    url: http://host.docker.internal:3000/mcp
+`
+	err := os.WriteFile(filepath.Join(tmpDir, "config.yaml"), []byte(configYAML), 0o644)
+	require.NoError(t, err)
+
+	got, err := Load(tmpDir)
+
+	require.NoError(t, err)
+	require.Len(t, got.MCPServers, 2)
+	assert.Equal(t, "ghcr.io/org/linear-mcp:latest", got.MCPServers["linear"].Image)
+	assert.Equal(t, 8080, got.MCPServers["linear"].Port)
+	assert.Equal(t, "${LINEAR_API_KEY}", got.MCPServers["linear"].Env["LINEAR_API_KEY"])
+	assert.Equal(t, "http://host.docker.internal:3000/mcp", got.MCPServers["external"].URL)
+}
+
+func TestLoadProject(t *testing.T) {
+	t.Run("file exists", func(t *testing.T) {
+		dir := t.TempDir()
+		configYAML := `mcp_servers:
+  my-db:
+    image: ghcr.io/org/db-mcp:latest
+    port: 5432
+    env:
+      DATABASE_URL: "${DATABASE_URL}"
+`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, ".claude-forge.yaml"), []byte(configYAML), 0o644))
+
+		got, err := LoadProject(dir)
+
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.Len(t, got.MCPServers, 1)
+		assert.Equal(t, "ghcr.io/org/db-mcp:latest", got.MCPServers["my-db"].Image)
+		assert.Equal(t, 5432, got.MCPServers["my-db"].Port)
+	})
+
+	t.Run("file does not exist", func(t *testing.T) {
+		dir := t.TempDir()
+
+		got, err := LoadProject(dir)
+
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("invalid yaml", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, ".claude-forge.yaml"), []byte(":::bad"), 0o644))
+
+		_, err := LoadProject(dir)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse project config")
+	})
+}
+
+func boolPtr(v bool) *bool { return &v }
+
+func TestResolveMCPServers(t *testing.T) {
+	tests := []struct {
+		name        string
+		global      map[string]MCPServerEntry
+		project     *ProjectConfig
+		wantNames   []string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "global only",
+			global: map[string]MCPServerEntry{
+				"linear": {Image: "linear:latest", Port: 8080},
+			},
+			wantNames: []string{"linear"},
+		},
+		{
+			name: "project overrides global",
+			global: map[string]MCPServerEntry{
+				"linear": {Image: "linear:v1", Port: 8080},
+			},
+			project: &ProjectConfig{
+				MCPServers: map[string]MCPServerEntry{
+					"linear": {Image: "linear:v2", Port: 9090},
+				},
+			},
+			wantNames: []string{"linear"},
+		},
+		{
+			name: "project adds new entry",
+			global: map[string]MCPServerEntry{
+				"linear": {Image: "linear:latest", Port: 8080},
+			},
+			project: &ProjectConfig{
+				MCPServers: map[string]MCPServerEntry{
+					"my-db": {Image: "db:latest", Port: 5432},
+				},
+			},
+			wantNames: []string{"linear", "my-db"},
+		},
+		{
+			name: "project disables global entry",
+			global: map[string]MCPServerEntry{
+				"linear": {Image: "linear:latest", Port: 8080},
+				"sentry": {Image: "sentry:latest", Port: 9090},
+			},
+			project: &ProjectConfig{
+				MCPServers: map[string]MCPServerEntry{
+					"sentry": {Enabled: boolPtr(false)},
+				},
+			},
+			wantNames: []string{"linear"},
+		},
+		{
+			name:      "nil global and nil project",
+			global:    nil,
+			project:   nil,
+			wantNames: nil,
+		},
+		{
+			name: "reserved name github",
+			global: map[string]MCPServerEntry{
+				"github": {Image: "custom:latest", Port: 8080},
+			},
+			wantErr:     true,
+			errContains: "reserved",
+		},
+		{
+			name: "reserved name kubernetes",
+			project: &ProjectConfig{
+				MCPServers: map[string]MCPServerEntry{
+					"kubernetes": {URL: "http://example.com/mcp"},
+				},
+			},
+			wantErr:     true,
+			errContains: "reserved",
+		},
+		{
+			name: "both image and url",
+			global: map[string]MCPServerEntry{
+				"bad": {Image: "img:latest", Port: 8080, URL: "http://example.com"},
+			},
+			wantErr:     true,
+			errContains: "cannot set both",
+		},
+		{
+			name: "neither image nor url",
+			global: map[string]MCPServerEntry{
+				"bad": {Port: 8080},
+			},
+			wantErr:     true,
+			errContains: "must set either",
+		},
+		{
+			name: "image without port",
+			global: map[string]MCPServerEntry{
+				"bad": {Image: "img:latest"},
+			},
+			wantErr:     true,
+			errContains: "port is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveMCPServers(tt.global, tt.project)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				return
+			}
+
+			require.NoError(t, err)
+			var gotNames []string
+			for name := range got {
+				gotNames = append(gotNames, name)
+			}
+			assert.ElementsMatch(t, tt.wantNames, gotNames)
+		})
+	}
+}
+
+func TestResolveMCPServers_ProjectPriority(t *testing.T) {
+	global := map[string]MCPServerEntry{
+		"linear": {Image: "linear:v1", Port: 8080, Env: map[string]string{"KEY": "global"}},
+	}
+	project := &ProjectConfig{
+		MCPServers: map[string]MCPServerEntry{
+			"linear": {Image: "linear:v2", Port: 9090, Env: map[string]string{"KEY": "project"}},
+		},
+	}
+
+	got, err := ResolveMCPServers(global, project)
+
+	require.NoError(t, err)
+	assert.Equal(t, "linear:v2", got["linear"].Image)
+	assert.Equal(t, 9090, got["linear"].Port)
+	assert.Equal(t, "project", got["linear"].Env["KEY"])
+}
+
+func TestMCPServerEntry_IsEnabled(t *testing.T) {
+	t.Run("nil defaults to true", func(t *testing.T) {
+		e := MCPServerEntry{}
+		assert.True(t, e.IsEnabled())
+	})
+	t.Run("explicit true", func(t *testing.T) {
+		e := MCPServerEntry{Enabled: boolPtr(true)}
+		assert.True(t, e.IsEnabled())
+	})
+	t.Run("explicit false", func(t *testing.T) {
+		e := MCPServerEntry{Enabled: boolPtr(false)}
+		assert.False(t, e.IsEnabled())
+	})
+}

--- a/internal/forge/container/client.go
+++ b/internal/forge/container/client.go
@@ -663,6 +663,7 @@ func (c *Client) ListForgeContainers(ctx context.Context) ([]ContainerInfo, erro
 	filterArgs.Add("name", "forge-gateway-")
 	filterArgs.Add("name", "forge-github-mcp-")
 	filterArgs.Add("name", "forge-k8s-mcp")
+	filterArgs.Add("name", "forge-mcp-")
 
 	containers, err := c.docker.ContainerList(ctx, container.ListOptions{
 		All:     true,

--- a/internal/forge/container/client_test.go
+++ b/internal/forge/container/client_test.go
@@ -1092,6 +1092,7 @@ func TestListForgeContainers_Filters(t *testing.T) {
 			expectedFilters.Add("name", "forge-gateway-")
 			expectedFilters.Add("name", "forge-github-mcp-")
 			expectedFilters.Add("name", "forge-k8s-mcp")
+			expectedFilters.Add("name", "forge-mcp-")
 			assert.Equal(t, expectedFilters, opts.Filters)
 
 			return []container.Summary{}, nil

--- a/internal/forge/orchestrator.go
+++ b/internal/forge/orchestrator.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -57,12 +58,13 @@ type StartOptions struct {
 
 // Session holds information about a running session.
 type Session struct {
-	AgentName     string
-	GatewayName   string
-	GitHubMCPName string
-	NetworkName   string
-	SessionID     string
-	ProjectID     string
+	AgentName      string
+	GatewayName    string
+	GitHubMCPName  string
+	NetworkName    string
+	SessionID      string
+	ProjectID      string
+	CustomMCPNames []string
 }
 
 // Start creates a new claude-forge session: loads config, identifies the project,
@@ -154,10 +156,26 @@ func (o *Orchestrator) Start(ctx context.Context, opts StartOptions) (*Session, 
 		return nil, fmt.Errorf("failed to ensure .claude.json: %w", err)
 	}
 
+	// Load project-level MCP config and resolve with global config
+	projectCfg, err := config.LoadProject(proj.Dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load project config: %w", err)
+	}
+
+	customMCPs, err := config.ResolveMCPServers(cfg.MCPServers, projectCfg)
+	if err != nil {
+		return nil, fmt.Errorf("invalid MCP server config: %w", err)
+	}
+
 	// Pull images if not present
 	imagesToPull := []string{cfg.Images.Agent, cfg.Images.Gateway, cfg.Images.GitHubMCP}
 	if cfg.Kubernetes.Enabled && len(cfg.Kubernetes.Contexts) > 0 {
 		imagesToPull = append(imagesToPull, cfg.Kubernetes.Image)
+	}
+	for _, entry := range customMCPs {
+		if entry.Image != "" {
+			imagesToPull = append(imagesToPull, entry.Image)
+		}
 	}
 	for _, img := range imagesToPull {
 		exists, err := o.Containers.ImageExists(ctx, img)
@@ -244,6 +262,90 @@ func (o *Orchestrator) Start(ctx context.Context, opts StartOptions) (*Session, 
 	// Add Kubernetes MCP if enabled
 	if cfg.Kubernetes.Enabled && len(cfg.Kubernetes.Contexts) > 0 {
 		mcpServers["kubernetes"] = claudecode.MCPServerConfig{Type: "url", URL: "http://k8s-mcp:8090/mcp"}
+	}
+
+	// Start custom MCP containers and register URLs
+	needSharedNetwork := false
+	names := make([]string, 0, len(customMCPs))
+	for name := range customMCPs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		entry := customMCPs[name]
+
+		if entry.URL != "" {
+			mcpServers[name] = claudecode.MCPServerConfig{Type: "url", URL: entry.URL}
+			continue
+		}
+
+		path := entry.Path
+		if path == "" {
+			path = "/mcp"
+		}
+
+		expandedEnv := expandEnvMap(entry.Env)
+		var mounts []mount.Mount
+		for _, m := range entry.Mounts {
+			source := expandHome(m.Source, o.HomeDir)
+			mounts = append(mounts, mount.Mount{
+				Type:     mount.TypeBind,
+				Source:   source,
+				Target:   m.Target,
+				ReadOnly: m.ReadOnly,
+			})
+		}
+
+		if entry.Shared {
+			needSharedNetwork = true
+			containerName := fmt.Sprintf("forge-mcp-%s", name)
+
+			if err := o.startSharedMCP(ctx, containerName, name, entry, expandedEnv, mounts); err != nil {
+				o.Cleanup(ctx, sess)
+				return nil, fmt.Errorf("failed to start shared MCP %q: %w", name, err)
+			}
+		} else {
+			containerName := fmt.Sprintf("forge-mcp-%s-%s-%s", name, proj.ID, sessionID)
+
+			mcpID, err := o.Containers.StartSharedService(ctx, container.SharedServiceOptions{
+				Name:        containerName,
+				Image:       entry.Image,
+				NetworkName: sess.NetworkName,
+				Alias:       name,
+				Env:         expandedEnv,
+				Cmd:         entry.Cmd,
+				Mounts:      mounts,
+			})
+			if err != nil {
+				o.Cleanup(ctx, sess)
+				return nil, fmt.Errorf("failed to start MCP %q: %w", name, err)
+			}
+
+			if err := o.Containers.WaitForReady(ctx, mcpID, 10*time.Second); err != nil {
+				logs, _ := o.Containers.ContainerLogs(ctx, mcpID)
+				o.Cleanup(ctx, sess)
+				if logs != "" {
+					return nil, fmt.Errorf("MCP %q failed to start: %w\nLogs:\n%s", name, err, logs)
+				}
+				return nil, fmt.Errorf("MCP %q failed to start: %w", name, err)
+			}
+
+			o.Log("Starting MCP: %s", name)
+			sess.CustomMCPNames = append(sess.CustomMCPNames, containerName)
+		}
+
+		mcpServers[name] = claudecode.MCPServerConfig{
+			Type: "url",
+			URL:  fmt.Sprintf("http://%s:%d%s", name, entry.Port, path),
+		}
+	}
+
+	// Ensure shared network exists if any shared MCPs were started
+	if needSharedNetwork {
+		if _, err := o.Containers.EnsureSharedNetwork(ctx, "forge-shared"); err != nil {
+			o.Log("Warning: failed to ensure shared network for custom MCPs: %v", err)
+		}
 	}
 
 	if err := claudecode.UpdateMCPServers(o.ConfigDir, mcpServers); err != nil {
@@ -356,8 +458,8 @@ func (o *Orchestrator) Start(ctx context.Context, opts StartOptions) (*Session, 
 		return nil, fmt.Errorf("failed to start agent: %w", err)
 	}
 
-	// Connect agent to shared network for Kubernetes MCP access
-	if cfg.Kubernetes.Enabled && len(cfg.Kubernetes.Contexts) > 0 {
+	// Connect agent to shared network for Kubernetes MCP or custom shared MCP access
+	if (cfg.Kubernetes.Enabled && len(cfg.Kubernetes.Contexts) > 0) || needSharedNetwork {
 		if err := o.Containers.ConnectNetwork(ctx, "forge-shared", sess.AgentName, nil); err != nil {
 			o.Log("Warning: failed to connect agent to shared network: %v", err)
 		}
@@ -371,6 +473,10 @@ func (o *Orchestrator) Cleanup(ctx context.Context, sess *Session) {
 	o.Log("Cleaning up...")
 	_ = o.Containers.StopContainer(ctx, sess.AgentName)
 	_ = o.Containers.RemoveContainer(ctx, sess.AgentName)
+	for _, name := range sess.CustomMCPNames {
+		_ = o.Containers.StopContainer(ctx, name)
+		_ = o.Containers.RemoveContainer(ctx, name)
+	}
 	_ = o.Containers.StopContainer(ctx, sess.GitHubMCPName)
 	_ = o.Containers.RemoveContainer(ctx, sess.GitHubMCPName)
 	_ = o.Containers.StopContainer(ctx, sess.GatewayName)
@@ -545,8 +651,70 @@ func (o *Orchestrator) startKubernetesMCP(ctx context.Context, cfg *config.Confi
 	return nil
 }
 
+// startSharedMCP ensures a shared custom MCP container is running.
+func (o *Orchestrator) startSharedMCP(ctx context.Context, containerName, alias string, entry config.MCPServerEntry, env map[string]string, mounts []mount.Mount) error {
+	if _, err := o.Containers.EnsureSharedNetwork(ctx, "forge-shared"); err != nil {
+		return fmt.Errorf("failed to ensure shared network: %w", err)
+	}
+
+	running, err := o.Containers.IsContainerRunning(ctx, containerName)
+	if err != nil {
+		return fmt.Errorf("failed to check %s status: %w", containerName, err)
+	}
+	if running {
+		o.Log("Starting MCP: %s (shared, already running)", alias)
+		return nil
+	}
+
+	o.Log("Starting MCP: %s (shared)", alias)
+	id, err := o.Containers.StartSharedService(ctx, container.SharedServiceOptions{
+		Name:        containerName,
+		Image:       entry.Image,
+		NetworkName: "forge-shared",
+		Alias:       alias,
+		Env:         env,
+		Cmd:         entry.Cmd,
+		Mounts:      mounts,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to start %s: %w", containerName, err)
+	}
+
+	if err := o.Containers.WaitForReady(ctx, id, 10*time.Second); err != nil {
+		return fmt.Errorf("%s failed to start: %w", containerName, err)
+	}
+
+	return nil
+}
+
+// expandEnvMap expands ${VAR} references in map values from the host environment.
+func expandEnvMap(env map[string]string) map[string]string {
+	if len(env) == 0 {
+		return nil
+	}
+	result := make(map[string]string, len(env))
+	for k, v := range env {
+		result[k] = os.ExpandEnv(v)
+	}
+	return result
+}
+
+// expandHome replaces a leading ~ with the home directory.
+func expandHome(path, homeDir string) string {
+	if strings.HasPrefix(path, "~/") {
+		return filepath.Join(homeDir, path[2:])
+	}
+	return path
+}
+
 // Build pulls the latest agent and gateway images.
 func (o *Orchestrator) Build(ctx context.Context) error {
+	return o.BuildForProject(ctx, "")
+}
+
+// BuildForProject pulls images for built-in and custom MCP servers.
+// If projectDir is non-empty, project-level config is also loaded.
+func (o *Orchestrator) BuildForProject(ctx context.Context, projectDir string) error {
 	cfg, err := config.Load(o.ConfigDir)
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
@@ -556,7 +724,40 @@ func (o *Orchestrator) Build(ctx context.Context) error {
 	if cfg.Kubernetes.Enabled {
 		images = append(images, cfg.Kubernetes.Image)
 	}
+
+	// Collect custom MCP images from global config
+	for _, entry := range cfg.MCPServers {
+		if entry.Image != "" && entry.IsEnabled() {
+			images = append(images, entry.Image)
+		}
+	}
+
+	// Collect custom MCP images from project config
+	if projectDir != "" {
+		projectCfg, err := config.LoadProject(projectDir)
+		if err != nil {
+			return fmt.Errorf("failed to load project config: %w", err)
+		}
+		if projectCfg != nil {
+			for _, entry := range projectCfg.MCPServers {
+				if entry.Image != "" && entry.IsEnabled() {
+					images = append(images, entry.Image)
+				}
+			}
+		}
+	}
+
+	// Deduplicate
+	seen := make(map[string]bool)
+	var unique []string
 	for _, img := range images {
+		if !seen[img] {
+			seen[img] = true
+			unique = append(unique, img)
+		}
+	}
+
+	for _, img := range unique {
 		o.Log("Pulling image: %s", img)
 		if err := o.Containers.PullImage(ctx, img); err != nil {
 			return fmt.Errorf("failed to pull image %s: %w", img, err)

--- a/internal/forge/orchestrator_test.go
+++ b/internal/forge/orchestrator_test.go
@@ -1212,6 +1212,311 @@ func TestStart_FailsOnGitHubMCPReady(t *testing.T) {
 	assert.Contains(t, err.Error(), "github-mcp failed to start")
 }
 
+func TestStart_WithCustomMCPPerSession(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, homeDir := setupOrchestrator(t, mockCM)
+
+	projectDir := setupGitProject(t)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+	t.Setenv("MY_API_KEY", "secret-123")
+
+	// Write global config with a custom MCP
+	configDir := filepath.Join(homeDir, ".config", "claude-forge")
+	configContent := `mcp_servers:
+  linear:
+    image: linear-mcp:latest
+    port: 8080
+    env:
+      API_KEY: "${MY_API_KEY}"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configContent), 0o644))
+
+	mockCM.EXPECT().ImageExists(gomock.Any(), gomock.Any()).Return(true, nil).Times(4) // agent, gateway, github-mcp, linear
+	mockCM.EXPECT().CreateNetwork(gomock.Any(), gomock.Any()).Return("net-id", nil)
+	mockCM.EXPECT().StartGateway(gomock.Any(), gomock.Any()).Return("gw-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "gw-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartGitHubMCP(gomock.Any(), gomock.Any()).Return("mcp-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "mcp-id", gomock.Any()).Return(nil)
+
+	// Custom MCP container
+	mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, opts container.SharedServiceOptions) (string, error) {
+			assert.Contains(t, opts.Name, "forge-mcp-linear-")
+			assert.Equal(t, "linear-mcp:latest", opts.Image)
+			assert.Equal(t, "linear", opts.Alias)
+			assert.Equal(t, "secret-123", opts.Env["API_KEY"])
+			return "custom-mcp-id", nil
+		})
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "custom-mcp-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartAgent(gomock.Any(), gomock.Any()).Return("agent-id", nil)
+
+	sess, err := orch.Start(context.Background(), StartOptions{
+		ProjectDir: projectDir,
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, sess.CustomMCPNames, 1)
+	assert.Contains(t, sess.CustomMCPNames[0], "forge-mcp-linear-")
+}
+
+func TestStart_WithCustomMCPShared(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, homeDir := setupOrchestrator(t, mockCM)
+
+	projectDir := setupGitProject(t)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+
+	// Write global config with a shared MCP
+	configDir := filepath.Join(homeDir, ".config", "claude-forge")
+	configContent := `mcp_servers:
+  sentry:
+    image: sentry-mcp:latest
+    port: 9090
+    shared: true
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configContent), 0o644))
+
+	mockCM.EXPECT().ImageExists(gomock.Any(), gomock.Any()).Return(true, nil).Times(4)
+	mockCM.EXPECT().CreateNetwork(gomock.Any(), gomock.Any()).Return("net-id", nil)
+	mockCM.EXPECT().StartGateway(gomock.Any(), gomock.Any()).Return("gw-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "gw-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartGitHubMCP(gomock.Any(), gomock.Any()).Return("mcp-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "mcp-id", gomock.Any()).Return(nil)
+
+	// Shared MCP: EnsureSharedNetwork + IsContainerRunning + StartSharedService
+	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("shared-net-id", nil).Times(2)
+	mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-mcp-sentry").Return(false, nil)
+	mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, opts container.SharedServiceOptions) (string, error) {
+			assert.Equal(t, "forge-mcp-sentry", opts.Name)
+			assert.Equal(t, "forge-shared", opts.NetworkName)
+			assert.Equal(t, "sentry", opts.Alias)
+			return "shared-mcp-id", nil
+		})
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "shared-mcp-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartAgent(gomock.Any(), gomock.Any()).Return("agent-id", nil)
+	mockCM.EXPECT().ConnectNetwork(gomock.Any(), "forge-shared", gomock.Any(), gomock.Nil()).Return(nil)
+
+	sess, err := orch.Start(context.Background(), StartOptions{
+		ProjectDir: projectDir,
+	})
+
+	require.NoError(t, err)
+	// Shared MCPs are NOT tracked in CustomMCPNames (they survive sessions)
+	assert.Empty(t, sess.CustomMCPNames)
+}
+
+func TestStart_WithCustomMCPURLOnly(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, homeDir := setupOrchestrator(t, mockCM)
+
+	projectDir := setupGitProject(t)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+
+	// Write global config with a URL-only MCP
+	configDir := filepath.Join(homeDir, ".config", "claude-forge")
+	configContent := `mcp_servers:
+  external:
+    url: http://host.docker.internal:3000/mcp
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configContent), 0o644))
+
+	mockCM.EXPECT().ImageExists(gomock.Any(), gomock.Any()).Return(true, nil).Times(3) // no custom image to check
+	mockCM.EXPECT().CreateNetwork(gomock.Any(), gomock.Any()).Return("net-id", nil)
+	mockCM.EXPECT().StartGateway(gomock.Any(), gomock.Any()).Return("gw-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "gw-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartGitHubMCP(gomock.Any(), gomock.Any()).Return("mcp-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "mcp-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartAgent(gomock.Any(), gomock.Any()).Return("agent-id", nil)
+
+	sess, err := orch.Start(context.Background(), StartOptions{
+		ProjectDir: projectDir,
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, sess.CustomMCPNames)
+}
+
+func TestStart_WithProjectMCPConfig(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, homeDir := setupOrchestrator(t, mockCM)
+
+	projectDir := setupGitProject(t)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+
+	// Write global config with a MCP
+	configDir := filepath.Join(homeDir, ".config", "claude-forge")
+	configContent := `mcp_servers:
+  linear:
+    image: linear-mcp:v1
+    port: 8080
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configContent), 0o644))
+
+	// Write project config that overrides linear and adds a new one
+	projectConfigContent := `mcp_servers:
+  linear:
+    image: linear-mcp:v2
+    port: 9090
+  my-db:
+    url: http://host.docker.internal:5432/mcp
+`
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, ".claude-forge.yaml"), []byte(projectConfigContent), 0o644))
+
+	// linear:v2 image from project config should be used
+	mockCM.EXPECT().ImageExists(gomock.Any(), gomock.Any()).Return(true, nil).Times(4) // agent, gateway, github-mcp, linear:v2
+	mockCM.EXPECT().CreateNetwork(gomock.Any(), gomock.Any()).Return("net-id", nil)
+	mockCM.EXPECT().StartGateway(gomock.Any(), gomock.Any()).Return("gw-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "gw-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartGitHubMCP(gomock.Any(), gomock.Any()).Return("mcp-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "mcp-id", gomock.Any()).Return(nil)
+
+	// linear per-session container with project's image
+	mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, opts container.SharedServiceOptions) (string, error) {
+			assert.Contains(t, opts.Name, "forge-mcp-linear-")
+			assert.Equal(t, "linear-mcp:v2", opts.Image)
+			return "custom-mcp-id", nil
+		})
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "custom-mcp-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartAgent(gomock.Any(), gomock.Any()).Return("agent-id", nil)
+
+	sess, err := orch.Start(context.Background(), StartOptions{
+		ProjectDir: projectDir,
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, sess.CustomMCPNames, 1)
+}
+
+func TestStart_ProjectMCPDisablesGlobal(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, homeDir := setupOrchestrator(t, mockCM)
+
+	projectDir := setupGitProject(t)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+
+	// Write global config
+	configDir := filepath.Join(homeDir, ".config", "claude-forge")
+	configContent := `mcp_servers:
+  linear:
+    image: linear-mcp:latest
+    port: 8080
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configContent), 0o644))
+
+	// Project disables linear
+	projectConfigContent := `mcp_servers:
+  linear:
+    enabled: false
+`
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, ".claude-forge.yaml"), []byte(projectConfigContent), 0o644))
+
+	// No custom MCP image to pull (disabled)
+	mockCM.EXPECT().ImageExists(gomock.Any(), gomock.Any()).Return(true, nil).Times(3)
+	mockCM.EXPECT().CreateNetwork(gomock.Any(), gomock.Any()).Return("net-id", nil)
+	mockCM.EXPECT().StartGateway(gomock.Any(), gomock.Any()).Return("gw-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "gw-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartGitHubMCP(gomock.Any(), gomock.Any()).Return("mcp-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "mcp-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartAgent(gomock.Any(), gomock.Any()).Return("agent-id", nil)
+
+	sess, err := orch.Start(context.Background(), StartOptions{
+		ProjectDir: projectDir,
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, sess.CustomMCPNames)
+}
+
+func TestCleanup_WithCustomMCPs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, _ := setupOrchestrator(t, mockCM)
+
+	sess := &Session{
+		AgentName:      "forge-agent-proj-sess1234",
+		GatewayName:    "forge-gateway-proj-sess1234",
+		GitHubMCPName:  "forge-github-mcp-proj-sess1234",
+		NetworkName:    "forge_net_proj_sess1234",
+		CustomMCPNames: []string{"forge-mcp-linear-proj-sess1234", "forge-mcp-my-db-proj-sess1234"},
+	}
+
+	// agent + 2 custom MCPs + github-mcp + gateway = 5
+	mockCM.EXPECT().StopContainer(gomock.Any(), "forge-agent-proj-sess1234").Return(nil)
+	mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-agent-proj-sess1234").Return(nil)
+	mockCM.EXPECT().StopContainer(gomock.Any(), "forge-mcp-linear-proj-sess1234").Return(nil)
+	mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-mcp-linear-proj-sess1234").Return(nil)
+	mockCM.EXPECT().StopContainer(gomock.Any(), "forge-mcp-my-db-proj-sess1234").Return(nil)
+	mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-mcp-my-db-proj-sess1234").Return(nil)
+	mockCM.EXPECT().StopContainer(gomock.Any(), "forge-github-mcp-proj-sess1234").Return(nil)
+	mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-github-mcp-proj-sess1234").Return(nil)
+	mockCM.EXPECT().StopContainer(gomock.Any(), "forge-gateway-proj-sess1234").Return(nil)
+	mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-gateway-proj-sess1234").Return(nil)
+	mockCM.EXPECT().RemoveNetwork(gomock.Any(), "forge_net_proj_sess1234").Return(nil)
+
+	orch.Cleanup(context.Background(), sess)
+}
+
+func TestExpandEnvMap(t *testing.T) {
+	t.Setenv("TEST_SECRET", "my-secret")
+
+	result := expandEnvMap(map[string]string{
+		"KEY":    "${TEST_SECRET}",
+		"PLAIN":  "literal",
+		"NESTED": "prefix-${TEST_SECRET}-suffix",
+	})
+
+	assert.Equal(t, "my-secret", result["KEY"])
+	assert.Equal(t, "literal", result["PLAIN"])
+	assert.Equal(t, "prefix-my-secret-suffix", result["NESTED"])
+}
+
+func TestExpandEnvMap_Nil(t *testing.T) {
+	result := expandEnvMap(nil)
+	assert.Nil(t, result)
+}
+
+func TestExpandHome(t *testing.T) {
+	assert.Equal(t, "/home/user/.config/mcp", expandHome("~/.config/mcp", "/home/user"))
+	assert.Equal(t, "/absolute/path", expandHome("/absolute/path", "/home/user"))
+	assert.Equal(t, "relative/path", expandHome("relative/path", "/home/user"))
+}
+
+func TestBuild_WithCustomMCPs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, homeDir := setupOrchestrator(t, mockCM)
+
+	configDir := filepath.Join(homeDir, ".config", "claude-forge")
+	configContent := `mcp_servers:
+  linear:
+    image: linear-mcp:latest
+    port: 8080
+  external:
+    url: http://example.com/mcp
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configContent), 0o644))
+
+	// 3 built-in + 1 custom image (URL-only doesn't count)
+	mockCM.EXPECT().PullImage(gomock.Any(), gomock.Any()).Return(nil).Times(4)
+
+	err := orch.Build(context.Background())
+	require.NoError(t, err)
+}
+
 func TestReadGHToken(t *testing.T) {
 	t.Run("valid hosts.yml", func(t *testing.T) {
 		dir := t.TempDir()

--- a/internal/forge/orchestrator_test.go
+++ b/internal/forge/orchestrator_test.go
@@ -1494,6 +1494,341 @@ func TestExpandHome(t *testing.T) {
 	assert.Equal(t, "relative/path", expandHome("relative/path", "/home/user"))
 }
 
+func TestStartSharedMCP_AlreadyRunning(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, _ := setupOrchestrator(t, mockCM)
+
+	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net-id", nil)
+	mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-mcp-sentry").Return(true, nil)
+
+	entry := config.MCPServerEntry{Image: "sentry:latest", Port: 9090, Shared: true}
+	err := orch.startSharedMCP(context.Background(), "forge-mcp-sentry", "sentry", entry, nil, nil)
+	require.NoError(t, err)
+}
+
+func TestStartSharedMCP_EnsureNetworkFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, _ := setupOrchestrator(t, mockCM)
+
+	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("", fmt.Errorf("docker error"))
+
+	entry := config.MCPServerEntry{Image: "sentry:latest", Port: 9090, Shared: true}
+	err := orch.startSharedMCP(context.Background(), "forge-mcp-sentry", "sentry", entry, nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to ensure shared network")
+}
+
+func TestStartSharedMCP_CheckRunningFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, _ := setupOrchestrator(t, mockCM)
+
+	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net-id", nil)
+	mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-mcp-sentry").Return(false, fmt.Errorf("inspect error"))
+
+	entry := config.MCPServerEntry{Image: "sentry:latest", Port: 9090, Shared: true}
+	err := orch.startSharedMCP(context.Background(), "forge-mcp-sentry", "sentry", entry, nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to check")
+}
+
+func TestStartSharedMCP_StartFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, _ := setupOrchestrator(t, mockCM)
+
+	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net-id", nil)
+	mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-mcp-sentry").Return(false, nil)
+	mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).Return("", fmt.Errorf("start failed"))
+
+	entry := config.MCPServerEntry{Image: "sentry:latest", Port: 9090, Shared: true}
+	err := orch.startSharedMCP(context.Background(), "forge-mcp-sentry", "sentry", entry, nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to start")
+}
+
+func TestStartSharedMCP_WaitForReadyFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, _ := setupOrchestrator(t, mockCM)
+
+	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net-id", nil)
+	mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-mcp-sentry").Return(false, nil)
+	mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).Return("id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "id", gomock.Any()).Return(fmt.Errorf("crash"))
+
+	entry := config.MCPServerEntry{Image: "sentry:latest", Port: 9090, Shared: true}
+	err := orch.startSharedMCP(context.Background(), "forge-mcp-sentry", "sentry", entry, nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to start")
+}
+
+func TestBuildForProject_WithProjectConfig(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, homeDir := setupOrchestrator(t, mockCM)
+
+	// Global config with one MCP
+	configDir := filepath.Join(homeDir, ".config", "claude-forge")
+	configContent := `mcp_servers:
+  linear:
+    image: linear-mcp:latest
+    port: 8080
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configContent), 0o644))
+
+	// Project config with another MCP
+	projectDir := t.TempDir()
+	projectContent := `mcp_servers:
+  my-db:
+    image: db-mcp:latest
+    port: 5432
+`
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, ".claude-forge.yaml"), []byte(projectContent), 0o644))
+
+	// 3 built-in + 2 custom
+	mockCM.EXPECT().PullImage(gomock.Any(), gomock.Any()).Return(nil).Times(5)
+
+	err := orch.BuildForProject(context.Background(), projectDir)
+	require.NoError(t, err)
+}
+
+func TestBuildForProject_ProjectConfigError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, _ := setupOrchestrator(t, mockCM)
+
+	// Project dir with invalid config
+	projectDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, ".claude-forge.yaml"), []byte(":::bad"), 0o644))
+
+	err := orch.BuildForProject(context.Background(), projectDir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load project config")
+}
+
+func TestBuildForProject_NoProjectDir(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, _ := setupOrchestrator(t, mockCM)
+
+	// 3 built-in images
+	mockCM.EXPECT().PullImage(gomock.Any(), gomock.Any()).Return(nil).Times(3)
+
+	err := orch.BuildForProject(context.Background(), "")
+	require.NoError(t, err)
+}
+
+func TestStart_CustomMCPPerSessionStartFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, homeDir := setupOrchestrator(t, mockCM)
+
+	projectDir := setupGitProject(t)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+
+	configDir := filepath.Join(homeDir, ".config", "claude-forge")
+	configContent := `mcp_servers:
+  linear:
+    image: linear-mcp:latest
+    port: 8080
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configContent), 0o644))
+
+	mockCM.EXPECT().ImageExists(gomock.Any(), gomock.Any()).Return(true, nil).Times(4)
+	mockCM.EXPECT().CreateNetwork(gomock.Any(), gomock.Any()).Return("net-id", nil)
+	mockCM.EXPECT().StartGateway(gomock.Any(), gomock.Any()).Return("gw-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "gw-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartGitHubMCP(gomock.Any(), gomock.Any()).Return("mcp-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "mcp-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).Return("", fmt.Errorf("start failed"))
+
+	// Cleanup
+	mockCM.EXPECT().StopContainer(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockCM.EXPECT().RemoveContainer(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockCM.EXPECT().RemoveNetwork(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	_, err := orch.Start(context.Background(), StartOptions{
+		ProjectDir: projectDir,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to start MCP")
+}
+
+func TestStart_CustomMCPPerSessionReadyFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, homeDir := setupOrchestrator(t, mockCM)
+
+	projectDir := setupGitProject(t)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+
+	configDir := filepath.Join(homeDir, ".config", "claude-forge")
+	configContent := `mcp_servers:
+  linear:
+    image: linear-mcp:latest
+    port: 8080
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configContent), 0o644))
+
+	mockCM.EXPECT().ImageExists(gomock.Any(), gomock.Any()).Return(true, nil).Times(4)
+	mockCM.EXPECT().CreateNetwork(gomock.Any(), gomock.Any()).Return("net-id", nil)
+	mockCM.EXPECT().StartGateway(gomock.Any(), gomock.Any()).Return("gw-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "gw-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartGitHubMCP(gomock.Any(), gomock.Any()).Return("mcp-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "mcp-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).Return("custom-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "custom-id", gomock.Any()).Return(fmt.Errorf("crash"))
+	mockCM.EXPECT().ContainerLogs(gomock.Any(), "custom-id").Return("error log", nil)
+
+	// Cleanup
+	mockCM.EXPECT().StopContainer(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockCM.EXPECT().RemoveContainer(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockCM.EXPECT().RemoveNetwork(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	_, err := orch.Start(context.Background(), StartOptions{
+		ProjectDir: projectDir,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to start")
+	assert.Contains(t, err.Error(), "error log")
+}
+
+func TestStart_CustomMCPSharedStartFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, homeDir := setupOrchestrator(t, mockCM)
+
+	projectDir := setupGitProject(t)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+
+	configDir := filepath.Join(homeDir, ".config", "claude-forge")
+	configContent := `mcp_servers:
+  sentry:
+    image: sentry-mcp:latest
+    port: 9090
+    shared: true
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configContent), 0o644))
+
+	mockCM.EXPECT().ImageExists(gomock.Any(), gomock.Any()).Return(true, nil).Times(4)
+	mockCM.EXPECT().CreateNetwork(gomock.Any(), gomock.Any()).Return("net-id", nil)
+	mockCM.EXPECT().StartGateway(gomock.Any(), gomock.Any()).Return("gw-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "gw-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartGitHubMCP(gomock.Any(), gomock.Any()).Return("mcp-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "mcp-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("", fmt.Errorf("network error"))
+
+	// Cleanup
+	mockCM.EXPECT().StopContainer(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockCM.EXPECT().RemoveContainer(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockCM.EXPECT().RemoveNetwork(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	_, err := orch.Start(context.Background(), StartOptions{
+		ProjectDir: projectDir,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to start shared MCP")
+}
+
+func TestStart_InvalidProjectConfig(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, _ := setupOrchestrator(t, mockCM)
+
+	projectDir := setupGitProject(t)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+
+	// Invalid project config
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, ".claude-forge.yaml"), []byte(":::bad"), 0o644))
+
+	_, err := orch.Start(context.Background(), StartOptions{
+		ProjectDir: projectDir,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load project config")
+}
+
+func TestStart_InvalidMCPConfig(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, homeDir := setupOrchestrator(t, mockCM)
+
+	projectDir := setupGitProject(t)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+
+	// Global config with invalid MCP (no image or url)
+	configDir := filepath.Join(homeDir, ".config", "claude-forge")
+	configContent := `mcp_servers:
+  bad:
+    port: 8080
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configContent), 0o644))
+
+	_, err := orch.Start(context.Background(), StartOptions{
+		ProjectDir: projectDir,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid MCP server config")
+}
+
+func TestStart_CustomMCPDefaultPath(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, homeDir := setupOrchestrator(t, mockCM)
+
+	projectDir := setupGitProject(t)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+
+	// MCP without explicit path (should default to /mcp)
+	configDir := filepath.Join(homeDir, ".config", "claude-forge")
+	configContent := `mcp_servers:
+  linear:
+    image: linear-mcp:latest
+    port: 8080
+    path: /custom-path
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configContent), 0o644))
+
+	mockCM.EXPECT().ImageExists(gomock.Any(), gomock.Any()).Return(true, nil).Times(4)
+	mockCM.EXPECT().CreateNetwork(gomock.Any(), gomock.Any()).Return("net-id", nil)
+	mockCM.EXPECT().StartGateway(gomock.Any(), gomock.Any()).Return("gw-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "gw-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartGitHubMCP(gomock.Any(), gomock.Any()).Return("mcp-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "mcp-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).Return("custom-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "custom-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartAgent(gomock.Any(), gomock.Any()).Return("agent-id", nil)
+
+	sess, err := orch.Start(context.Background(), StartOptions{
+		ProjectDir: projectDir,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, sess)
+}
+
 func TestBuild_WithCustomMCPs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
@@ -1515,6 +1850,186 @@ func TestBuild_WithCustomMCPs(t *testing.T) {
 
 	err := orch.Build(context.Background())
 	require.NoError(t, err)
+}
+
+func TestStart_GatewayCrashNoLogs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, _ := setupOrchestrator(t, mockCM)
+
+	projectDir := setupGitProject(t)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+
+	mockCM.EXPECT().ImageExists(gomock.Any(), gomock.Any()).Return(true, nil).Times(3)
+	mockCM.EXPECT().CreateNetwork(gomock.Any(), gomock.Any()).Return("net-id", nil)
+	mockCM.EXPECT().StartGateway(gomock.Any(), gomock.Any()).Return("gw-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "gw-id", gomock.Any()).Return(fmt.Errorf("timeout"))
+	mockCM.EXPECT().ContainerLogs(gomock.Any(), "gw-id").Return("", nil)
+
+	mockCM.EXPECT().StopContainer(gomock.Any(), gomock.Any()).Return(nil).Times(3)
+	mockCM.EXPECT().RemoveContainer(gomock.Any(), gomock.Any()).Return(nil).Times(3)
+	mockCM.EXPECT().RemoveNetwork(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+	_, err := orch.Start(context.Background(), StartOptions{
+		ProjectDir: projectDir,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gateway container failed to start")
+	assert.NotContains(t, err.Error(), "Gateway logs")
+}
+
+func TestStart_GitHubMCPReadyNoLogs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, _ := setupOrchestrator(t, mockCM)
+
+	projectDir := setupGitProject(t)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+
+	mockCM.EXPECT().ImageExists(gomock.Any(), gomock.Any()).Return(true, nil).Times(3)
+	mockCM.EXPECT().CreateNetwork(gomock.Any(), gomock.Any()).Return("net-id", nil)
+	mockCM.EXPECT().StartGateway(gomock.Any(), gomock.Any()).Return("gw-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "gw-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartGitHubMCP(gomock.Any(), gomock.Any()).Return("mcp-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "mcp-id", gomock.Any()).Return(fmt.Errorf("timeout"))
+	mockCM.EXPECT().ContainerLogs(gomock.Any(), "mcp-id").Return("", nil)
+
+	mockCM.EXPECT().StopContainer(gomock.Any(), gomock.Any()).Return(nil).Times(3)
+	mockCM.EXPECT().RemoveContainer(gomock.Any(), gomock.Any()).Return(nil).Times(3)
+	mockCM.EXPECT().RemoveNetwork(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+	_, err := orch.Start(context.Background(), StartOptions{
+		ProjectDir: projectDir,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "github-mcp failed to start")
+	assert.NotContains(t, err.Error(), "Logs:")
+}
+
+func TestStart_CustomMCPWithMounts(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, homeDir := setupOrchestrator(t, mockCM)
+
+	projectDir := setupGitProject(t)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+
+	// Create mount source directory
+	mountSource := filepath.Join(homeDir, ".config", "my-mcp")
+	require.NoError(t, os.MkdirAll(mountSource, 0o755))
+
+	configDir := filepath.Join(homeDir, ".config", "claude-forge")
+	configContent := fmt.Sprintf(`mcp_servers:
+  my-mcp:
+    image: my-mcp:latest
+    port: 8080
+    mounts:
+      - source: %s
+        target: /config
+        read_only: true
+`, mountSource)
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configContent), 0o644))
+
+	mockCM.EXPECT().ImageExists(gomock.Any(), gomock.Any()).Return(true, nil).Times(4)
+	mockCM.EXPECT().CreateNetwork(gomock.Any(), gomock.Any()).Return("net-id", nil)
+	mockCM.EXPECT().StartGateway(gomock.Any(), gomock.Any()).Return("gw-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "gw-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartGitHubMCP(gomock.Any(), gomock.Any()).Return("mcp-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "mcp-id", gomock.Any()).Return(nil)
+
+	mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, opts container.SharedServiceOptions) (string, error) {
+			require.Len(t, opts.Mounts, 1)
+			assert.Equal(t, mountSource, opts.Mounts[0].Source)
+			assert.Equal(t, "/config", opts.Mounts[0].Target)
+			assert.True(t, opts.Mounts[0].ReadOnly)
+			return "mcp-mount-id", nil
+		})
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "mcp-mount-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartAgent(gomock.Any(), gomock.Any()).Return("agent-id", nil)
+
+	sess, err := orch.Start(context.Background(), StartOptions{
+		ProjectDir: projectDir,
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, sess.CustomMCPNames, 1)
+}
+
+func TestStart_CustomMCPPerSessionReadyFailsNoLogs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, homeDir := setupOrchestrator(t, mockCM)
+
+	projectDir := setupGitProject(t)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+
+	configDir := filepath.Join(homeDir, ".config", "claude-forge")
+	configContent := `mcp_servers:
+  my-mcp:
+    image: my-mcp:latest
+    port: 8080
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configContent), 0o644))
+
+	mockCM.EXPECT().ImageExists(gomock.Any(), gomock.Any()).Return(true, nil).Times(4)
+	mockCM.EXPECT().CreateNetwork(gomock.Any(), gomock.Any()).Return("net-id", nil)
+	mockCM.EXPECT().StartGateway(gomock.Any(), gomock.Any()).Return("gw-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "gw-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartGitHubMCP(gomock.Any(), gomock.Any()).Return("mcp-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "mcp-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).Return("custom-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "custom-id", gomock.Any()).Return(fmt.Errorf("timeout"))
+	mockCM.EXPECT().ContainerLogs(gomock.Any(), "custom-id").Return("", nil)
+
+	// Cleanup: agent + github-mcp + gateway (custom MCP not yet in session)
+	mockCM.EXPECT().StopContainer(gomock.Any(), gomock.Any()).Return(nil).Times(3)
+	mockCM.EXPECT().RemoveContainer(gomock.Any(), gomock.Any()).Return(nil).Times(3)
+	mockCM.EXPECT().RemoveNetwork(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+	_, err := orch.Start(context.Background(), StartOptions{
+		ProjectDir: projectDir,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `MCP "my-mcp" failed to start`)
+	assert.NotContains(t, err.Error(), "Logs:")
+}
+
+func TestStart_GithubTokenFromEnv(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, _ := setupOrchestrator(t, mockCM)
+
+	projectDir := setupGitProject(t)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+	t.Setenv("GITHUB_TOKEN", "ghp_test123")
+
+	mockCM.EXPECT().ImageExists(gomock.Any(), gomock.Any()).Return(true, nil).Times(3)
+	mockCM.EXPECT().CreateNetwork(gomock.Any(), gomock.Any()).Return("net-id", nil)
+	mockCM.EXPECT().StartGateway(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, opts container.GatewayOptions) (string, error) {
+			assert.Equal(t, "ghp_test123", opts.Env["GITHUB_TOKEN"])
+			return "gw-id", nil
+		})
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "gw-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartGitHubMCP(gomock.Any(), gomock.Any()).Return("mcp-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "mcp-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartAgent(gomock.Any(), gomock.Any()).Return("agent-id", nil)
+
+	sess, err := orch.Start(context.Background(), StartOptions{
+		ProjectDir: projectDir,
+	})
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, sess.SessionID)
 }
 
 func TestReadGHToken(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add custom MCP server support in `~/.config/claude-forge/config.yaml` under `mcp_servers` section
- Support three modes: container-based per-session, shared singleton (`shared: true`), and URL-only (external)
- Add project-level config via `.claude-forge.yaml` in the project root — project entries take priority over global, `enabled: false` disables a global entry
- Environment variables use `${VAR}` syntax expanded from host env at runtime; mount paths support `~` expansion
- Custom MCP containers appear in `claude-forge status` and are cleaned up by `claude-forge stop`
- `claude-forge build` pulls images for custom MCPs (global + project when run from a project dir)

## Test plan
- [x] Config loading with `mcp_servers` section parses correctly
- [x] Project config loading from `.claude-forge.yaml`
- [x] Resolution logic: project overrides global, `enabled: false` removes entries
- [x] Validation: reserved names rejected, image+port or url required, no both
- [x] Per-session MCP container started with correct name, alias, env expansion
- [x] Shared MCP container started with singleton pattern (reuses if running)
- [x] URL-only MCP registered without starting a container
- [x] Cleanup removes per-session custom MCP containers
- [x] Build pulls custom MCP images
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)