### PR TITLE
feat: auto-sync host Claude Code plugins at session start

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ claude-forge build
 claude-forge auth
 
 # Sync host Claude Code plugins into forge's plugin directory
+# (this also runs automatically at the start of every session)
 claude-forge plugins sync
 
 # Restart the shared MCP server containers (e.g. Kubernetes MCP)

--- a/cmd/claude-forge/main.go
+++ b/cmd/claude-forge/main.go
@@ -94,6 +94,13 @@ func startSession(skipPermissions, worktree bool, prompt, resumeID, resumeSubdir
 	}
 	defer cleanup()
 
+	// Sync the host's locally installed Claude Code plugins into forge's plugin
+	// directory so they are available in the session without a manual sync.
+	// Best-effort: a failure here should not block starting the session.
+	if err := syncHostPlugins(orch.HomeDir); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: plugin sync failed: %v\n", err)
+	}
+
 	ctx := context.Background()
 	hostUID := os.Getuid()
 	hostGID := os.Getgid()
@@ -679,7 +686,14 @@ var pluginsSyncRun = func(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get home directory: %w", err)
 	}
+	return syncHostPlugins(homeDir)
+}
 
+// syncHostPlugins reinstalls the host's locally installed Claude Code plugins
+// into forge's persistent plugins directory (~/.claude-forge/plugins) by running
+// "claude plugins install" inside a temporary container. It is a no-op when the
+// host has no plugins. Used by "plugins sync" and automatically at session start.
+var syncHostPlugins = func(homeDir string) error {
 	plugins, err := readHostPlugins(homeDir)
 	if err != nil {
 		return err

--- a/cmd/claude-forge/start_session_test.go
+++ b/cmd/claude-forge/start_session_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"testing"
@@ -88,6 +89,48 @@ func TestStartSession_NonInteractive(t *testing.T) {
 	// Non-interactive (prompt set) so we don't try to attach to a TTY.
 	err = startSession(true, false, "do a task", "", "", false, nil, "", "")
 	require.NoError(t, err)
+}
+
+// TestStartSession_PluginSyncFailureNonFatal verifies that a failure while
+// syncing host plugins at session start is logged but does not abort the
+// session — plugin sync is best-effort.
+func TestStartSession_PluginSyncFailureNonFatal(t *testing.T) {
+	homeDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(homeDir+"/.claude", 0o755))
+	require.NoError(t, os.MkdirAll(homeDir+"/.config/claude-forge", 0o755))
+
+	projectDir := t.TempDir()
+	runGitIn(t, projectDir, "init")
+	runGitIn(t, projectDir, "remote", "add", "origin", "git@github.com:test-owner/test-repo.git")
+
+	origWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(projectDir))
+	t.Cleanup(func() { _ = os.Chdir(origWD) })
+
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+
+	originalOrch := createOrchestrator
+	createOrchestrator = func() (*forge.Orchestrator, func(), error) {
+		orch := forge.NewOrchestrator(fakeContainerManager{}, homeDir)
+		orch.Log = func(string, ...any) {}
+		return orch, func() {}, nil
+	}
+	t.Cleanup(func() { createOrchestrator = originalOrch })
+
+	originalSync := syncHostPlugins
+	var syncedHomeDir string
+	syncHostPlugins = func(h string) error {
+		syncedHomeDir = h
+		return errors.New("boom")
+	}
+	t.Cleanup(func() { syncHostPlugins = originalSync })
+
+	err = startSession(true, false, "do a task", "", "", false, nil, "", "")
+	require.NoError(t, err)
+	// Sync was invoked with the orchestrator's home dir, and its failure was
+	// tolerated.
+	require.Equal(t, homeDir, syncedHomeDir)
 }
 
 func runGitIn(t *testing.T, dir string, args ...string) {


### PR DESCRIPTION
## Summary

Makes the host's **locally-installed Claude Code plugins** available inside the session automatically — no manual `claude-forge plugins sync` step needed.

At the start of every `start`/`resume` session, forge now reinstalls the host's installed plugins (`~/.claude/plugins/installed_plugins.json`) into its persistent plugins directory (`~/.claude-forge/plugins`, mounted into the agent at `/home/user/.claude/plugins`).

> **Note:** This supersedes the earlier `--no-claude-config` opt-out idea in this branch. Per discussion, the agents/skills/commands/rules dirs are already mounted by default and don't need an opt-out; the real goal was using locally-installed plugins. The opt-out work has been fully reverted from this PR.

## Why reinstall instead of bind-mount?

Host plugins can reference local-directory marketplaces that don't resolve inside the container. The existing `plugins sync` already reinstalls them against remote marketplaces; this PR simply runs that same logic automatically at session start.

## Changes

- `cmd/claude-forge/main.go`
  - Extract the sync logic out of the `plugins sync` command into a reusable `syncHostPlugins(homeDir)`.
  - Invoke it from `startSession` (covers both `start` and `resume`), **best-effort**: a failure is logged to stderr but does not block the session; it's a no-op when the host has no plugins.
- `cmd/claude-forge/start_session_test.go` — new `TestStartSession_PluginSyncFailureNonFatal` verifying sync is invoked with the orchestrator's home dir and that a sync failure does not abort the session.
- `README.md` — note that `plugins sync` also runs automatically at session start.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt` — clean.
- `go test -race ./...` — passes.
- Coverage (excl. mocks) **90.6%** (≥90% threshold); unit-test-timeout check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)