### PR TITLE
feat(github-mcp): Add github_pr_resolve_thread tool + Makefile to build images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,51 @@
+# claude-forge Makefile
+#
+# Image-building targets for the container roles claude-forge runs. By default
+# the tags match the image names in internal/forge/config/config.go, so a local
+# build is picked up automatically: the orchestrator only pulls an image when it
+# is not already present locally (ImageExists), so a freshly built tag is used
+# as-is. Override any *_IMAGE variable to publish under a different tag.
+#
+# The agent image copies a host-built linux binary, so it is built for the
+# host's architecture by default (override GOARCH for cross-builds). The gateway
+# and github-mcp images build their binaries inside multi-stage Dockerfiles.
+
+AGENT_IMAGE      ?= ghcr.io/michael-freling/claude-forge-agent:latest
+GATEWAY_IMAGE    ?= ghcr.io/michael-freling/claude-forge-gateway:latest
+GITHUB_MCP_IMAGE ?= ghcr.io/michael-freling/claude-forge-github-mcp:latest
+KUBE_MCP_IMAGE   ?= ghcr.io/containers/kubernetes-mcp-server:latest
+
+GOARCH ?= $(shell go env GOARCH)
+
+.PHONY: help test images images-no-cache \
+	agent-image gateway-image github-mcp-image kube-mcp-image
+
+help: ## Show this help
+	@grep -hE '^[a-zA-Z0-9_-]+:.*?## ' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+test: ## Run all Go tests (root module + github-mcp module)
+	go test ./...
+	cd github-mcp && go test ./...
+
+images: agent-image gateway-image github-mcp-image kube-mcp-image ## Build/pull all container images
+
+images-no-cache: ## Build all locally-built images with --no-cache
+	$(MAKE) agent-image gateway-image github-mcp-image DOCKER_BUILD_FLAGS=--no-cache
+
+# DOCKER_BUILD_FLAGS lets `images-no-cache` (or the caller) inject flags.
+DOCKER_BUILD_FLAGS ?=
+
+agent-image: ## Build the agent image (Claude Code runtime)
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) go build -o docker/agent/claude-forge ./cmd/claude-forge/
+	docker build $(DOCKER_BUILD_FLAGS) -t $(AGENT_IMAGE) docker/agent/
+	rm -f docker/agent/claude-forge
+
+gateway-image: ## Build the gateway image (git proxy)
+	docker build $(DOCKER_BUILD_FLAGS) -t $(GATEWAY_IMAGE) -f docker/gateway/Dockerfile .
+
+github-mcp-image: ## Build the per-session GitHub MCP image
+	docker build $(DOCKER_BUILD_FLAGS) -t $(GITHUB_MCP_IMAGE) github-mcp/
+
+kube-mcp-image: ## Pull the shared Kubernetes MCP image (built upstream)
+	docker pull $(KUBE_MCP_IMAGE)

--- a/github-mcp/README.md
+++ b/github-mcp/README.md
@@ -13,6 +13,7 @@ A GitHub MCP (Model Context Protocol) server that runs as a per-session sidecar 
 | `github_pr_merge` | Merge a pull request | write |
 | `github_pr_comment` | Comment on a pull request | write |
 | `github_pr_reviews` | List PR reviews | read |
+| `github_pr_resolve_thread` | Resolve a PR review comment thread (GraphQL) | write |
 | `github_issue_list` | List issues | read |
 | `github_issue_get` | Get an issue | read |
 | `github_issue_create` | Create an issue | write |
@@ -26,6 +27,10 @@ A GitHub MCP (Model Context Protocol) server that runs as a per-session sidecar 
 
 - **Read** operations are allowed on any repository.
 - **Write** operations are restricted to the configured `--owner`/`--repo`.
+- `github_pr_resolve_thread` is a write op. GraphQL thread node IDs are
+  global, so rather than accept a thread ID it takes a PR `number` plus a
+  review `comment_id` and looks the thread up **within the configured repo**,
+  keeping the single-repo write restriction intact.
 
 ## Usage
 

