### PR TITLE
feat: Add session names to claude-forge start, resume, and list

### DIFF
--- a/cmd/claude-forge/main.go
+++ b/cmd/claude-forge/main.go
@@ -83,7 +83,7 @@ func newOrchestrator() (*forge.Orchestrator, func(), error) {
 }
 
 // startSession runs the common logic for the start and resume commands.
-func startSession(skipPermissions, worktree bool, prompt, resumeID, resumeSubdir string, continueSession bool, mounts []string, resumeWorktreeName string) error {
+func startSession(skipPermissions, worktree bool, prompt, resumeID, resumeSubdir string, continueSession bool, mounts []string, resumeWorktreeName, name string) error {
 	orch, cleanup, err := createOrchestrator()
 	if err != nil {
 		return err
@@ -107,6 +107,7 @@ func startSession(skipPermissions, worktree bool, prompt, resumeID, resumeSubdir
 		GID:                hostGID,
 		Mounts:             mounts,
 		ResumeWorktreeName: resumeWorktreeName,
+		Name:               name,
 	})
 	if err != nil {
 		return err
@@ -259,6 +260,7 @@ func newStartCmd() *cobra.Command {
 		noSkipPermissions bool
 		prompt            string
 		mounts            []string
+		name              string
 	)
 
 	cmd := &cobra.Command{
@@ -266,10 +268,10 @@ func newStartCmd() *cobra.Command {
 		Short: "Start a new Claude Code session in a Docker container",
 		Long: `Start launches a new Claude Code agent and gateway in Docker containers.
 By default, --dangerously-skip-permissions is enabled. Use --no-skip-permissions
-to disable it.`,
+to disable it. A session --name is required and is passed to Claude Code.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			skipPermissions := !noSkipPermissions
-			return startSession(skipPermissions, worktree, prompt, "", "", false, mounts, "")
+			return startSession(skipPermissions, worktree, prompt, "", "", false, mounts, "", name)
 		},
 	}
 
@@ -277,6 +279,8 @@ to disable it.`,
 	cmd.Flags().BoolVar(&noSkipPermissions, "no-skip-permissions", false, "Disable --dangerously-skip-permissions")
 	cmd.Flags().StringVarP(&prompt, "prompt", "p", "", "Initial prompt to send to Claude Code")
 	cmd.Flags().StringArrayVar(&mounts, "mount", nil, "Additional host directories to mount (format: host_path:container_path)")
+	cmd.Flags().StringVarP(&name, "name", "n", "", "Human-readable name for this session (required)")
+	_ = cmd.MarkFlagRequired("name")
 
 	return cmd
 }
@@ -286,6 +290,7 @@ func newResumeCmd() *cobra.Command {
 	var (
 		list   bool
 		mounts []string
+		name   string
 	)
 
 	cmd := &cobra.Command{
@@ -293,7 +298,7 @@ func newResumeCmd() *cobra.Command {
 		Short: "Resume a past Claude Code session",
 		Long: `Resume a previous session by ID, or use --list to see available sessions.
 If no session ID is given and --list is not set, the most recent session
-is continued.`,
+is continued. The session name is reused unless overridden with --name.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cwd, err := os.Getwd()
@@ -323,13 +328,13 @@ is continued.`,
 				}
 
 				w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-				fmt.Fprintln(w, "SESSION ID\tCREATED\tWORKTREE\tFIRST MESSAGE")
+				fmt.Fprintln(w, "SESSION ID\tNAME\tCREATED\tWORKTREE\tFIRST MESSAGE")
 				for _, s := range sessions {
 					firstMsg := s.FirstMsg
 					if len(firstMsg) > 60 {
 						firstMsg = firstMsg[:57] + "..."
 					}
-					fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", s.ID, s.CreatedAt.Format(time.RFC3339), s.WorktreeName(), firstMsg)
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", s.ID, s.Name, s.CreatedAt.Format(time.RFC3339), s.WorktreeName(), firstMsg)
 				}
 				return w.Flush()
 			}
@@ -339,7 +344,7 @@ is continued.`,
 				if err != nil {
 					return err
 				}
-				return startSession(true, sess.IsWorktree(), "", args[0], sess.Subdir, false, mounts, sess.WorktreeName())
+				return startSession(true, sess.IsWorktree(), "", args[0], sess.Subdir, false, mounts, sess.WorktreeName(), resumeName(name, sess.Name))
 			}
 
 			// Continue most recent session, detecting worktree if needed
@@ -351,14 +356,23 @@ is continued.`,
 				return fmt.Errorf("no sessions found to continue")
 			}
 			mostRecent := sessions[0]
-			return startSession(true, mostRecent.IsWorktree(), "", mostRecent.ID, mostRecent.Subdir, false, mounts, mostRecent.WorktreeName())
+			return startSession(true, mostRecent.IsWorktree(), "", mostRecent.ID, mostRecent.Subdir, false, mounts, mostRecent.WorktreeName(), resumeName(name, mostRecent.Name))
 		},
 	}
 
 	cmd.Flags().BoolVar(&list, "list", false, "List available sessions")
 	cmd.Flags().StringArrayVar(&mounts, "mount", nil, "Additional host directories to mount (format: host_path:container_path)")
+	cmd.Flags().StringVarP(&name, "name", "n", "", "Override the session name passed to Claude Code (defaults to the stored name)")
 
 	return cmd
+}
+
+// resumeName returns the override name if provided, otherwise the stored name.
+func resumeName(override, stored string) string {
+	if override != "" {
+		return override
+	}
+	return stored
 }
 
 // newStopCmd creates the "stop" subcommand.

--- a/cmd/claude-forge/main.go
+++ b/cmd/claude-forge/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -53,6 +54,7 @@ containers, Docker networks, and session state.`,
 		newInitCmd(),
 		newStartCmd(),
 		newResumeCmd(),
+		newListCmd(),
 		newStopCmd(),
 		newStatusCmd(),
 		newBuildCmd(),
@@ -260,18 +262,20 @@ func newStartCmd() *cobra.Command {
 		noSkipPermissions bool
 		prompt            string
 		mounts            []string
-		name              string
 	)
 
 	cmd := &cobra.Command{
-		Use:   "start",
+		Use:   "start <name>",
 		Short: "Start a new Claude Code session in a Docker container",
 		Long: `Start launches a new Claude Code agent and gateway in Docker containers.
-By default, --dangerously-skip-permissions is enabled. Use --no-skip-permissions
-to disable it. A session --name is required and is passed to Claude Code.`,
+The required <name> argument is a human-readable session name; it is passed to
+Claude Code and shown in 'resume --list'. By default,
+--dangerously-skip-permissions is enabled; use --no-skip-permissions to disable
+it.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			skipPermissions := !noSkipPermissions
-			return startSession(skipPermissions, worktree, prompt, "", "", false, mounts, "", name)
+			return startSession(skipPermissions, worktree, prompt, "", "", false, mounts, "", args[0])
 		},
 	}
 
@@ -279,16 +283,69 @@ to disable it. A session --name is required and is passed to Claude Code.`,
 	cmd.Flags().BoolVar(&noSkipPermissions, "no-skip-permissions", false, "Disable --dangerously-skip-permissions")
 	cmd.Flags().StringVarP(&prompt, "prompt", "p", "", "Initial prompt to send to Claude Code")
 	cmd.Flags().StringArrayVar(&mounts, "mount", nil, "Additional host directories to mount (format: host_path:container_path)")
-	cmd.Flags().StringVarP(&name, "name", "n", "", "Human-readable name for this session (required)")
-	_ = cmd.MarkFlagRequired("name")
 
 	return cmd
+}
+
+// projectSessionDir resolves the host session directory for the project in the
+// current working directory.
+func projectSessionDir() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get working directory: %w", err)
+	}
+	proj, err := project.Identify(cwd)
+	if err != nil {
+		return "", fmt.Errorf("failed to identify project: %w", err)
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return filepath.Join(homeDir, ".claude-forge", proj.ID), nil
+}
+
+// listSessions writes the session table for sessionDir to w.
+func listSessions(w io.Writer, sessionDir string) error {
+	sessions, err := session.List(sessionDir)
+	if err != nil {
+		return fmt.Errorf("failed to list sessions: %w", err)
+	}
+	if len(sessions) == 0 {
+		fmt.Fprintln(w, "No sessions found.")
+		return nil
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "SESSION ID\tNAME\tCREATED\tWORKTREE\tFIRST MESSAGE")
+	for _, s := range sessions {
+		firstMsg := s.FirstMsg
+		if len(firstMsg) > 60 {
+			firstMsg = firstMsg[:57] + "..."
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", s.ID, s.Name, s.CreatedAt.Format(time.RFC3339), s.WorktreeName(), firstMsg)
+	}
+	return tw.Flush()
+}
+
+// newListCmd creates the "list" subcommand.
+func newListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List past Claude Code sessions for the current project",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			sessionDir, err := projectSessionDir()
+			if err != nil {
+				return err
+			}
+			return listSessions(cmd.OutOrStdout(), sessionDir)
+		},
+	}
 }
 
 // newResumeCmd creates the "resume" subcommand.
 func newResumeCmd() *cobra.Command {
 	var (
-		list   bool
 		mounts []string
 		name   string
 	)
@@ -296,47 +353,14 @@ func newResumeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "resume [session-id]",
 		Short: "Resume a past Claude Code session",
-		Long: `Resume a previous session by ID, or use --list to see available sessions.
-If no session ID is given and --list is not set, the most recent session
-is continued. The session name is reused unless overridden with --name.`,
+		Long: `Resume a previous session by ID. If no session ID is given, the most
+recent session is continued. Run 'claude-forge list' to see available
+sessions. The session name is reused unless overridden with --name.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cwd, err := os.Getwd()
+			sessionDir, err := projectSessionDir()
 			if err != nil {
-				return fmt.Errorf("failed to get working directory: %w", err)
-			}
-
-			proj, err := project.Identify(cwd)
-			if err != nil {
-				return fmt.Errorf("failed to identify project: %w", err)
-			}
-
-			homeDir, err := os.UserHomeDir()
-			if err != nil {
-				return fmt.Errorf("failed to get home directory: %w", err)
-			}
-			sessionDir := filepath.Join(homeDir, ".claude-forge", proj.ID)
-
-			if list {
-				sessions, err := session.List(sessionDir)
-				if err != nil {
-					return fmt.Errorf("failed to list sessions: %w", err)
-				}
-				if len(sessions) == 0 {
-					fmt.Println("No sessions found.")
-					return nil
-				}
-
-				w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-				fmt.Fprintln(w, "SESSION ID\tNAME\tCREATED\tWORKTREE\tFIRST MESSAGE")
-				for _, s := range sessions {
-					firstMsg := s.FirstMsg
-					if len(firstMsg) > 60 {
-						firstMsg = firstMsg[:57] + "..."
-					}
-					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", s.ID, s.Name, s.CreatedAt.Format(time.RFC3339), s.WorktreeName(), firstMsg)
-				}
-				return w.Flush()
+				return err
 			}
 
 			if len(args) == 1 {
@@ -360,7 +384,6 @@ is continued. The session name is reused unless overridden with --name.`,
 		},
 	}
 
