### PR TITLE
docs: update README and add update-readme skill

### DIFF
--- a/.claude/skills/update-readme/SKILL.md
+++ b/.claude/skills/update-readme/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: update-readme
+description: Keep README.md, the end-user documentation, in sync with the actual claude-forge CLI and configuration. Use after adding/removing/renaming a CLI command or flag, changing config fields or default images, or whenever the README may have drifted from the code. Verifies every documented command, flag, config key, and image against the source of truth.
+---
+
+# Keep the README up to date
+
+`README.md` is the primary end-user documentation for claude-forge. It drifts
+out of sync whenever the CLI or config changes but the docs don't. This skill
+keeps it accurate by checking every claim against the source of truth — never
+from memory.
+
+## Sources of truth
+
+| What the README documents | Where the truth lives |
+| --- | --- |
+| Commands, subcommands, flags, args | `cmd/claude-forge/main.go` (cobra `Use:`/`Short:`/`Long:`, `cmd.Flags()`, `Args:`) |
+| Config keys and structure | `internal/forge/config/config.go` (struct `yaml:"..."` tags) |
+| Default Docker image references | `internal/forge/config/config.go` (`Default*Image` constants) |
+| Container architecture / lifecycle | `internal/forge/orchestrator.go`, `CLAUDE.md` |
+| Installation / build | `go.mod` (module path, Go version), `Makefile` |
+
+## Workflow
+
+1. **Scope the change.** Identify what changed (a new command, a renamed flag,
+   a new config field, a new image). If invoked proactively after a code edit,
+   start from the diff.
+
+2. **Enumerate the real CLI.** Read `cmd/claude-forge/main.go` and list every
+   command registered in `newRootCmd()`'s `AddCommand(...)`, plus each
+   subcommand's `Use:`, required `Args:`, and every `cmd.Flags()` flag (name,
+   shorthand, default, description). Prefer building the binary and running it
+   when feasible:
+
+   ```bash
+   go build -o /tmp/claude-forge ./cmd/claude-forge/
+   /tmp/claude-forge --help
+   /tmp/claude-forge <command> --help
+   ```
+
+3. **Enumerate config + images.** Read `internal/forge/config/config.go`. List
+   every `yaml:"..."` key under `Config`, `ImagesConfig`, `DefaultsConfig`, and
+   `KubernetesConfig`, and the `Default*Image` constant values.
+
+4. **Diff against the README.** Compare the lists to `README.md`. Flag:
+   - Commands/flags documented but no longer present (remove them)
+   - Commands/flags that exist but are undocumented (add them)
+   - Wrong required arguments (e.g. `start` requires a `<name>`)
+   - Stale config keys, image references, or example values
+   - Examples that would error if run verbatim
+
+5. **Update `README.md`.** Fix the discrepancies. Keep the existing structure,
+   tone, and section order. Use realistic, copy-pasteable examples that match
+   the real flags. Don't invent features that aren't in the code.
+
+6. **Verify.** Re-read the relevant README sections and re-run `--help` for any
+   command you touched to confirm the docs now match.
+
+## Guardrails
+
+- **Never document from memory.** Every command, flag, default, and config key
+  must trace to the current source. The CLI changes across versions.
+- **Don't over-document internals.** `gateway` and similar
+  container-use-only commands exist for the orchestrator, not end users —
+  match the README's existing level of detail rather than dumping every
+  internal subcommand.
+- **Keep examples runnable.** If an example shows `claude-forge start`, make
+  sure the required `<name>` argument is present.
+- **One concern per change.** This skill maintains end-user docs in
+  `README.md`. Architecture/design docs live under `docs/` and `CLAUDE.md`;
+  update those separately when relevant.

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ docker/agent/claude-forge
 # Coverage files
 coverage*.txt
 