--- a/github-mcp/graphql.go
+++ b/github-mcp/graphql.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// graphQLRequest is the request body for the GitHub GraphQL API.
+type graphQLRequest struct {
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables,omitempty"`
+}
+
+// doGraphQL posts a query/mutation to the GitHub GraphQL endpoint and returns
+// the raw `data` payload. It errors if the transport fails, the HTTP status is
+// >= 400, or the response carries GraphQL errors.
+func doGraphQL(ctx context.Context, client *GitHubClient, query string, variables map[string]any) (json.RawMessage, error) {
+	reqBody, err := json.Marshal(graphQLRequest{Query: query, Variables: variables})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal GraphQL request: %w", err)
+	}
+
+	resp, err := client.Do(ctx, http.MethodPost, "/graphql", strings.NewReader(string(reqBody)))
+	if err != nil {
+		return nil, fmt.Errorf("GraphQL request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read GraphQL response: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("GraphQL request returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var envelope struct {
+		Data   json.RawMessage `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, fmt.Errorf("failed to parse GraphQL response: %w", err)
+	}
+	if len(envelope.Errors) > 0 {
+		msgs := make([]string, 0, len(envelope.Errors))
+		for _, e := range envelope.Errors {
+			msgs = append(msgs, e.Message)
+		}
+		return nil, fmt.Errorf("GraphQL error: %s", strings.Join(msgs, "; "))
+	}
+	return envelope.Data, nil
+}
+
+const reviewThreadsQuery = `query($owner:String!,$repo:String!,$number:Int!,$cursor:String){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$number){
+      reviewThreads(first:100,after:$cursor){
+        pageInfo{hasNextPage endCursor}
+        nodes{id isResolved comments(first:100){nodes{databaseId}}}
+      }
+    }
+  }
+}`
+
+const resolveThreadMutation = `mutation($threadId:ID!){
+  resolveReviewThread(input:{threadId:$threadId}){thread{id isResolved}}
+}`
+
+// reviewThread is a PR review thread along with whether it is resolved.
+type reviewThread struct {
+	ID         string
+	IsResolved bool
+}
+
+// findReviewThreadByComment returns the review thread on owner/repo#number that
+// contains the review comment with the given database ID. It paginates over the
+// PR's review threads and returns nil (no error) if no matching thread exists.
+// Scoping the lookup to owner/repo is what keeps thread resolution restricted
+// to the configured repository.
+func findReviewThreadByComment(ctx context.Context, client *GitHubClient, owner, repo string, number, commentID int) (*reviewThread, error) {
+	var cursor *string
+	for {
+		vars := map[string]any{"owner": owner, "repo": repo, "number": number}
+		if cursor != nil {
+			vars["cursor"] = *cursor
+		}
+
+		data, err := doGraphQL(ctx, client, reviewThreadsQuery, vars)
+		if err != nil {
+			return nil, err
+		}
+
+		var parsed struct {
+			Repository struct {
+				PullRequest struct {
+					ReviewThreads struct {
+						PageInfo struct {
+							HasNextPage bool   `json:"hasNextPage"`
+							EndCursor   string `json:"endCursor"`
+						} `json:"pageInfo"`
+						Nodes []struct {
+							ID         string `json:"id"`
+							IsResolved bool   `json:"isResolved"`
+							Comments   struct {
+								Nodes []struct {
+									DatabaseID int64 `json:"databaseId"`
+								} `json:"nodes"`
+							} `json:"comments"`
+						} `json:"nodes"`
+					} `json:"reviewThreads"`
+				} `json:"pullRequest"`
+			} `json:"repository"`
+		}
+		if err := json.Unmarshal(data, &parsed); err != nil {
+			return nil, fmt.Errorf("failed to parse review threads: %w", err)
+		}
+
+		for _, n := range parsed.Repository.PullRequest.ReviewThreads.Nodes {
+			for _, c := range n.Comments.Nodes {
+				if c.DatabaseID == int64(commentID) {
+					return &reviewThread{ID: n.ID, IsResolved: n.IsResolved}, nil
+				}
+			}
+		}
+
+		pi := parsed.Repository.PullRequest.ReviewThreads.PageInfo
+		if !pi.HasNextPage || pi.EndCursor == "" {
+			return nil, nil
+		}
+		next := pi.EndCursor
+		cursor = &next
+	}
+}
+
+// resolveReviewThreadByID resolves a review thread by its GraphQL node ID and
+// returns the resulting resolved state.
+func resolveReviewThreadByID(ctx context.Context, client *GitHubClient, threadID string) (bool, error) {
+	data, err := doGraphQL(ctx, client, resolveThreadMutation, map[string]any{"threadId": threadID})
+	if err != nil {
+		return false, err
+	}
+
+	var parsed struct {
+		ResolveReviewThread struct {
+			Thread struct {
+				IsResolved bool `json:"isResolved"`
+			} `json:"thread"`
+		} `json:"resolveReviewThread"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return false, fmt.Errorf("failed to parse resolve response: %w", err)
+	}
+	return parsed.ResolveReviewThread.Thread.IsResolved, nil
+}