-	cmd.Flags().BoolVar(&list, "list", false, "List available sessions")
 	cmd.Flags().StringArrayVar(&mounts, "mount", nil, "Additional host directories to mount (format: host_path:container_path)")
 	cmd.Flags().StringVarP(&name, "name", "n", "", "Override the session name passed to Claude Code (defaults to the stored name)")
 

--- a/cmd/claude-forge/main.go
+++ b/cmd/claude-forge/main.go
@@ -370,14 +370,10 @@ func newPruneCmd() *cobra.Command {
 		Use:   "prune",
 		Short: "Delete old Claude Code sessions for the current project",
 		Long: `Prune removes session transcripts (and their name sidecars) for the
-current project. Select what to delete with --older-than and/or --keep:
---keep protects the N most recent sessions, and --older-than only deletes
-sessions older than the given age. Use --dry-run to preview.`,
+current project. By default it deletes sessions older than 30 days. Narrow
+or widen the window with --older-than, and protect the N most recent
+sessions with --keep. Use --dry-run to preview.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if olderThan == "" && keep < 0 {
-				return fmt.Errorf("specify --older-than and/or --keep")
-			}
-
 			var maxAge time.Duration
 			if olderThan != "" {
 				var err error
@@ -435,7 +431,7 @@ sessions older than the given age. Use --dry-run to preview.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&olderThan, "older-than", "", "Delete sessions older than this age (e.g. 30d, 720h)")
+	cmd.Flags().StringVar(&olderThan, "older-than", "30d", "Delete sessions older than this age (e.g. 30d, 720h)")
 	cmd.Flags().IntVar(&keep, "keep", -1, "Keep the N most recent sessions, delete the rest")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show what would be deleted without deleting")
 

--- a/cmd/claude-forge/main.go
+++ b/cmd/claude-forge/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -55,6 +56,7 @@ containers, Docker networks, and session state.`,
 		newStartCmd(),
 		newResumeCmd(),
 		newListCmd(),
+		newPruneCmd(),
 		newStopCmd(),
 		newStatusCmd(),
 		newBuildCmd(),
@@ -341,6 +343,103 @@ func newListCmd() *cobra.Command {
 			return listSessions(cmd.OutOrStdout(), sessionDir)
 		},
 	}
+}
+
+// parseAge parses a session age. It accepts standard Go durations (e.g. "720h")
+// plus a "<N>d" day form (e.g. "30d").
+func parseAge(s string) (time.Duration, error) {
+	if rest, ok := strings.CutSuffix(s, "d"); ok {
+		days, err := strconv.Atoi(rest)
+		if err != nil {
+			return 0, fmt.Errorf("invalid duration %q", s)
+		}
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+	return time.ParseDuration(s)
+}
+
+// newPruneCmd creates the "prune" subcommand.
+func newPruneCmd() *cobra.Command {
+	var (
+		olderThan string
+		keep      int
+		dryRun    bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "prune",
+		Short: "Delete old Claude Code sessions for the current project",
+		Long: `Prune removes session transcripts (and their name sidecars) for the
+current project. Select what to delete with --older-than and/or --keep:
+--keep protects the N most recent sessions, and --older-than only deletes
+sessions older than the given age. Use --dry-run to preview.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if olderThan == "" && keep < 0 {
+				return fmt.Errorf("specify --older-than and/or --keep")
+			}
+
+			var maxAge time.Duration
+			if olderThan != "" {
+				var err error
+				maxAge, err = parseAge(olderThan)
+				if err != nil {
+					return fmt.Errorf("invalid --older-than: %w", err)
+				}
+			}
+
+			sessionDir, err := projectSessionDir()
+			if err != nil {
+				return err
+			}
+			sessions, err := session.List(sessionDir)
+			if err != nil {
+				return fmt.Errorf("failed to list sessions: %w", err)
+			}
+
+			// sessions are sorted most-recent-first.
+			now := time.Now()
+			var toPrune []session.Session
+			for i, s := range sessions {
+				if keep >= 0 && i < keep {
+					continue // protected: among the N newest
+				}
+				if olderThan != "" && now.Sub(s.CreatedAt) < maxAge {
+					continue // not old enough
+				}
+				toPrune = append(toPrune, s)
+			}
+
+			w := cmd.OutOrStdout()
+			if len(toPrune) == 0 {
+				fmt.Fprintln(w, "No sessions to prune.")
+				return nil
+			}
+
+			for _, s := range toPrune {
+				if dryRun {
+					fmt.Fprintf(w, "would delete  %s  %s  %s\n", s.ID, s.CreatedAt.Format(time.RFC3339), s.Name)
+					continue
+				}
+				if err := session.Delete(sessionDir, s); err != nil {
+					return err
+				}
+				fmt.Fprintf(w, "deleted  %s  %s  %s\n", s.ID, s.CreatedAt.Format(time.RFC3339), s.Name)
+			}
+
+			verb := "Deleted"
+			if dryRun {
+				verb = "Would delete"
+			}
+			fmt.Fprintf(w, "%s %d session(s).\n", verb, len(toPrune))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&olderThan, "older-than", "", "Delete sessions older than this age (e.g. 30d, 720h)")
+	cmd.Flags().IntVar(&keep, "keep", -1, "Keep the N most recent sessions, delete the rest")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show what would be deleted without deleting")
+
+	return cmd
 }
 
 // newResumeCmd creates the "resume" subcommand.

--- a/cmd/claude-forge/main.go
+++ b/cmd/claude-forge/main.go
@@ -351,11 +351,12 @@ func newResumeCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "resume [session-id]",
+		Use:   "resume [session-id|name]",
 		Short: "Resume a past Claude Code session",
-		Long: `Resume a previous session by ID. If no session ID is given, the most
-recent session is continued. Run 'claude-forge list' to see available
-sessions. The session name is reused unless overridden with --name.`,
+		Long: `Resume a previous session by ID or by name (the most recent session
+with that name). If no argument is given, the most recent session is
+continued. Run 'claude-forge list' to see available sessions. The session
+name is reused unless overridden with --name.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			sessionDir, err := projectSessionDir()
@@ -368,7 +369,8 @@ sessions. The session name is reused unless overridden with --name.`,
 				if err != nil {
 					return err
 				}
-				return startSession(true, sess.IsWorktree(), "", args[0], sess.Subdir, false, mounts, sess.WorktreeName(), resumeName(name, sess.Name))
+				// Use the resolved session ID (args[0] may be a name).
+				return startSession(true, sess.IsWorktree(), "", sess.ID, sess.Subdir, false, mounts, sess.WorktreeName(), resumeName(name, sess.Name))
 			}
 
 			// Continue most recent session, detecting worktree if needed