-# Claude Code state
-.claude/
+# Claude Code state (local settings) — but track shared project skills
+.claude/*
+!.claude/skills/
 github-mcp/github-mcp

--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@
 
 - Runs Claude Code in Docker with `--dangerously-skip-permissions` by default
 - Gateway proxy mediates all GitHub traffic (git + API) with per-repo write restrictions
+- Per-session **GitHub MCP** sidecar scoped to the current repository
+- Optional shared **Kubernetes MCP** server for cluster access, gated by generated RBAC
 - Multiple instances can run in parallel across different projects
-- Session persistence — resume previous sessions by ID
+- Named sessions with persistence — resume previous sessions by ID or name
 - Automatic auth detection from `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, or `~/.claude/.credentials.json`
 - Dependency caching for Go, npm, pnpm, and pip
-- Host git identity and Claude Code configuration carried into the container
+- Host git identity, Claude Code configuration, and plugins carried into the container
 
 ## Prerequisites
 
@@ -38,44 +40,70 @@ go build -o claude-forge ./cmd/claude-forge/
 # Navigate to your project directory
 cd ~/my-project
 
-# Start an interactive session
-claude-forge start
+# Start an interactive session (the name is required)
+claude-forge start "add auth tests"
 
 # Start with a prompt (non-interactive, exits when done)
-claude-forge start -p "Add unit tests for the auth package"
+claude-forge start "auth tests" -p "Add unit tests for the auth package"
 ```
 
-On first run, `claude-forge build` is called automatically to pull the agent and gateway Docker images.
+On first run, `claude-forge build` is called automatically to pull the agent, gateway, and GitHub MCP Docker images.
 
 ## Usage
 
 ### Start a Session
 
+`start` takes a required human-readable `<name>` argument. The name is passed to
+Claude Code and shown in `claude-forge list`.
+
 ```bash
 # Interactive session (attaches to container TTY)
-claude-forge start
+claude-forge start "refactor parser"
 
 # Non-interactive with a prompt
-claude-forge start -p "Fix the flaky test in auth_test.go"
+claude-forge start "fix flaky test" -p "Fix the flaky test in auth_test.go"
 
 # With worktree mode
-claude-forge start --worktree
+claude-forge start "experiment" --worktree
 
 # Without --dangerously-skip-permissions
-claude-forge start --no-skip-permissions
+claude-forge start "careful run" --no-skip-permissions
+
+# Mount additional host directories (repeatable)
+claude-forge start "with data" --mount /host/data:/work/data
 ```
 
-### Resume a Session
+### List and Resume Sessions
 
 ```bash
+# List past sessions for the current project
+claude-forge list
+
 # Resume the most recent session
 claude-forge resume
 
-# List available sessions
-claude-forge resume --list
-
-# Resume a specific session by ID
+# Resume a specific session by ID or name
 claude-forge resume <session-id>
+claude-forge resume "refactor parser"
+
+# Override the session name on resume
+claude-forge resume <session-id> --name "new name"
+```
+
+### Prune Old Sessions
+
+```bash
+# Delete sessions older than 30 days (default)
+claude-forge prune
+
+# Delete sessions older than a custom age
+claude-forge prune --older-than 7d
+
+# Keep the 10 most recent sessions, delete the rest
+claude-forge prune --keep 10
+
+# Preview without deleting
+claude-forge prune --dry-run
 ```
 
 ### Manage Containers
@@ -91,11 +119,20 @@ claude-forge stop
 ### Other Commands
 
 ```bash
+# Write a default config to ~/.config/claude-forge/config.yaml
+claude-forge init
+
 # Pull/rebuild Docker images
 claude-forge build
 
 # Verify authentication credentials
 claude-forge auth
+
+# Sync host Claude Code plugins into forge's plugin directory
+claude-forge plugins sync
+
+# Restart the shared MCP server containers (e.g. Kubernetes MCP)
+claude-forge mcp restart
 
 # Show version
 claude-forge version
@@ -103,18 +140,30 @@ claude-forge version
 
 ## Configuration
 
-Configuration is stored in `~/.config/claude-forge/config.yaml`:
+Configuration is stored in `~/.config/claude-forge/config.yaml`. Run
+`claude-forge init` to write a default file with detected settings.
 
 ```yaml
 # Override Docker images (defaults to GHCR.io images)
 images:
   agent: ghcr.io/michael-freling/claude-forge-agent:latest
   gateway: ghcr.io/michael-freling/claude-forge-gateway:latest
+  github_mcp: ghcr.io/michael-freling/claude-forge-github-mcp:latest
 
 # Default flags
 defaults:
   skip_permissions: true
   worktree: false
+
+# Optional Kubernetes MCP integration
+kubernetes:
+  enabled: false
+  image: ghcr.io/containers/kubernetes-mcp-server:latest
+  default_context: dev
+  contexts:
+    - host_context: dev
+      service_account_name: claude-forge-agent
+      service_account_namespace: default
 ```
 
 ## Authentication
@@ -127,6 +176,20 @@ defaults:
 
 Run `claude-forge auth` to verify your credentials are detected.
 
+## Kubernetes Access
+
+When `kubernetes.enabled` is set, claude-forge runs a shared Kubernetes MCP
+server that Claude Code can use to inspect and operate on your cluster. Access
+is constrained by RBAC rather than by disabling destructive operations — the
+agent's permissions are exactly what you grant its service account.
+
+Generate the ServiceAccount, ClusterRole, and ClusterRoleBinding (with safe
+carveouts — no secrets, no exec, no RBAC tampering) and apply them:
+
+```bash
+claude-forge kube render --context dev | kubectl apply -f -
+```
+
 ## How It Works
 
 When you run `claude-forge start`, it:
@@ -135,8 +198,9 @@ When you run `claude-forge start`, it:
 2. Resolves authentication credentials
 3. Creates a Docker network for the session
 4. Starts a **gateway** container that proxies GitHub traffic with write restrictions
-5. Starts an **agent** container running Claude Code with your project mounted at `/work`
-6. Attaches your terminal (interactive) or waits for completion (with `-p`)
+5. Starts a **GitHub MCP** sidecar scoped to the current repository
+6. Starts an **agent** container running Claude Code with your project mounted at `/work`
+7. Attaches your terminal (interactive) or waits for completion (with `-p`)
 
 The gateway ensures Claude Code can freely read from any GitHub repository but can only push to or create PRs on the current project's repository.
 


### PR DESCRIPTION
## Summary

Two related changes that fix the end-user docs and keep them from drifting again.

### 1. Update `README.md` to match the current CLI

The README had drifted from the actual CLI surface. Brought back in sync with `cmd/claude-forge/main.go` and `internal/forge/config/config.go`:

- **`start` now requires a `<name>` argument** — documented named sessions and updated all examples.
- **New commands documented**: `init`, `list`, `prune` (`--older-than`/`--keep`/`--dry-run`), `plugins sync`, `mcp restart`, `kube render`.
- **Resume by ID or name**, plus the `--name` and `--mount` flags.
- **GitHub MCP sidecar** added to Features and the "How It Works" flow.
- **Optional Kubernetes MCP integration** — new section covering `kubernetes.enabled` and RBAC via `kube render`.
- **Config example** updated with `images.github_mcp` and the `kubernetes` block.

### 2. Add an `update-readme` Claude Code skill

New project skill at `.claude/skills/update-readme/SKILL.md` that keeps the README aligned with the code going forward. It cross-checks every documented command, flag, config key, and default image against the source of truth (`main.go`, `config.go`) rather than from memory, and prefers running `--help` on a freshly built binary.

`.gitignore` is adjusted to track `.claude/skills/` while still ignoring local Claude settings.

## Test plan
- [x] Cross-checked every command/flag against `cmd/claude-forge/main.go`
- [x] Verified config fields and default images against `internal/forge/config/config.go`
- [x] Confirmed the skill file is tracked (`git check-ignore` returns non-zero)
- Docs/tooling-only change; no application code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)