--- a/github-mcp/graphql_test.go
+++ b/github-mcp/graphql_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newGraphQLClient returns a GitHubClient pointed at the given test server.
+func newGraphQLClient(url string) *GitHubClient {
+	c := NewGitHubClient(NewGitHubAuthFromToken("test-token"))
+	c.baseURL = url
+	return c
+}
+
+func TestDoGraphQL(t *testing.T) {
+	t.Run("success returns data", func(t *testing.T) {
+		gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/graphql", r.URL.Path)
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+			w.Write([]byte(`{"data":{"hello":"world"}}`))
+		}))
+		defer gh.Close()
+
+		data, err := doGraphQL(context.Background(), newGraphQLClient(gh.URL), "query{}", nil)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"hello":"world"}`, string(data))
+	})
+
+	t.Run("http error", func(t *testing.T) {
+		gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("boom"))
+		}))
+		defer gh.Close()
+
+		_, err := doGraphQL(context.Background(), newGraphQLClient(gh.URL), "query{}", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "HTTP 500")
+	})
+
+	t.Run("graphql errors", func(t *testing.T) {
+		gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{"errors":[{"message":"Could not resolve to a node"}]}`))
+		}))
+		defer gh.Close()
+
+		_, err := doGraphQL(context.Background(), newGraphQLClient(gh.URL), "query{}", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Could not resolve to a node")
+	})
+
+	t.Run("invalid json response", func(t *testing.T) {
+		gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("not json"))
+		}))
+		defer gh.Close()
+
+		_, err := doGraphQL(context.Background(), newGraphQLClient(gh.URL), "query{}", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse")
+	})
+
+	t.Run("transport error", func(t *testing.T) {
+		c := newGraphQLClient("http://127.0.0.1:0")
+		_, err := doGraphQL(context.Background(), c, "query{}", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "GraphQL request failed")
+	})
+}
+
+func TestFindReviewThreadByComment(t *testing.T) {
+	t.Run("found on first page", func(t *testing.T) {
+		gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{"data":{"repository":{"pullRequest":{"reviewThreads":{
+				"pageInfo":{"hasNextPage":false,"endCursor":""},
+				"nodes":[{"id":"T1","isResolved":false,"comments":{"nodes":[{"databaseId":100},{"databaseId":101}]}}]
+			}}}}}`))
+		}))
+		defer gh.Close()
+
+		thread, err := findReviewThreadByComment(context.Background(), newGraphQLClient(gh.URL), "o", "r", 5, 101)
+		require.NoError(t, err)
+		require.NotNil(t, thread)
+		assert.Equal(t, "T1", thread.ID)
+		assert.False(t, thread.IsResolved)
+	})
+
+	t.Run("found on second page", func(t *testing.T) {
+		gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			if strings.Contains(string(body), `"cursor":"c1"`) {
+				w.Write([]byte(`{"data":{"repository":{"pullRequest":{"reviewThreads":{
+					"pageInfo":{"hasNextPage":false,"endCursor":""},
+					"nodes":[{"id":"T2","isResolved":false,"comments":{"nodes":[{"databaseId":200}]}}]
+				}}}}}`))
+				return
+			}
+			w.Write([]byte(`{"data":{"repository":{"pullRequest":{"reviewThreads":{
+				"pageInfo":{"hasNextPage":true,"endCursor":"c1"},
+				"nodes":[{"id":"T1","isResolved":false,"comments":{"nodes":[{"databaseId":999}]}}]
+			}}}}}`))
+		}))
+		defer gh.Close()
+
+		thread, err := findReviewThreadByComment(context.Background(), newGraphQLClient(gh.URL), "o", "r", 5, 200)
+		require.NoError(t, err)
+		require.NotNil(t, thread)
+		assert.Equal(t, "T2", thread.ID)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{"data":{"repository":{"pullRequest":{"reviewThreads":{
+				"pageInfo":{"hasNextPage":false,"endCursor":""},
+				"nodes":[{"id":"T1","isResolved":false,"comments":{"nodes":[{"databaseId":1}]}}]
+			}}}}}`))
+		}))
+		defer gh.Close()
+
+		thread, err := findReviewThreadByComment(context.Background(), newGraphQLClient(gh.URL), "o", "r", 5, 999)
+		require.NoError(t, err)
+		assert.Nil(t, thread)
+	})
+
+	t.Run("propagates graphql error", func(t *testing.T) {
+		gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{"errors":[{"message":"boom"}]}`))
+		}))
+		defer gh.Close()
+
+		_, err := findReviewThreadByComment(context.Background(), newGraphQLClient(gh.URL), "o", "r", 5, 1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "boom")
+	})
+}
+
+func TestResolveReviewThreadByID(t *testing.T) {
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		assert.Contains(t, string(body), "resolveReviewThread")
+		assert.Contains(t, string(body), "T1")
+		w.Write([]byte(`{"data":{"resolveReviewThread":{"thread":{"id":"T1","isResolved":true}}}}`))
+	}))
+	defer gh.Close()
+
+	resolved, err := resolveReviewThreadByID(context.Background(), newGraphQLClient(gh.URL), "T1")
+	require.NoError(t, err)
+	assert.True(t, resolved)
+}
+
+func TestResolveReviewThreadByID_Error(t *testing.T) {
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"errors":[{"message":"Could not resolve to a node with the global id"}]}`))
+	}))
+	defer gh.Close()
+
+	_, err := resolveReviewThreadByID(context.Background(), newGraphQLClient(gh.URL), "bad")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Could not resolve")
+}