--- a/cmd/claude-forge/main_test.go
+++ b/cmd/claude-forge/main_test.go
@@ -115,13 +115,26 @@ func pruneSetup(t *testing.T) string {
 }
 
 func TestPruneCmd(t *testing.T) {
-	t.Run("requires a filter", func(t *testing.T) {
-		pruneSetup(t)
+	t.Run("defaults to older-than 30 days", func(t *testing.T) {
+		sessionDir := pruneSetup(t)
+		writeSessionFile(t, filepath.Join(sessionDir, "-work", "old.jsonl"), "2020-01-01T00:00:00Z", "old")
+		recent := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+		writeSessionFile(t, filepath.Join(sessionDir, "-work", "new.jsonl"), recent, "new")
+
 		cmd := newPruneCmd()
-		cmd.SetArgs([]string{})
-		err := cmd.Execute()
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "older-than")
+		cmd.SetArgs([]string{}) // no flags → default 30d window
+		out := captureStdout(t, func() { require.NoError(t, cmd.Execute()) })
+
+		assert.Contains(t, out, "Deleted 1 session")
+		assert.NoFileExists(t, filepath.Join(sessionDir, "-work", "old.jsonl"))
+		assert.FileExists(t, filepath.Join(sessionDir, "-work", "new.jsonl"))
+	})
+
+	t.Run("older-than default is 30d", func(t *testing.T) {
+		cmd := newPruneCmd()
+		f := cmd.Flags().Lookup("older-than")
+		require.NotNil(t, f)
+		assert.Equal(t, "30d", f.DefValue)
 	})
 
 	t.Run("invalid older-than", func(t *testing.T) {

--- a/cmd/claude-forge/main_test.go
+++ b/cmd/claude-forge/main_test.go
@@ -26,7 +26,7 @@ func TestNewRootCmd(t *testing.T) {
 	assert.Equal(t, "claude-forge", cmd.Use)
 
 	expectedSubcommands := []string{
-		"init", "start", "resume", "stop", "status",
+		"init", "start", "resume", "list", "stop", "status",
 		"build", "auth", "plugins", "version", "gateway", "kube", "mcp",
 	}
 
@@ -53,7 +53,10 @@ func TestNewRootCmd(t *testing.T) {
 func TestNewStartCmd(t *testing.T) {
 	cmd := newStartCmd()
 
-	assert.Equal(t, "start", cmd.Use)
+	assert.Equal(t, "start <name>", cmd.Use)
+
+	// The session name is a required positional argument.
+	require.NotNil(t, cmd.Args)
 
 	worktreeFlag := cmd.Flags().Lookup("worktree")
 	require.NotNil(t, worktreeFlag)
@@ -67,19 +70,15 @@ func TestNewStartCmd(t *testing.T) {
 	require.NotNil(t, promptFlag)
 	assert.Equal(t, "", promptFlag.DefValue)
 	assert.Equal(t, "p", promptFlag.Shorthand)
-
-	nameFlag := cmd.Flags().Lookup("name")
-	require.NotNil(t, nameFlag)
-	assert.Equal(t, "n", nameFlag.Shorthand)
 }
 
-func TestStartCmd_RequiresName(t *testing.T) {
+func TestStartCmd_RequiresNameArg(t *testing.T) {
 	cmd := newStartCmd()
 	cmd.SetArgs([]string{})
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "name")
+	assert.Contains(t, err.Error(), "accepts 1 arg")
 }
 
 func TestResumeName(t *testing.T) {
@@ -93,9 +92,9 @@ func TestNewResumeCmd(t *testing.T) {
 
 	assert.Equal(t, "resume [session-id]", cmd.Use)
 
-	listFlag := cmd.Flags().Lookup("list")
-	require.NotNil(t, listFlag)
-	assert.Equal(t, "false", listFlag.DefValue)
+	nameFlag := cmd.Flags().Lookup("name")
+	require.NotNil(t, nameFlag)
+	assert.Equal(t, "n", nameFlag.Shorthand)
 
 	// Verify MaximumNArgs(1) is set by checking the Args validator.
 	require.NotNil(t, cmd.Args)
@@ -397,7 +396,7 @@ func TestGatewayCmd_MissingRepo(t *testing.T) {
 	assert.Contains(t, err.Error(), "--owner and --repo are required")
 }
 
-func TestResumeCmd_List_NoSessions(t *testing.T) {
+func TestListCmd_NoSessions(t *testing.T) {
 	setupTestOrchestrator(t, &stubContainerManager{})
 	repoDir := setupTestGitRepo(t)
 
@@ -406,8 +405,8 @@ func TestResumeCmd_List_NoSessions(t *testing.T) {
 	require.NoError(t, os.Chdir(repoDir))
 	t.Cleanup(func() { os.Chdir(origDir) })
 
-	cmd := newResumeCmd()
-	cmd.SetArgs([]string{"--list"})
+	cmd := newListCmd()
+	cmd.SetArgs([]string{})
 
 	output := captureStdout(t, func() {
 		err = cmd.Execute()
@@ -416,7 +415,7 @@ func TestResumeCmd_List_NoSessions(t *testing.T) {
 	assert.Contains(t, output, "No sessions found.")
 }
 
-func TestResumeCmd_List_WithSessions(t *testing.T) {
+func TestListCmd_WithSessions(t *testing.T) {
 	setupTestOrchestrator(t, &stubContainerManager{})
 	repoDir := setupTestGitRepo(t)
 
@@ -443,8 +442,8 @@ func TestResumeCmd_List_WithSessions(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "abc12345.json"),
 		[]byte(`{"name":"my-session"}`), 0o644))
 
-	cmd := newResumeCmd()
-	cmd.SetArgs([]string{"--list"})
+	cmd := newListCmd()
+	cmd.SetArgs([]string{})
 
 	output := captureStdout(t, func() {
 		err = cmd.Execute()
@@ -458,7 +457,7 @@ func TestResumeCmd_List_WithSessions(t *testing.T) {
 	assert.Contains(t, output, "Hello Claude")
 }
 
-func TestResumeCmd_List_WithLongMessage(t *testing.T) {
+func TestListCmd_WithLongMessage(t *testing.T) {
 	setupTestOrchestrator(t, &stubContainerManager{})
 	repoDir := setupTestGitRepo(t)
 
@@ -481,8 +480,8 @@ func TestResumeCmd_List_WithLongMessage(t *testing.T) {
 	sessionFile := filepath.Join(sessionDir, "def67890.jsonl")
 	writeSessionFile(t, sessionFile, "2025-01-15T10:30:01Z", longMsg)
 
-	cmd := newResumeCmd()
-	cmd.SetArgs([]string{"--list"})
+	cmd := newListCmd()
+	cmd.SetArgs([]string{})
 
 	output := captureStdout(t, func() {
 		err = cmd.Execute()
@@ -516,14 +515,14 @@ func TestResumeCmd_NotInGitRepo(t *testing.T) {
 	t.Cleanup(func() { os.Chdir(origDir) })
 
 	cmd := newResumeCmd()
-	cmd.SetArgs([]string{"--list"})
+	cmd.SetArgs([]string{})
 
 	err = cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to identify project")
 }
 
-func TestResumeCmd_List_ShowsWorktreeName(t *testing.T) {
+func TestListCmd_ShowsWorktreeName(t *testing.T) {
 	setupTestOrchestrator(t, &stubContainerManager{})
 	repoDir := setupTestGitRepo(t)
 
@@ -552,8 +551,8 @@ func TestResumeCmd_List_ShowsWorktreeName(t *testing.T) {
 	writeSessionFile(t, filepath.Join(wtDir, "wt-session.jsonl"),
 		"2025-01-15T11:00:00Z", "worktree work")
 
-	cmd := newResumeCmd()
-	cmd.SetArgs([]string{"--list"})
+	cmd := newListCmd()
+	cmd.SetArgs([]string{})
 
 	output := captureStdout(t, func() {
 		err = cmd.Execute()

--- a/cmd/claude-forge/main_test.go
+++ b/cmd/claude-forge/main_test.go
@@ -90,7 +90,7 @@ func TestResumeName(t *testing.T) {
 func TestNewResumeCmd(t *testing.T) {
 	cmd := newResumeCmd()
 
-	assert.Equal(t, "resume [session-id]", cmd.Use)
+	assert.Equal(t, "resume [session-id|name]", cmd.Use)
 
 	nameFlag := cmd.Flags().Lookup("name")
 	require.NotNil(t, nameFlag)

--- a/cmd/claude-forge/main_test.go
+++ b/cmd/claude-forge/main_test.go
@@ -26,7 +26,7 @@ func TestNewRootCmd(t *testing.T) {
 	assert.Equal(t, "claude-forge", cmd.Use)
 
 	expectedSubcommands := []string{
-		"init", "start", "resume", "list", "stop", "status",
+		"init", "start", "resume", "list", "prune", "stop", "status",
 		"build", "auth", "plugins", "version", "gateway", "kube", "mcp",
 	}
 
@@ -79,6 +79,124 @@ func TestStartCmd_RequiresNameArg(t *testing.T) {
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "accepts 1 arg")
+}
+
+func TestParseAge(t *testing.T) {
+	d, err := parseAge("30d")
+	require.NoError(t, err)
+	assert.Equal(t, 30*24*time.Hour, d)
+
+	d, err = parseAge("48h")
+	require.NoError(t, err)
+	assert.Equal(t, 48*time.Hour, d)
+
+	_, err = parseAge("xd")
+	require.Error(t, err)
+
+	_, err = parseAge("nonsense")
+	require.Error(t, err)
+}
+
+// pruneSetup chdirs into a fresh git repo and returns the project session dir.
+func pruneSetup(t *testing.T) string {
+	t.Helper()
+	repoDir := setupTestGitRepo(t)
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(repoDir))
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+	sessionDir := filepath.Join(homeDir, ".claude-forge", strings.ReplaceAll(repoDir, "/", "-"))
+	require.NoError(t, os.MkdirAll(filepath.Join(sessionDir, "-work"), 0o755))
+	t.Cleanup(func() { os.RemoveAll(sessionDir) })
+	return sessionDir
+}
+
+func TestPruneCmd(t *testing.T) {
+	t.Run("requires a filter", func(t *testing.T) {
+		pruneSetup(t)
+		cmd := newPruneCmd()
+		cmd.SetArgs([]string{})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "older-than")
+	})
+
+	t.Run("invalid older-than", func(t *testing.T) {
+		pruneSetup(t)
+		cmd := newPruneCmd()
+		cmd.SetArgs([]string{"--older-than", "notaduration"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid --older-than")
+	})
+
+	t.Run("older-than dry-run keeps files", func(t *testing.T) {
+		sessionDir := pruneSetup(t)
+		oldFile := filepath.Join(sessionDir, "-work", "old.jsonl")
+		writeSessionFile(t, oldFile, "2020-01-01T00:00:00Z", "old one")
+		recent := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+		newFile := filepath.Join(sessionDir, "-work", "new.jsonl")
+		writeSessionFile(t, newFile, recent, "new one")
+
+		cmd := newPruneCmd()
+		cmd.SetArgs([]string{"--older-than", "30d", "--dry-run"})
+		out := captureStdout(t, func() { require.NoError(t, cmd.Execute()) })
+
+		assert.Contains(t, out, "would delete")
+		assert.Contains(t, out, "old")
+		assert.NotContains(t, out, "new.jsonl")
+		assert.FileExists(t, oldFile) // dry-run: nothing removed
+		assert.FileExists(t, newFile)
+	})
+
+	t.Run("older-than deletes old transcript and sidecar", func(t *testing.T) {
+		sessionDir := pruneSetup(t)
+		oldFile := filepath.Join(sessionDir, "-work", "old.jsonl")
+		writeSessionFile(t, oldFile, "2020-01-01T00:00:00Z", "old one")
+		require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "old.json"), []byte(`{"name":"gone"}`), 0o644))
+		recent := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+		newFile := filepath.Join(sessionDir, "-work", "new.jsonl")
+		writeSessionFile(t, newFile, recent, "new one")
+
+		cmd := newPruneCmd()
+		cmd.SetArgs([]string{"--older-than", "30d"})
+		out := captureStdout(t, func() { require.NoError(t, cmd.Execute()) })
+
+		assert.Contains(t, out, "Deleted 1 session")
+		assert.NoFileExists(t, oldFile)
+		assert.NoFileExists(t, filepath.Join(sessionDir, "old.json"))
+		assert.FileExists(t, newFile) // recent one survives
+	})
+
+	t.Run("keep protects newest", func(t *testing.T) {
+		sessionDir := pruneSetup(t)
+		writeSessionFile(t, filepath.Join(sessionDir, "-work", "a.jsonl"), "2026-01-01T00:00:00Z", "a")
+		writeSessionFile(t, filepath.Join(sessionDir, "-work", "b.jsonl"), "2026-02-01T00:00:00Z", "b")
+		writeSessionFile(t, filepath.Join(sessionDir, "-work", "c.jsonl"), "2026-03-01T00:00:00Z", "c")
+
+		cmd := newPruneCmd()
+		cmd.SetArgs([]string{"--keep", "1"})
+		out := captureStdout(t, func() { require.NoError(t, cmd.Execute()) })
+
+		assert.Contains(t, out, "Deleted 2 session")
+		assert.FileExists(t, filepath.Join(sessionDir, "-work", "c.jsonl"))   // newest kept
+		assert.NoFileExists(t, filepath.Join(sessionDir, "-work", "a.jsonl")) // older pruned
+		assert.NoFileExists(t, filepath.Join(sessionDir, "-work", "b.jsonl"))
+	})
+
+	t.Run("nothing to prune", func(t *testing.T) {
+		sessionDir := pruneSetup(t)
+		recent := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+		writeSessionFile(t, filepath.Join(sessionDir, "-work", "new.jsonl"), recent, "new")
+
+		cmd := newPruneCmd()
+		cmd.SetArgs([]string{"--older-than", "30d"})
+		out := captureStdout(t, func() { require.NoError(t, cmd.Execute()) })
+		assert.Contains(t, out, "No sessions to prune.")
+	})
 }
 
 func TestResumeName(t *testing.T) {

--- a/cmd/claude-forge/main_test.go
+++ b/cmd/claude-forge/main_test.go
@@ -67,6 +67,25 @@ func TestNewStartCmd(t *testing.T) {
 	require.NotNil(t, promptFlag)
 	assert.Equal(t, "", promptFlag.DefValue)
 	assert.Equal(t, "p", promptFlag.Shorthand)
+
+	nameFlag := cmd.Flags().Lookup("name")
+	require.NotNil(t, nameFlag)
+	assert.Equal(t, "n", nameFlag.Shorthand)
+}
+
+func TestStartCmd_RequiresName(t *testing.T) {
+	cmd := newStartCmd()
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "name")
+}
+
+func TestResumeName(t *testing.T) {
+	assert.Equal(t, "override", resumeName("override", "stored"))
+	assert.Equal(t, "stored", resumeName("", "stored"))
+	assert.Equal(t, "", resumeName("", ""))
 }
 
 func TestNewResumeCmd(t *testing.T) {
@@ -420,6 +439,10 @@ func TestResumeCmd_List_WithSessions(t *testing.T) {
 	sessionFile := filepath.Join(sessionDir, "abc12345.jsonl")
 	writeSessionFile(t, sessionFile, "2025-01-15T10:30:01Z", "Hello Claude")
 
+	// Write a sidecar metadata file so the NAME column is populated.
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "abc12345.json"),
+		[]byte(`{"name":"my-session"}`), 0o644))
+
 	cmd := newResumeCmd()
 	cmd.SetArgs([]string{"--list"})
 
@@ -428,8 +451,10 @@ func TestResumeCmd_List_WithSessions(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Contains(t, output, "SESSION ID")
+	assert.Contains(t, output, "NAME")
 	assert.Contains(t, output, "WORKTREE")
 	assert.Contains(t, output, "abc12345")
+	assert.Contains(t, output, "my-session")
 	assert.Contains(t, output, "Hello Claude")
 }
 

--- a/cmd/update-ci-secrets/main.go
+++ b/cmd/update-ci-secrets/main.go
@@ -42,19 +42,21 @@ func newRootCmd() *cobra.Command {
 repository so the Claude Code PR review workflow (.github/workflows/claude-review.yml)
 can authenticate.
 
-The token comes from --oauth-token, or is resolved from the local Claude Code
-credentials (~/.claude/.credentials.json) when --from-credentials is set.
+By default the token is resolved from the local Claude Code credentials
+(~/.claude/.credentials.json). Pass --oauth-token to set a token directly
+instead.
 
 The secret is set on the repository in the current directory unless --repo is
 given. Requires the gh CLI to be installed and authenticated with repo admin
 access.`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if oauthToken == "" && !fromCreds {
-				return fmt.Errorf("provide --oauth-token or --from-credentials")
-			}
-			if oauthToken != "" && fromCreds {
+			fromCredsSet := cmd.Flags().Changed("from-credentials")
+			if oauthToken != "" && fromCreds && fromCredsSet {
 				return fmt.Errorf("--oauth-token and --from-credentials are mutually exclusive")
+			}
+			if oauthToken == "" && fromCredsSet && !fromCreds {
+				return fmt.Errorf("provide --oauth-token or enable --from-credentials")
 			}
 
 			u := newUpdater(repo)
@@ -64,14 +66,16 @@ access.`,
 				masked string
 				err    error
 			)
-			if fromCreds {
+			// Default to resolving from local Claude Code credentials unless an
+			// explicit --oauth-token is given.
+			if oauthToken != "" {
+				masked, err = u.Update(ctx, oauthToken)
+			} else {
 				home, herr := os.UserHomeDir()
 				if herr != nil {
 					return fmt.Errorf("failed to locate home directory: %w", herr)
 				}
 				masked, err = u.UpdateFromCredentials(ctx, filepath.Join(home, ".claude"))
-			} else {
-				masked, err = u.Update(ctx, oauthToken)
 			}
 			if err != nil {
 				return err
@@ -88,7 +92,7 @@ access.`,
 
 	cmd.Flags().StringVar(&repo, "repo", "", "GitHub repository (owner/name); defaults to the repository in the current directory")
 	cmd.Flags().StringVar(&oauthToken, "oauth-token", "", "OAuth token to set directly")
-	cmd.Flags().BoolVar(&fromCreds, "from-credentials", false, "Resolve token from local Claude Code credentials")
+	cmd.Flags().BoolVar(&fromCreds, "from-credentials", true, "Resolve token from local Claude Code credentials")
 
 	return cmd
 }

--- a/cmd/update-ci-secrets/main_test.go
+++ b/cmd/update-ci-secrets/main_test.go
@@ -136,6 +136,18 @@ func TestRun_FromCredentialsSuccess(t *testing.T) {
 	assert.Contains(t, out, "Set CLAUDE_CODE_OAUTH_TOKEN")
 }
 
+func TestRun_OAuthTokenWithCredentialsExplicitlyDisabled(t *testing.T) {
+	// Explicitly disabling credentials while supplying a token is valid.
+	f := &fakeUpdater{masked: "sk-ant-o...abcd"}
+	withFakeUpdater(t, f)
+
+	_, err := runCmd("--from-credentials=false", "--oauth-token", "sk-ant-oat-token")
+	require.NoError(t, err)
+	assert.True(t, f.updateCalled)
+	assert.False(t, f.fromCredsCall)
+	assert.Equal(t, "sk-ant-oat-token", f.gotToken)
+}
+
 func TestRun_UpdaterError(t *testing.T) {
 	f := &fakeUpdater{err: errors.New("gh boom")}
 	withFakeUpdater(t, f)

--- a/cmd/update-ci-secrets/main_test.go
+++ b/cmd/update-ci-secrets/main_test.go
@@ -54,14 +54,46 @@ func runCmd(args ...string) (string, error) {
 	return out.String(), err
 }
 
-func TestRun_RequiresAFlag(t *testing.T) {
-	_, err := runCmd()
-	assert.ErrorContains(t, err, "--oauth-token or --from-credentials")
+func TestRun_DefaultsToCredentials(t *testing.T) {
+	f := &fakeUpdater{masked: "sk-ant-o...wxyz"}
+	withFakeUpdater(t, f)
+
+	out, err := runCmd()
+	require.NoError(t, err)
+	assert.True(t, f.fromCredsCall)
+	assert.False(t, f.updateCalled)
+	assert.Contains(t, f.gotClaudeDir, ".claude")
+	assert.Contains(t, out, "Set CLAUDE_CODE_OAUTH_TOKEN")
+}
+
+func TestRun_FromCredentialsDisabledWithoutToken(t *testing.T) {
+	_, err := runCmd("--from-credentials=false")
+	assert.ErrorContains(t, err, "--oauth-token or enable --from-credentials")
+}
+
+func TestRun_FromCredentialsDefaultValue(t *testing.T) {
+	cmd := newRootCmd()
+	flag := cmd.Flags().Lookup("from-credentials")
+	assert.NotNil(t, flag)
+	assert.Equal(t, "true", flag.DefValue)
 }
 
 func TestRun_MutuallyExclusiveFlags(t *testing.T) {
 	_, err := runCmd("--oauth-token", "tok", "--from-credentials")
 	assert.ErrorContains(t, err, "mutually exclusive")
+}
+
+func TestRun_OAuthTokenWithDefaultCredentialsFlag(t *testing.T) {
+	// --oauth-token alone must work even though --from-credentials now
+	// defaults to true (it's only a conflict when explicitly set).
+	f := &fakeUpdater{masked: "sk-ant-o...abcd"}
+	withFakeUpdater(t, f)
+
+	_, err := runCmd("--oauth-token", "sk-ant-oat-token")
+	require.NoError(t, err)
+	assert.True(t, f.updateCalled)
+	assert.False(t, f.fromCredsCall)
+	assert.Equal(t, "sk-ant-oat-token", f.gotToken)
 }
 
 func TestRun_RepoFlagDefaultsEmpty(t *testing.T) {

--- a/internal/cisecrets/cisecrets.go
+++ b/internal/cisecrets/cisecrets.go
@@ -58,7 +58,7 @@ func (u *Updater) Update(ctx context.Context, token string) (string, error) {
 func (u *Updater) UpdateFromCredentials(ctx context.Context, claudeDir string) (string, error) {
 	creds, err := auth.Resolve(claudeDir)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("%w; pass --oauth-token to set a token directly", err)
 	}
 	if creds.AuthType != "oauth" {
 		return "", fmt.Errorf("resolved credential is %q, not an OAuth token; %s requires an OAuth login (run 'claude' to authenticate)", creds.AuthType, SecretName)

--- a/internal/cisecrets/cisecrets_test.go
+++ b/internal/cisecrets/cisecrets_test.go
@@ -100,7 +100,7 @@ func TestUpdateFromCredentials(t *testing.T) {
 	t.Run("resolve error", func(t *testing.T) {
 		u := &Updater{Repo: "owner/repo", setter: func(context.Context, string, string, string) error { return nil }}
 		_, err := u.UpdateFromCredentials(context.Background(), filepath.Join(t.TempDir(), "missing"))
-		assert.Error(t, err)
+		assert.ErrorContains(t, err, "--oauth-token")
 	})
 }
 

--- a/internal/forge/orchestrator.go
+++ b/internal/forge/orchestrator.go
@@ -72,6 +72,13 @@ type Session struct {
 // resolves credentials, creates containers, and returns the session info.
 // The caller is responsible for attaching to the agent and calling Cleanup.
 func (o *Orchestrator) Start(ctx context.Context, opts StartOptions) (*Session, error) {
+	// Fail fast on an invalid session name before doing any container work.
+	if opts.Name != "" {
+		if err := session.ValidateName(opts.Name); err != nil {
+			return nil, err
+		}
+	}
+
 	// Resolve project directory
 	projectDir := opts.ProjectDir
 	if projectDir == "" {
@@ -301,6 +308,8 @@ func (o *Orchestrator) Start(ctx context.Context, opts StartOptions) (*Session, 
 	} else if opts.Continue {
 		agentCmd = append(agentCmd, "--continue")
 	} else {
+		// --session-id and --name are Claude Code CLI flags; re-verify they
+		// still exist against `claude --help` when bumping the agent image.
 		agentCmd = append(agentCmd, "--session-id", claudeSessionID)
 	}
 	if opts.Name != "" {
@@ -308,14 +317,6 @@ func (o *Orchestrator) Start(ctx context.Context, opts StartOptions) (*Session, 
 	}
 	if opts.Prompt != "" {
 		agentCmd = append(agentCmd, "-p", opts.Prompt)
-	}
-
-	// Persist the session name in a sidecar file so `resume --list` and
-	// `resume` can surface and reuse it later.
-	if fresh && opts.Name != "" {
-		if err := session.WriteMetadata(sessionDir, claudeSessionID, session.Metadata{Name: opts.Name}); err != nil {
-			return nil, fmt.Errorf("failed to write session metadata: %w", err)
-		}
 	}
 
 	// Build environment variables
@@ -407,6 +408,16 @@ func (o *Orchestrator) Start(ctx context.Context, opts StartOptions) (*Session, 
 	}); err != nil {
 		o.Cleanup(ctx, sess)
 		return nil, fmt.Errorf("failed to start agent: %w", err)
+	}
+
+	// Persist the session name in a sidecar file so `resume --list` and
+	// `resume` can surface and reuse it later. Written only after the agent
+	// starts so a failed start leaves no orphaned sidecar. A write failure is
+	// non-fatal: the session runs, the name just isn't recorded.
+	if fresh && opts.Name != "" {
+		if err := session.WriteMetadata(sessionDir, claudeSessionID, session.Metadata{Name: opts.Name}); err != nil {
+			o.Log("Warning: failed to write session metadata: %v", err)
+		}
 	}
 
 	return sess, nil

--- a/internal/forge/orchestrator.go
+++ b/internal/forge/orchestrator.go
@@ -308,11 +308,14 @@ func (o *Orchestrator) Start(ctx context.Context, opts StartOptions) (*Session, 
 	} else if opts.Continue {
 		agentCmd = append(agentCmd, "--continue")
 	} else {
-		// --session-id and --name are Claude Code CLI flags; re-verify they
-		// still exist against `claude --help` when bumping the agent image.
+		// --session-id is a Claude Code CLI flag; re-verify it still exists
+		// against `claude --help` when bumping the agent image.
 		agentCmd = append(agentCmd, "--session-id", claudeSessionID)
 	}
 	if opts.Name != "" {
+		// --name is a Claude Code CLI flag (passed on fresh and resume/continue
+		// paths); re-verify it still exists against `claude --help` when bumping
+		// the agent image.
 		agentCmd = append(agentCmd, "--name", opts.Name)
 	}
 	if opts.Prompt != "" {

--- a/internal/forge/orchestrator.go
+++ b/internal/forge/orchestrator.go
@@ -55,6 +55,7 @@ type StartOptions struct {
 	GID                int      // host user GID
 	Mounts             []string // additional host:container bind mounts
 	ResumeWorktreeName string   // worktree name when resuming a worktree session
+	Name               string   // human-readable session name (passed to Claude Code via --name)
 }
 
 // Session holds information about a running session.
@@ -271,6 +272,17 @@ func (o *Orchestrator) Start(ctx context.Context, opts StartOptions) (*Session, 
 		return nil, fmt.Errorf("failed to register MCP servers in .claude.json: %w", err)
 	}
 
+	// For fresh sessions, pin the Claude session ID so the resulting JSONL and
+	// the sidecar metadata file share a known identifier.
+	fresh := opts.ResumeID == "" && !opts.Continue
+	var claudeSessionID string
+	if fresh {
+		claudeSessionID, err = session.GenerateUUID()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// Build agent command args
 	var agentCmd []string
 	if opts.SkipPermissions {
@@ -288,9 +300,22 @@ func (o *Orchestrator) Start(ctx context.Context, opts StartOptions) (*Session, 
 		}
 	} else if opts.Continue {
 		agentCmd = append(agentCmd, "--continue")
+	} else {
+		agentCmd = append(agentCmd, "--session-id", claudeSessionID)
+	}
+	if opts.Name != "" {
+		agentCmd = append(agentCmd, "--name", opts.Name)
 	}
 	if opts.Prompt != "" {
 		agentCmd = append(agentCmd, "-p", opts.Prompt)
+	}
+
+	// Persist the session name in a sidecar file so `resume --list` and
+	// `resume` can surface and reuse it later.
+	if fresh && opts.Name != "" {
+		if err := session.WriteMetadata(sessionDir, claudeSessionID, session.Metadata{Name: opts.Name}); err != nil {
+			return nil, fmt.Errorf("failed to write session metadata: %w", err)
+		}
 	}
 
 	// Build environment variables

--- a/internal/forge/orchestrator_test.go
+++ b/internal/forge/orchestrator_test.go
@@ -2,6 +2,7 @@ package forge
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/michael-freling/claude-code-tools/internal/forge/config"
 	"github.com/michael-freling/claude-code-tools/internal/forge/container"
+	"github.com/michael-freling/claude-code-tools/internal/forge/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -553,7 +555,24 @@ func TestStart_WithName_PinsSessionIDAndWritesSidecar(t *testing.T) {
 	sidecar := filepath.Join(homeDir, ".claude-forge", sess.ProjectID, capturedSessionID+".json")
 	data, err := os.ReadFile(sidecar)
 	require.NoError(t, err)
-	assert.Contains(t, string(data), `"name": "claude"`)
+	var got session.Metadata
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, "claude", got.Name)
+}
+
+func TestStart_RejectsInvalidName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, _ := setupOrchestrator(t, mockCM)
+
+	// No container methods should be called: validation fails first.
+	_, err := orch.Start(context.Background(), StartOptions{
+		Name:       "bad\tname",
+		ProjectDir: setupGitProject(t),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tab or newline")
 }
 
 func TestStart_Resume_WithName_NoSessionID(t *testing.T) {

--- a/internal/forge/orchestrator_test.go
+++ b/internal/forge/orchestrator_test.go
@@ -509,6 +509,86 @@ func TestStart_CommandArgs(t *testing.T) {
 	assert.NotNil(t, sess)
 }
 
+func TestStart_WithName_PinsSessionIDAndWritesSidecar(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, homeDir := setupOrchestrator(t, mockCM)
+
+	projectDir := setupGitProject(t)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+
+	var capturedSessionID string
+	mockCM.EXPECT().ImageExists(gomock.Any(), gomock.Any()).Return(true, nil).Times(3)
+	mockCM.EXPECT().CreateNetwork(gomock.Any(), gomock.Any()).Return("net-id", nil)
+	mockCM.EXPECT().StartGateway(gomock.Any(), gomock.Any()).Return("gw-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "gw-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartGitHubMCP(gomock.Any(), gomock.Any()).Return("mcp-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "mcp-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartAgent(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, opts container.AgentOptions) (string, error) {
+			assert.Contains(t, opts.Cmd, "--session-id")
+			assert.Contains(t, opts.Cmd, "--name")
+			assert.Contains(t, opts.Cmd, "claude")
+			assert.NotContains(t, opts.Cmd, "--resume")
+			assert.NotContains(t, opts.Cmd, "--continue")
+			// Capture the value following --session-id.
+			for i, a := range opts.Cmd {
+				if a == "--session-id" && i+1 < len(opts.Cmd) {
+					capturedSessionID = opts.Cmd[i+1]
+				}
+			}
+			return "agent-id", nil
+		})
+
+	sess, err := orch.Start(context.Background(), StartOptions{
+		SkipPermissions: true,
+		Name:            "claude",
+		ProjectDir:      projectDir,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	require.NotEmpty(t, capturedSessionID)
+	sidecar := filepath.Join(homeDir, ".claude-forge", sess.ProjectID, capturedSessionID+".json")
+	data, err := os.ReadFile(sidecar)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"name": "claude"`)
+}
+
+func TestStart_Resume_WithName_NoSessionID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, _ := setupOrchestrator(t, mockCM)
+
+	projectDir := setupGitProject(t)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+
+	mockCM.EXPECT().ImageExists(gomock.Any(), gomock.Any()).Return(true, nil).Times(3)
+	mockCM.EXPECT().CreateNetwork(gomock.Any(), gomock.Any()).Return("net-id", nil)
+	mockCM.EXPECT().StartGateway(gomock.Any(), gomock.Any()).Return("gw-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "gw-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartGitHubMCP(gomock.Any(), gomock.Any()).Return("mcp-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "mcp-id", gomock.Any()).Return(nil)
+	mockCM.EXPECT().StartAgent(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, opts container.AgentOptions) (string, error) {
+			assert.Contains(t, opts.Cmd, "--resume")
+			assert.Contains(t, opts.Cmd, "--name")
+			assert.Contains(t, opts.Cmd, "claude")
+			assert.NotContains(t, opts.Cmd, "--session-id")
+			return "agent-id", nil
+		})
+
+	_, err := orch.Start(context.Background(), StartOptions{
+		ResumeID:     "abc12345",
+		ResumeSubdir: "-work",
+		Name:         "claude",
+		ProjectDir:   projectDir,
+	})
+	require.NoError(t, err)
+}
+
 func TestStart_ResumeSession(t *testing.T) {
 	ctrl := gomock.NewController(t)
 

--- a/internal/forge/session/session.go
+++ b/internal/forge/session/session.go
@@ -22,12 +22,61 @@ func GenerateID() (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
+// GenerateUUID returns a random RFC 4122 version 4 UUID, suitable for use as
+// Claude Code's --session-id. Pinning the session ID lets us name the sidecar
+// metadata file (and the resulting JSONL) by a known identifier.
+func GenerateUUID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to generate session UUID: %w", err)
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}
+
 // Session represents a claude-forge session.
 type Session struct {
 	ID        string
 	CreatedAt time.Time
 	FirstMsg  string
+	Name      string // human-readable name from the sidecar metadata file
 	Subdir    string // relative subdirectory within session dir (e.g., "-work", "-work-.claude-worktrees-feature")
+}
+
+// Metadata is sidecar information about a session, stored next to the JSONL
+// file as <session-id>.json under the project's session directory.
+type Metadata struct {
+	Name string `json:"name"`
+}
+
+// metadataPath returns the sidecar metadata path for a session ID.
+func metadataPath(sessionDir, sessionID string) string {
+	return filepath.Join(sessionDir, sessionID+".json")
+}
+
+// WriteMetadata writes the sidecar metadata file for a session.
+func WriteMetadata(sessionDir, sessionID string, meta Metadata) error {
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal session metadata: %w", err)
+	}
+	if err := os.WriteFile(metadataPath(sessionDir, sessionID), append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("failed to write session metadata: %w", err)
+	}
+	return nil
+}
+
+// readMetadata reads the sidecar metadata for a session. A missing or invalid
+// file yields a zero Metadata and no error.
+func readMetadata(sessionDir, sessionID string) Metadata {
+	data, err := os.ReadFile(metadataPath(sessionDir, sessionID))
+	if err != nil {
+		return Metadata{}
+	}
+	var meta Metadata
+	_ = json.Unmarshal(data, &meta)
+	return meta
 }
 
 const worktreeSubdirPrefix = "-work--claude-worktrees-"
@@ -110,6 +159,7 @@ func List(sessionDir string) ([]Session, error) {
 				continue
 			}
 			sess.Subdir = subdir
+			sess.Name = readMetadata(sessionDir, sessionID).Name
 			sessions = append(sessions, *sess)
 		}
 	}

--- a/internal/forge/session/session.go
+++ b/internal/forge/session/session.go
@@ -55,8 +55,21 @@ func metadataPath(sessionDir, sessionID string) string {
 	return filepath.Join(sessionDir, sessionID+".json")
 }
 
+// ValidateName checks that a session name is safe to store and display. Names
+// must not contain tab or newline characters, which would corrupt the
+// tab-separated `resume --list` output.
+func ValidateName(name string) error {
+	if strings.ContainsAny(name, "\t\n\r") {
+		return fmt.Errorf("session name must not contain tab or newline characters")
+	}
+	return nil
+}
+
 // WriteMetadata writes the sidecar metadata file for a session.
 func WriteMetadata(sessionDir, sessionID string, meta Metadata) error {
+	if err := ValidateName(meta.Name); err != nil {
+		return err
+	}
 	data, err := json.MarshalIndent(meta, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal session metadata: %w", err)

--- a/internal/forge/session/session.go
+++ b/internal/forge/session/session.go
@@ -80,15 +80,20 @@ func WriteMetadata(sessionDir, sessionID string, meta Metadata) error {
 	return nil
 }
 
-// readMetadata reads the sidecar metadata for a session. A missing or invalid
-// file yields a zero Metadata and no error.
+// readMetadata reads the sidecar metadata for a session. A missing, unreadable,
+// or corrupt sidecar is treated the same: it yields a zero Metadata and no
+// error, so the name simply renders blank in `resume --list` rather than
+// failing the listing. Sidecars are only ever written by WriteMetadata (valid
+// JSON), so corruption indicates external tampering.
 func readMetadata(sessionDir, sessionID string) Metadata {
 	data, err := os.ReadFile(metadataPath(sessionDir, sessionID))
 	if err != nil {
 		return Metadata{}
 	}
 	var meta Metadata
-	_ = json.Unmarshal(data, &meta)
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return Metadata{}
+	}
 	return meta
 }
 

--- a/internal/forge/session/session.go
+++ b/internal/forge/session/session.go
@@ -257,6 +257,19 @@ func parseSessionFile(sessionID string, filePath string) (*Session, error) {
 	}, nil
 }
 
+// Delete removes a session's transcript (.jsonl) and its sidecar metadata
+// (.json), if present. Missing files are not an error.
+func Delete(sessionDir string, s Session) error {
+	jsonl := filepath.Join(sessionDir, s.Subdir, s.ID+".jsonl")
+	if err := os.Remove(jsonl); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove session transcript: %w", err)
+	}
+	if err := os.Remove(metadataPath(sessionDir, s.ID)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove session metadata: %w", err)
+	}
+	return nil
+}
+
 // Find locates a session by exact ID, or failing that by name, across all
 // subdirectories in sessionDir. An ID match always wins over a name match.
 // Because names are not unique, the most recently created session with a

--- a/internal/forge/session/session.go
+++ b/internal/forge/session/session.go
@@ -257,16 +257,24 @@ func parseSessionFile(sessionID string, filePath string) (*Session, error) {
 	}, nil
 }
 
-// Find locates a session by ID across all subdirectories in sessionDir.
-func Find(sessionDir, sessionID string) (*Session, error) {
+// Find locates a session by exact ID, or failing that by name, across all
+// subdirectories in sessionDir. An ID match always wins over a name match.
+// Because names are not unique, the most recently created session with a
+// matching name is returned (List is sorted most-recent-first).
+func Find(sessionDir, ref string) (*Session, error) {
 	sessions, err := List(sessionDir)
 	if err != nil {
 		return nil, err
 	}
 	for i := range sessions {
-		if sessions[i].ID == sessionID {
+		if sessions[i].ID == ref {
 			return &sessions[i], nil
 		}
 	}
-	return nil, fmt.Errorf("session %s not found", sessionID)
+	for i := range sessions {
+		if sessions[i].Name != "" && sessions[i].Name == ref {
+			return &sessions[i], nil
+		}
+	}
+	return nil, fmt.Errorf("session %q not found (by id or name)", ref)
 }

--- a/internal/forge/session/session_test.go
+++ b/internal/forge/session/session_test.go
@@ -30,6 +30,67 @@ func TestGenerateID_Unique(t *testing.T) {
 	}
 }
 
+func TestGenerateUUID(t *testing.T) {
+	id, err := GenerateUUID()
+	require.NoError(t, err)
+
+	// RFC 4122 version 4 UUID format: 8-4-4-4-12 hex digits, version 4, variant 8/9/a/b.
+	assert.Regexp(t, regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`), id)
+}
+
+func TestGenerateUUID_Unique(t *testing.T) {
+	ids := make(map[string]bool)
+	for range 100 {
+		id, err := GenerateUUID()
+		require.NoError(t, err)
+		assert.False(t, ids[id], "duplicate UUID generated: %s", id)
+		ids[id] = true
+	}
+}
+
+func TestWriteMetadata(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	require.NoError(t, WriteMetadata(tmpDir, "sess-1", Metadata{Name: "claude"}))
+
+	got := readMetadata(tmpDir, "sess-1")
+	assert.Equal(t, "claude", got.Name)
+}
+
+func TestWriteMetadata_Error(t *testing.T) {
+	// Writing into a non-existent directory fails.
+	err := WriteMetadata(filepath.Join(t.TempDir(), "missing"), "sess-1", Metadata{Name: "claude"})
+	require.Error(t, err)
+}
+
+func TestReadMetadata_MissingOrInvalid(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Missing file yields a zero Metadata, no panic.
+	assert.Equal(t, Metadata{}, readMetadata(tmpDir, "absent"))
+
+	// Invalid JSON also yields a zero Metadata.
+	require.NoError(t, os.WriteFile(metadataPath(tmpDir, "broken"), []byte("not json"), 0o644))
+	assert.Equal(t, Metadata{}, readMetadata(tmpDir, "broken"))
+}
+
+func TestList_PopulatesNameFromSidecar(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	workDir := filepath.Join(tmpDir, "-work")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "sess-1.jsonl"),
+		[]byte(`{"type":"user","message":{"role":"user","content":"hi"},"timestamp":"2026-05-08T14:30:01Z"}`+"\n"), 0o644))
+
+	// Sidecar lives at the session-dir root, keyed by session ID.
+	require.NoError(t, WriteMetadata(tmpDir, "sess-1", Metadata{Name: "my-session"}))
+
+	got, err := List(tmpDir)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "my-session", got[0].Name)
+}
+
 func TestList(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/forge/session/session_test.go
+++ b/internal/forge/session/session_test.go
@@ -350,6 +350,32 @@ func TestFind(t *testing.T) {
 	})
 }
 
+func TestDelete(t *testing.T) {
+	tmp := t.TempDir()
+
+	t.Run("removes transcript and sidecar", func(t *testing.T) {
+		work := filepath.Join(tmp, "-work")
+		require.NoError(t, os.MkdirAll(work, 0o755))
+		jsonl := filepath.Join(work, "s1.jsonl")
+		require.NoError(t, os.WriteFile(jsonl, []byte("{}"), 0o644))
+		require.NoError(t, WriteMetadata(tmp, "s1", Metadata{Name: "n1"}))
+
+		require.NoError(t, Delete(tmp, Session{ID: "s1", Subdir: "-work"}))
+		assert.NoFileExists(t, jsonl)
+		assert.NoFileExists(t, metadataPath(tmp, "s1"))
+
+		// Idempotent: deleting again is not an error.
+		require.NoError(t, Delete(tmp, Session{ID: "s1", Subdir: "-work"}))
+	})
+
+	t.Run("removes legacy root transcript", func(t *testing.T) {
+		jsonl := filepath.Join(tmp, "s2.jsonl")
+		require.NoError(t, os.WriteFile(jsonl, []byte("{}"), 0o644))
+		require.NoError(t, Delete(tmp, Session{ID: "s2"}))
+		assert.NoFileExists(t, jsonl)
+	})
+}
+
 func TestFind_ByName(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/forge/session/session_test.go
+++ b/internal/forge/session/session_test.go
@@ -350,6 +350,45 @@ func TestFind(t *testing.T) {
 	})
 }
 
+func TestFind_ByName(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	workDir := filepath.Join(tmpDir, "-work")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+
+	// Two sessions named "hello"; the more recent one should win.
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "old.jsonl"),
+		[]byte(`{"type":"user","message":{"role":"user","content":"a"},"timestamp":"2026-05-08T10:00:00Z"}`+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "new.jsonl"),
+		[]byte(`{"type":"user","message":{"role":"user","content":"b"},"timestamp":"2026-05-09T10:00:00Z"}`+"\n"), 0o644))
+	require.NoError(t, WriteMetadata(tmpDir, "old", Metadata{Name: "hello"}))
+	require.NoError(t, WriteMetadata(tmpDir, "new", Metadata{Name: "hello"}))
+
+	// A third session whose ID equals another session's name, to prove ID wins.
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "hello.jsonl"),
+		[]byte(`{"type":"user","message":{"role":"user","content":"c"},"timestamp":"2026-05-07T10:00:00Z"}`+"\n"), 0o644))
+
+	t.Run("resolves by name to most recent match", func(t *testing.T) {
+		// "hello" matches the session whose ID is literally "hello" first (ID wins).
+		sess, err := Find(tmpDir, "hello")
+		require.NoError(t, err)
+		assert.Equal(t, "hello", sess.ID)
+	})
+
+	t.Run("name-only ref resolves to most recent named session", func(t *testing.T) {
+		sess, err := Find(tmpDir, "world-does-not-exist")
+		require.Error(t, err)
+		assert.Nil(t, sess)
+	})
+
+	t.Run("name match when no ID collision", func(t *testing.T) {
+		require.NoError(t, WriteMetadata(tmpDir, "new", Metadata{Name: "greeting"}))
+		sess, err := Find(tmpDir, "greeting")
+		require.NoError(t, err)
+		assert.Equal(t, "new", sess.ID)
+	})
+}
+
 func TestFind_ReadError(t *testing.T) {
 	// Use a path that exists but can't be read (not a directory)
 	tmpFile := filepath.Join(t.TempDir(), "not-a-dir")

--- a/internal/forge/session/session_test.go
+++ b/internal/forge/session/session_test.go
@@ -63,6 +63,24 @@ func TestWriteMetadata_Error(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestValidateName(t *testing.T) {
+	require.NoError(t, ValidateName(""))
+	require.NoError(t, ValidateName("my-session"))
+	require.NoError(t, ValidateName("name with spaces"))
+
+	for _, bad := range []string{"a\tb", "a\nb", "a\rb"} {
+		err := ValidateName(bad)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tab or newline")
+	}
+}
+
+func TestWriteMetadata_RejectsInvalidName(t *testing.T) {
+	err := WriteMetadata(t.TempDir(), "sess-1", Metadata{Name: "bad\tname"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tab or newline")
+}
+
 func TestReadMetadata_MissingOrInvalid(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/test/e2e/forge/e2e_test.go
+++ b/test/e2e/forge/e2e_test.go
@@ -120,7 +120,7 @@ func TestForgeStart(t *testing.T) {
 
 Reply with the raw command outputs only, no other text.`
 	sessionName := "e2e-session"
-	cmd := exec.CommandContext(ctx, binaryPath, "start", "--name", sessionName, "-p", prompt)
+	cmd := exec.CommandContext(ctx, binaryPath, "start", sessionName, "-p", prompt)
 	cmd.Dir = projectRoot // Must be a git repo with a GitHub remote for project.Identify.
 	cmd.Env = append(os.Environ(),
 		"HOME="+tempHome,
@@ -169,7 +169,7 @@ Reply with the raw command outputs only, no other text.`
 	}
 
 	// Step 8: Verify the session JSONL was persisted to the host so
-	// `claude-forge resume --list` can find it. Claude Code in the container
+	// `claude-forge list` can find it. Claude Code in the container
 	// (cwd=/work) writes sessions under the encoded path -work/.
 	projectID := strings.ReplaceAll(projectRoot, "/", "-")
 	hostSessionDir := filepath.Join(tempHome, ".claude-forge", projectID, "-work")
@@ -195,30 +195,30 @@ Reply with the raw command outputs only, no other text.`
 	assert.Contains(t, string(sidecarData), sessionName,
 		"sidecar metadata should contain the session name")
 
-	// Step 9: `claude-forge resume --list` must surface that session.
+	// Step 9: `claude-forge list` must surface that session.
 	// resume reads from the host, so it does not need Docker or auth.
 	listCtx, listCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer listCancel()
-	listCmd := exec.CommandContext(listCtx, binaryPath, "resume", "--list")
+	listCmd := exec.CommandContext(listCtx, binaryPath, "list")
 	listCmd.Dir = projectRoot
 	listCmd.Env = append(os.Environ(), "HOME="+tempHome)
 
 	listOutput, listErr := listCmd.CombinedOutput()
 	listOutStr := string(listOutput)
-	t.Logf("claude-forge resume --list output:\n%s", listOutStr)
-	require.NoError(t, listErr, "resume --list failed: %s", listOutStr)
+	t.Logf("claude-forge list output:\n%s", listOutStr)
+	require.NoError(t, listErr, "list failed: %s", listOutStr)
 
 	assert.NotContains(t, listOutStr, "No sessions found.",
-		"resume --list should not be empty after a session was created")
+		"list should not be empty after a session was created")
 	assert.Contains(t, listOutStr, "WORKTREE",
-		"resume --list should include the WORKTREE column header")
+		"list should include the WORKTREE column header")
 	assert.Contains(t, listOutStr, "NAME",
-		"resume --list should include the NAME column header")
+		"list should include the NAME column header")
 	assert.Contains(t, listOutStr, sessionName,
-		"resume --list should show the session name %s", sessionName)
+		"list should show the session name %s", sessionName)
 	expectedID := strings.TrimSuffix(sessionFile, ".jsonl")
 	assert.Contains(t, listOutStr, expectedID,
-		"resume --list should include the session ID %s", expectedID)
+		"list should include the session ID %s", expectedID)
 }
 
 // TestForgeStart_NoGitHubAuth verifies that claude-forge fails with a clear
@@ -307,7 +307,7 @@ func TestForgeStart_NoGitHubAuth(t *testing.T) {
 		"CLAUDE_CODE_OAUTH_TOKEN="+oauthToken,
 	)
 
-	cmd := exec.CommandContext(ctx, binaryPath, "start", "--name", "e2e-noauth", "-p", "hello")
+	cmd := exec.CommandContext(ctx, binaryPath, "start", "e2e-noauth", "-p", "hello")
 	cmd.Dir = projectRoot
 	cmd.Env = filteredEnv
 
@@ -577,7 +577,7 @@ func writeTestSession(t *testing.T, path, timestamp, message string) {
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 }
 
-// TestResumeList_NonWorktreeSession verifies that `resume --list` shows
+// TestResumeList_NonWorktreeSession verifies that `list` shows
 // non-worktree sessions with an empty WORKTREE column.
 func TestResumeList_NonWorktreeSession(t *testing.T) {
 	binaryPath := buildForge(t)
@@ -593,14 +593,14 @@ func TestResumeList_NonWorktreeSession(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, binaryPath, "resume", "--list")
+	cmd := exec.CommandContext(ctx, binaryPath, "list")
 	cmd.Dir = projectRoot
 	cmd.Env = append(os.Environ(), "HOME="+tempHome)
 
 	output, err := cmd.CombinedOutput()
 	outputStr := string(output)
-	t.Logf("resume --list output:\n%s", outputStr)
-	require.NoError(t, err, "resume --list failed: %s", outputStr)
+	t.Logf("list output:\n%s", outputStr)
+	require.NoError(t, err, "list failed: %s", outputStr)
 
 	assert.Contains(t, outputStr, "SESSION ID")
 	assert.Contains(t, outputStr, "WORKTREE")
@@ -618,7 +618,7 @@ func TestResumeList_NonWorktreeSession(t *testing.T) {
 	assert.NotContains(t, dataLine, "worktrees")
 }
 
-// TestResumeList_WorktreeSession verifies that `resume --list` shows
+// TestResumeList_WorktreeSession verifies that `list` shows
 // worktree sessions with the worktree name in the WORKTREE column.
 func TestResumeList_WorktreeSession(t *testing.T) {
 	binaryPath := buildForge(t)
@@ -638,14 +638,14 @@ func TestResumeList_WorktreeSession(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, binaryPath, "resume", "--list")
+	cmd := exec.CommandContext(ctx, binaryPath, "list")
 	cmd.Dir = projectRoot
 	cmd.Env = append(os.Environ(), "HOME="+tempHome)
 
 	output, err := cmd.CombinedOutput()
 	outputStr := string(output)
-	t.Logf("resume --list output:\n%s", outputStr)
-	require.NoError(t, err, "resume --list failed: %s", outputStr)
+	t.Logf("list output:\n%s", outputStr)
+	require.NoError(t, err, "list failed: %s", outputStr)
 
 	assert.Contains(t, outputStr, "WORKTREE")
 	assert.Contains(t, outputStr, "wt-session")
@@ -689,14 +689,14 @@ func TestResumeList_MixedSessions(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, binaryPath, "resume", "--list")
+	cmd := exec.CommandContext(ctx, binaryPath, "list")
 	cmd.Dir = projectRoot
 	cmd.Env = append(os.Environ(), "HOME="+tempHome)
 
 	output, err := cmd.CombinedOutput()
 	outputStr := string(output)
-	t.Logf("resume --list output:\n%s", outputStr)
-	require.NoError(t, err, "resume --list failed: %s", outputStr)
+	t.Logf("list output:\n%s", outputStr)
+	require.NoError(t, err, "list failed: %s", outputStr)
 
 	lines := strings.Split(strings.TrimSpace(outputStr), "\n")
 	require.GreaterOrEqual(t, len(lines), 4, "expected header + 3 data lines")

--- a/test/e2e/forge/e2e_test.go
+++ b/test/e2e/forge/e2e_test.go
@@ -119,7 +119,8 @@ func TestForgeStart(t *testing.T) {
 3. go test ./internal/forge/config/...
 
 Reply with the raw command outputs only, no other text.`
-	cmd := exec.CommandContext(ctx, binaryPath, "start", "-p", prompt)
+	sessionName := "e2e-session"
+	cmd := exec.CommandContext(ctx, binaryPath, "start", "--name", sessionName, "-p", prompt)
 	cmd.Dir = projectRoot // Must be a git repo with a GitHub remote for project.Identify.
 	cmd.Env = append(os.Environ(),
 		"HOME="+tempHome,
@@ -185,6 +186,15 @@ Reply with the raw command outputs only, no other text.`
 	require.NotEmpty(t, sessionFile, "expected at least one .jsonl session file under %s", hostSessionDir)
 	t.Logf("session file persisted to host: %s", filepath.Join(hostSessionDir, sessionFile))
 
+	// The session name should be persisted in the sidecar metadata file, keyed
+	// by the same session ID and stored at the project session-dir root.
+	sessionID := strings.TrimSuffix(sessionFile, ".jsonl")
+	sidecarPath := filepath.Join(tempHome, ".claude-forge", projectID, sessionID+".json")
+	sidecarData, err := os.ReadFile(sidecarPath)
+	require.NoError(t, err, "expected sidecar metadata file at %s", sidecarPath)
+	assert.Contains(t, string(sidecarData), sessionName,
+		"sidecar metadata should contain the session name")
+
 	// Step 9: `claude-forge resume --list` must surface that session.
 	// resume reads from the host, so it does not need Docker or auth.
 	listCtx, listCancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -202,6 +212,10 @@ Reply with the raw command outputs only, no other text.`
 		"resume --list should not be empty after a session was created")
 	assert.Contains(t, listOutStr, "WORKTREE",
 		"resume --list should include the WORKTREE column header")
+	assert.Contains(t, listOutStr, "NAME",
+		"resume --list should include the NAME column header")
+	assert.Contains(t, listOutStr, sessionName,
+		"resume --list should show the session name %s", sessionName)
 	expectedID := strings.TrimSuffix(sessionFile, ".jsonl")
 	assert.Contains(t, listOutStr, expectedID,
 		"resume --list should include the session ID %s", expectedID)
@@ -293,7 +307,7 @@ func TestForgeStart_NoGitHubAuth(t *testing.T) {
 		"CLAUDE_CODE_OAUTH_TOKEN="+oauthToken,
 	)
 
-	cmd := exec.CommandContext(ctx, binaryPath, "start", "-p", "hello")
+	cmd := exec.CommandContext(ctx, binaryPath, "start", "--name", "e2e-noauth", "-p", "hello")
 	cmd.Dir = projectRoot
 	cmd.Env = filteredEnv
 


### PR DESCRIPTION
## Summary

Adds human-readable session names to `claude-forge`. The name is **required** when starting a session, **passed to Claude Code** via its `--name` flag, and persisted in a **sidecar metadata file** so it can be shown and reused later.

## CLI surface

- **`claude-forge start <name> [flags]`** — `<name>` is a required positional argument (a human-readable session name). For fresh sessions it pins Claude's session ID via `--session-id <uuid>` (so the JSONL filename is known up front), passes `--name` to Claude Code, and writes a sidecar `~/.claude-forge/<project-id>/<session-id>.json`.
- **`claude-forge list`** — dedicated command that lists past sessions for the current project (replaces the old `resume --list`), with a `NAME` column populated from the sidecar.
- **`claude-forge resume [session-id] [--name <override>]`** — resumes by ID (or continues the most recent), reading the stored name from the sidecar and passing it to Claude Code. `--name` optionally overrides the stored name.

## Implementation notes

- `session` package: `GenerateUUID`, `Metadata`, `WriteMetadata`, `ValidateName` (rejects tab/newline), and a `Name` field on `Session` (populated from the sidecar in `List`).
- The sidecar lives at the project session-dir **root**, keyed by Claude's session UUID, so it works for both normal (`-work`) and worktree (`-work--claude-worktrees-<name>`) sessions even though the worktree subdir isn't known at start time.
- The sidecar is written only **after** the agent starts (no orphaned file on failed start) and a write failure is non-fatal.
- The forge container/network 8-hex ID stays separate from the Claude session UUID, so `stop`'s network-name parsing is unaffected.
- CLI flags (`--session-id`, `--name`) were confirmed against Claude Code's `--help`; the e2e test guards against regressions on image bumps.

## update-ci-secrets

- `--from-credentials` now **defaults to `true`** (resolve the token from `~/.claude/.credentials.json`); `--oauth-token` still overrides. A missing credentials file now produces an actionable error suggesting `--oauth-token`.

## Testing

- `go build`, `go vet` (incl. `-tags=forge_e2e`), gofmt, golangci-lint v2.6.2 — all clean.
- `go test -race ./...` passes; filtered coverage **90.3%** (≥ 90% gate).
- Unit tests cover UUID generation, sidecar read/write, name validation, `list` output, `resume` name reuse/override, and `start` requiring the positional name.
- e2e `TestForgeStart` passes `start <name>`, asserts the sidecar contains the name, and verifies `list` shows the `NAME` column and value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)