--- a/github-mcp/server_test.go
+++ b/github-mcp/server_test.go
@@ -108,7 +108,8 @@ func TestToolsList(t *testing.T) {
 	expectedTools := []string{
 		"github_pr_list", "github_pr_get", "github_pr_create",
 		"github_pr_update", "github_pr_merge", "github_pr_comment",
-		"github_pr_reviews", "github_issue_list", "github_issue_get",
+		"github_pr_reviews", "github_pr_resolve_thread",
+		"github_issue_list", "github_issue_get",
 		"github_issue_create", "github_issue_comment", "github_repo_get",
 		"github_release_list", "github_checks_list", "github_api",
 	}

--- a/github-mcp/tools.go
+++ b/github-mcp/tools.go
@@ -27,6 +27,11 @@ type toolDef struct {
 	// buildRequest constructs the GitHub API method, path, and body from the
 	// tool arguments and the server's configured owner/repo.
 	buildRequest func(args map[string]any, owner, repo string) (method, path string, body io.Reader, err error)
+
+	// execute, when non-nil, fully handles the tool call instead of the generic
+	// buildRequest/policy/HTTP flow. It is used by tools that need GraphQL or
+	// multi-step logic. Such tools are responsible for their own policy checks.
+	execute func(ctx context.Context, args map[string]any, owner, repo string, policy *Policy, client *GitHubClient) (string, bool, error)
 }
 
 // jsonSchema is a helper for building JSON Schema objects.
@@ -47,21 +52,22 @@ var toolRegistry map[string]*toolDef
 
 func init() {
 	toolRegistry = map[string]*toolDef{
-		"github_pr_list":       prListTool(),
-		"github_pr_get":        prGetTool(),
-		"github_pr_create":     prCreateTool(),
-		"github_pr_update":     prUpdateTool(),
-		"github_pr_merge":      prMergeTool(),
-		"github_pr_comment":    prCommentTool(),
-		"github_pr_reviews":    prReviewsTool(),
-		"github_issue_list":    issueListTool(),
-		"github_issue_get":     issueGetTool(),
-		"github_issue_create":  issueCreateTool(),
-		"github_issue_comment": issueCommentTool(),
-		"github_repo_get":      repoGetTool(),
-		"github_release_list":  releaseListTool(),
-		"github_checks_list":   checksListTool(),
-		"github_api":           apiTool(),
+		"github_pr_list":           prListTool(),
+		"github_pr_get":            prGetTool(),
+		"github_pr_create":         prCreateTool(),
+		"github_pr_update":         prUpdateTool(),
+		"github_pr_merge":          prMergeTool(),
+		"github_pr_comment":        prCommentTool(),
+		"github_pr_reviews":        prReviewsTool(),
+		"github_pr_resolve_thread": prResolveThreadTool(),
+		"github_issue_list":        issueListTool(),
+		"github_issue_get":         issueGetTool(),
+		"github_issue_create":      issueCreateTool(),
+		"github_issue_comment":     issueCommentTool(),
+		"github_repo_get":          repoGetTool(),
+		"github_release_list":      releaseListTool(),
+		"github_checks_list":       checksListTool(),
+		"github_api":               apiTool(),
 	}
 }
 
@@ -79,6 +85,12 @@ func executeTool(ctx context.Context, name string, args map[string]any, owner, r
 	td, ok := toolRegistry[name]
 	if !ok {
 		return "", false, fmt.Errorf("unknown tool: %s", name)
+	}
+
+	// Tools with a custom executor (e.g. GraphQL-based) handle everything
+	// themselves, including their own policy enforcement.
+	if td.execute != nil {
+		return td.execute(ctx, args, owner, repo, policy, client)
 	}
 
 	method, path, body, err := td.buildRequest(args, owner, repo)
@@ -294,6 +306,64 @@ func prReviewsTool() *toolDef {
 			o, r := resolveOwnerRepo(args, owner, repo)
 			path := fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews", o, r, num)
 			return http.MethodGet, path, nil, nil
+		},
+	}
+}
+
+// prResolveThreadTool resolves a PR review comment thread. Resolving a thread
+// is only possible via the GraphQL API, so this tool uses a custom executor.
+// To preserve the single-repo write limitation, it locates the thread within
+// the configured owner/repo (GraphQL thread node IDs are global and would
+// otherwise allow resolving threads in any repository).
+func prResolveThreadTool() *toolDef {
+	return &toolDef{
+		Definition: ToolDefinition{
+			Name: "github_pr_resolve_thread",
+			Description: "Resolve a pull request review comment thread (the thread that contains " +
+				"the given review comment). Restricted to the configured repository.",
+			InputSchema: jsonSchema{
+				Type: "object",
+				Properties: map[string]property{
+					"number":     {Type: "number", Description: "Pull request number"},
+					"comment_id": {Type: "number", Description: "Database ID of a review comment in the thread to resolve"},
+				},
+				Required: []string{"number", "comment_id"},
+			},
+		},
+		IsWrite: true,
+		execute: func(ctx context.Context, args map[string]any, owner, repo string, policy *Policy, client *GitHubClient) (string, bool, error) {
+			number, ok := getNumber(args, "number")
+			if !ok {
+				return "", false, fmt.Errorf("missing required parameter: number")
+			}
+			commentID, ok := getNumber(args, "comment_id")
+			if !ok {
+				return "", false, fmt.Errorf("missing required parameter: comment_id")
+			}
+
+			// Enforce the single-repo write policy against the configured
+			// owner/repo. The thread is always looked up within that repo below,
+			// so resolution cannot reach another repository.
+			if err := policy.CheckTool("github_pr_resolve_thread", true, owner, repo); err != nil {
+				return "", false, err
+			}
+
+			thread, err := findReviewThreadByComment(ctx, client, owner, repo, number, commentID)
+			if err != nil {
+				return "", false, err
+			}
+			if thread == nil {
+				return fmt.Sprintf("no review thread found for comment %d on %s/%s#%d", commentID, owner, repo, number), true, nil
+			}
+			if thread.IsResolved {
+				return fmt.Sprintf(`{"threadId":%q,"isResolved":true,"alreadyResolved":true}`, thread.ID), false, nil
+			}
+
+			resolved, err := resolveReviewThreadByID(ctx, client, thread.ID)
+			if err != nil {
+				return "", false, err
+			}
+			return fmt.Sprintf(`{"threadId":%q,"isResolved":%t}`, thread.ID, resolved), false, nil
 		},
 	}
 }

--- a/github-mcp/tools_test.go
+++ b/github-mcp/tools_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"context"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -443,5 +446,93 @@ func TestHelperFunctions(t *testing.T) {
 		o, r = resolveOwnerRepo(map[string]any{}, "x", "y")
 		assert.Equal(t, "x", o)
 		assert.Equal(t, "y", r)
+	})
+}
+
+func TestResolveThreadTool_Execute(t *testing.T) {
+	policy := &Policy{AllowedOwner: "my-owner", AllowedRepo: "my-repo"}
+
+	// graphHandler serves the review-threads query and the resolve mutation.
+	graphHandler := func(threadResolved bool) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			if strings.Contains(string(body), "mutation") {
+				w.Write([]byte(`{"data":{"resolveReviewThread":{"thread":{"id":"T1","isResolved":true}}}}`))
+				return
+			}
+			resolved := "false"
+			if threadResolved {
+				resolved = "true"
+			}
+			w.Write([]byte(`{"data":{"repository":{"pullRequest":{"reviewThreads":{` +
+				`"pageInfo":{"hasNextPage":false,"endCursor":""},` +
+				`"nodes":[{"id":"T1","isResolved":` + resolved + `,"comments":{"nodes":[{"databaseId":100}]}}]}}}}}`))
+		}
+	}
+
+	t.Run("resolves an open thread", func(t *testing.T) {
+		gh := httptest.NewServer(graphHandler(false))
+		defer gh.Close()
+		client := newGraphQLClient(gh.URL)
+
+		out, isErr, err := executeTool(context.Background(), "github_pr_resolve_thread",
+			map[string]any{"number": float64(79), "comment_id": float64(100)},
+			"my-owner", "my-repo", policy, client)
+		require.NoError(t, err)
+		assert.False(t, isErr)
+		assert.Contains(t, out, `"isResolved":true`)
+		assert.NotContains(t, out, "alreadyResolved")
+	})
+
+	t.Run("already resolved is a no-op", func(t *testing.T) {
+		gh := httptest.NewServer(graphHandler(true))
+		defer gh.Close()
+		client := newGraphQLClient(gh.URL)
+
+		out, isErr, err := executeTool(context.Background(), "github_pr_resolve_thread",
+			map[string]any{"number": float64(79), "comment_id": float64(100)},
+			"my-owner", "my-repo", policy, client)
+		require.NoError(t, err)
+		assert.False(t, isErr)
+		assert.Contains(t, out, "alreadyResolved")
+	})
+
+	t.Run("comment not found", func(t *testing.T) {
+		gh := httptest.NewServer(graphHandler(false))
+		defer gh.Close()
+		client := newGraphQLClient(gh.URL)
+
+		out, isErr, err := executeTool(context.Background(), "github_pr_resolve_thread",
+			map[string]any{"number": float64(79), "comment_id": float64(999)},
+			"my-owner", "my-repo", policy, client)
+		require.NoError(t, err)
+		assert.True(t, isErr)
+		assert.Contains(t, out, "no review thread found")
+	})
+
+	t.Run("missing number", func(t *testing.T) {
+		_, _, err := executeTool(context.Background(), "github_pr_resolve_thread",
+			map[string]any{"comment_id": float64(100)},
+			"my-owner", "my-repo", policy, newGraphQLClient("http://unused"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "number")
+	})
+
+	t.Run("missing comment_id", func(t *testing.T) {
+		_, _, err := executeTool(context.Background(), "github_pr_resolve_thread",
+			map[string]any{"number": float64(79)},
+			"my-owner", "my-repo", policy, newGraphQLClient("http://unused"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "comment_id")
+	})
+
+	t.Run("policy denies a non-configured repo", func(t *testing.T) {
+		// owner/repo differ from the policy's allowed repo: must be rejected
+		// before any GraphQL call.
+		_, _, err := executeTool(context.Background(), "github_pr_resolve_thread",
+			map[string]any{"number": float64(79), "comment_id": float64(100)},
+			"other-owner", "other-repo", policy, newGraphQLClient("http://unused"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "write access denied")
 	})
 }


### PR DESCRIPTION
Supersedes #80 and #81 — combines them so a single checkout builds an image that actually contains the new tool.

## 1. `github_pr_resolve_thread` MCP tool

Resolves a PR review comment thread (GraphQL-only operation). To preserve the server's single-repo write limitation (GraphQL thread node IDs are global), it takes a PR `number` + a review `comment_id` and looks the thread up **within the configured `--owner`/`--repo`** before resolving — so it can never touch another repository. Implemented via a new optional `execute` hook on `toolDef`; helpers live in `graphql.go`.

## 2. Makefile to (re)build container images

```
make images            # agent, gateway, github-mcp, kube-mcp
make github-mcp-image  # just the per-session GitHub MCP image
make agent-image / gateway-image / kube-mcp-image
make images-no-cache / test / help
```

Default tags match `internal/forge/config/config.go`, so a local build is picked up without editing config (the orchestrator only pulls when an image is absent).

## Testing

- `go build`, `go vet`, gofmt, golangci-lint v2.6.2 — clean.
- github-mcp module coverage (excluding `main.go`) **92.7%**, above the 90% gate.
- Makefile targets validated via `make -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)