### PR TITLE
feat: configurable custom MCP servers (remote, OAuth, local sidecars)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,19 @@ mcp_servers:
     args: ["--flag"]
     env:
       API_KEY: "${MY_TOOL_API_KEY}"
+  # Container server — claude-forge runs an image as a per-session sidecar
+  - name: my-sidecar
+    type: container
+    image: ghcr.io/example/some-mcp:latest
+    port: 8080
+    path: /mcp
+  # Wrapped stdio — run a stdio command in a sidecar, bridged to HTTP
+  - name: gcloud
+    type: container
+    command: npx
+    args: ["-y", "@google-cloud/gcloud-mcp"]
+    mounts:
+      - "~/.config/gcloud:/root/.config/gcloud:ro"
 
 # Optional Kubernetes MCP integration
 kubernetes:
@@ -193,14 +206,40 @@ kubernetes:
 
 Beyond the built-in `github` (and optional `kubernetes`) servers, you can expose
 any number of additional MCP servers to the agent via the `mcp_servers` list in
-`config.yaml`. Each entry is one of two kinds:
+`config.yaml`. Each entry is one of these kinds:
 
 - **Remote** (`type: http` or `type: sse`) — an HTTP/SSE endpoint reached over
   the network. Set `url`, and optionally `headers` for authentication. This is
   the right choice for hosted third-party servers such as the Vercel MCP server.
-- **Stdio** (`type: stdio`) — a command launched inside the agent container. Set
-  `command`, and optionally `args` and `env`. The command must be available in
-  the agent image.
+- **Stdio** (`type: stdio`) — a command launched by Claude Code inside the agent
+  container. Set `command`, and optionally `args` and `env`. The command must be
+  available in the agent image.
+- **Container** (`type: container`) — a server claude-forge runs as a
+  **per-session sidecar** on the session network, reached at
+  `http://<name>:<port><path>` (default path `/mcp`). Use this for any MCP
+  server packaged as a container, or to run a locally-installed one that the
+  agent image doesn't have. Two forms:
+  - **Native HTTP image** — set `image` + `port` (+ optional `args`). The image
+    serves MCP over HTTP itself.
+  - **Wrapped stdio** — set `command` (+ optional `args`). claude-forge runs the
+    command inside a sidecar and bridges its stdio to HTTP with
+    [supergateway](https://github.com/supercorp-ai/supergateway). The base
+    `image` defaults to `node:22-slim` (so `npx`-based servers work); override
+    it when the command needs a different runtime or extra CLIs. Pass secrets
+    via `env` (the wrapped process inherits the sidecar's environment) and host
+    paths via `mounts` (`host:container[:ro]`).
+
+  The sidecar's `name` is used as its network hostname, so it must be a valid
+  DNS label. Sidecars are torn down automatically when the session ends, and a
+  server that fails to start is skipped with a warning rather than aborting the
+  session.
+
+> Note: a `type: stdio` server runs in the *agent* container and needs its
+> command baked into the agent image; a `type: container` **wrapped stdio**
+> server runs in its own sidecar, so you can bring arbitrary runtimes without
+> modifying the agent image. Remote HTTP servers are reachable because the agent
+> container has normal outbound internet — the git gateway only proxies git
+> traffic.
 
 `${VAR}` references in `url`, `headers`, `command`, `args`, and `env` are
 expanded from your host environment when a session starts, so API tokens can be

--- a/README.md
+++ b/README.md
@@ -183,9 +183,11 @@ mcp_servers:
     image: ghcr.io/example/some-mcp:latest
     port: 8080
     path: /mcp
-  # Wrapped stdio — run a stdio command in a sidecar, bridged to HTTP
+  # Wrapped stdio — run a stdio command in a sidecar, bridged to HTTP.
+  # scope: global runs one shared instance reused across all sessions.
   - name: gcloud
     type: container
+    scope: global
     command: npx
     args: ["-y", "@google-cloud/gcloud-mcp"]
     mounts:
@@ -230,9 +232,18 @@ any number of additional MCP servers to the agent via the `mcp_servers` list in
     paths via `mounts` (`host:container[:ro]`).
 
   The sidecar's `name` is used as its network hostname, so it must be a valid
-  DNS label. Sidecars are torn down automatically when the session ends, and a
-  server that fails to start is skipped with a warning rather than aborting the
-  session.
+  DNS label. A server that fails to start is skipped with a warning rather than
+  aborting the session.
+
+  **Scope** (`scope:`, container only) controls how the instance is reused:
+  - `session` (default) — one sidecar per session, on the session network, torn
+    down when the session ends. Right for servers scoped to a session/repo.
+  - `global` — a single shared instance on the `forge-shared` network, reused
+    across all sessions (the same model as the Kubernetes MCP). Use it for
+    session-independent servers so N sessions don't spawn N copies. A global
+    server outlives individual sessions and is managed with
+    `claude-forge mcp restart` rather than per-session cleanup — so it must not
+    depend on any one session's or project's secrets.
 
 > Note: a `type: stdio` server runs in the *agent* container and needs its
 > command baked into the agent image; a `type: container` **wrapped stdio**

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - Gateway proxy mediates all GitHub traffic (git + API) with per-repo write restrictions
 - Per-session **GitHub MCP** sidecar scoped to the current repository
 - Optional shared **Kubernetes MCP** server for cluster access, gated by generated RBAC
+- Custom **MCP servers** (remote http/sse or stdio) configurable per install
 - Multiple instances can run in parallel across different projects
 - Named sessions with persistence — resume previous sessions by ID or name
 - Automatic auth detection from `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, or `~/.claude/.credentials.json`
@@ -156,6 +157,27 @@ defaults:
   skip_permissions: true
   worktree: false
 
+# Custom MCP servers (in addition to the built-in github/kubernetes servers)
+mcp_servers:
+  # Remote server (http/sse) with a static token
+  - name: example
+    type: http                       # http (default) | sse | stdio
+    url: https://mcp.example.com
+    headers:
+      Authorization: "Bearer ${EXAMPLE_TOKEN}"
+  # Remote server that authenticates via OAuth (e.g. hosted Vercel MCP)
+  - name: vercel
+    type: http
+    url: https://mcp.vercel.com
+    oauth: true
+  # Stdio server — a command run inside the agent container
+  - name: my-tool
+    type: stdio
+    command: my-mcp-server
+    args: ["--flag"]
+    env:
+      API_KEY: "${MY_TOOL_API_KEY}"
+
 # Optional Kubernetes MCP integration
 kubernetes:
   enabled: false
@@ -166,6 +188,76 @@ kubernetes:
       service_account_name: claude-forge-agent
       service_account_namespace: default
 ```
+
+## Custom MCP Servers
+
+Beyond the built-in `github` (and optional `kubernetes`) servers, you can expose
+any number of additional MCP servers to the agent via the `mcp_servers` list in
+`config.yaml`. Each entry is one of two kinds:
+
+- **Remote** (`type: http` or `type: sse`) — an HTTP/SSE endpoint reached over
+  the network. Set `url`, and optionally `headers` for authentication. This is
+  the right choice for hosted third-party servers such as the Vercel MCP server.
+- **Stdio** (`type: stdio`) — a command launched inside the agent container. Set
+  `command`, and optionally `args` and `env`. The command must be available in
+  the agent image.
+
+`${VAR}` references in `url`, `headers`, `command`, `args`, and `env` are
+expanded from your host environment when a session starts, so API tokens can be
+supplied without being written into `config.yaml`:
+
+```yaml
+mcp_servers:
+  - name: example
+    type: http
+    url: https://mcp.example.com
+    headers:
+      Authorization: "Bearer ${EXAMPLE_TOKEN}"
+```
+
+```bash
+export EXAMPLE_TOKEN=...
+claude-forge start "work session"
+```
+
+Server names must be unique and may not shadow the built-in `github` or
+`kubernetes` servers.
+
+### OAuth MCP servers (e.g. Vercel)
+
+Some hosted MCP servers authenticate via an interactive OAuth flow instead of a
+static token. That flow (browser + localhost callback) **cannot complete inside
+the headless container**, so authenticate once on the host — Claude Code stores
+the resulting token in `~/.claude/.credentials.json`, which claude-forge mounts
+into the container, so every session reuses it.
+
+Mark such servers with `oauth: true`:
+
+```yaml
+mcp_servers:
+  - name: vercel
+    type: http
+    url: https://mcp.vercel.com
+    oauth: true
+```
+
+Authenticate once on the host (use the **same name and URL** so the container
+finds the token):
+
+```bash
+claude mcp add --transport http vercel https://mcp.vercel.com
+claude            # then run: /mcp  →  vercel  →  Authenticate
+```
+
+At session start, claude-forge preflights every `oauth: true` server and prints
+a warning (without blocking the session) if its token is missing or expired, so
+you learn up front that the server won't connect rather than discovering it
+mid-session.
+
+> Note: OAuth token reuse relies on host and container sharing the file-based
+> credential store, which is the case on Linux/WSL. On macOS the token is kept
+> in the system Keychain (not the mounted file), so this carry-over does not
+> apply there.
 
 ## Authentication
 

--- a/README.md
+++ b/README.md
@@ -177,21 +177,21 @@ mcp_servers:
     args: ["--flag"]
     env:
       API_KEY: "${MY_TOOL_API_KEY}"
-  # Container server — claude-forge runs an image as a per-session sidecar
-  - name: my-sidecar
-    type: container
-    image: ghcr.io/example/some-mcp:latest
-    port: 8080
-    path: /mcp
-  # Wrapped stdio — run a stdio command in a sidecar, bridged to HTTP.
-  # scope: global runs one shared instance reused across all sessions.
+  # Container server — claude-forge runs it as a sidecar. scope defaults to
+  # global (one shared instance reused across all sessions).
   - name: gcloud
     type: container
-    scope: global
-    command: npx
+    command: npx           # wrapped stdio (bridged to HTTP)
     args: ["-y", "@google-cloud/gcloud-mcp"]
     mounts:
       - "~/.config/gcloud:/root/.config/gcloud:ro"
+  # Per-session (isolated) native HTTP image
+  - name: my-sidecar
+    type: container
+    scope: session
+    image: ghcr.io/example/some-mcp:latest
+    port: 8080
+    path: /mcp
 
 # Optional Kubernetes MCP integration
 kubernetes:
@@ -216,11 +216,11 @@ any number of additional MCP servers to the agent via the `mcp_servers` list in
 - **Stdio** (`type: stdio`) — a command launched by Claude Code inside the agent
   container. Set `command`, and optionally `args` and `env`. The command must be
   available in the agent image.
-- **Container** (`type: container`) — a server claude-forge runs as a
-  **per-session sidecar** on the session network, reached at
-  `http://<name>:<port><path>` (default path `/mcp`). Use this for any MCP
-  server packaged as a container, or to run a locally-installed one that the
-  agent image doesn't have. Two forms:
+- **Container** (`type: container`) — a server claude-forge runs as a **sidecar**
+  container, reached at `http://<name>:<port><path>` (default path `/mcp`). Use
+  this for any MCP server packaged as a container, or to run a locally-installed
+  one that the agent image doesn't have. By default it runs once and is shared
+  across sessions (see **Scope** below). Two forms:
   - **Native HTTP image** — set `image` + `port` (+ optional `args`). The image
     serves MCP over HTTP itself.
   - **Wrapped stdio** — set `command` (+ optional `args`). claude-forge runs the
@@ -236,14 +236,15 @@ any number of additional MCP servers to the agent via the `mcp_servers` list in
   aborting the session.
 
   **Scope** (`scope:`, container only) controls how the instance is reused:
-  - `session` (default) — one sidecar per session, on the session network, torn
-    down when the session ends. Right for servers scoped to a session/repo.
-  - `global` — a single shared instance on the `forge-shared` network, reused
-    across all sessions (the same model as the Kubernetes MCP). Use it for
-    session-independent servers so N sessions don't spawn N copies. A global
-    server outlives individual sessions and is managed with
+  - `global` (default) — a single shared instance on the `forge-shared` network,
+    reused across all sessions (the same model as the Kubernetes MCP), so N
+    sessions don't spawn N copies. A global server is **shared across projects**,
+    **outlives individual sessions**, and is managed with
     `claude-forge mcp restart` rather than per-session cleanup — so it must not
     depend on any one session's or project's secrets.
+  - `session` — one sidecar per session, on the session network, torn down when
+    the session ends. Use it for servers that need per-session/per-project
+    isolation.
 
 > Note: a `type: stdio` server runs in the *agent* container and needs its
 > command baked into the agent image; a `type: container` **wrapped stdio**

--- a/cmd/claude-forge/main.go
+++ b/cmd/claude-forge/main.go
@@ -221,6 +221,37 @@ defaults:
   skip_permissions: false
   worktree: false
 
+# Custom MCP servers exposed to the agent, in addition to the built-in
+# github (and optional kubernetes) servers.
+#
+# Each entry is either a remote server (http/sse, reached over the network)
+# or a stdio server (a command run inside the agent container). ${VAR}
+# references are expanded from the host environment at session start, so
+# tokens stay out of this file.
+#
+# mcp_servers:
+#   # Remote example with a static token in a header.
+#   - name: example
+#     type: http                       # http (default) | sse | stdio
+#     url: https://mcp.example.com
+#     headers:
+#       Authorization: "Bearer ${EXAMPLE_TOKEN}"
+#   # OAuth example: a hosted Vercel MCP server. OAuth can't complete inside the
+#   # headless container, so authenticate once on the host (its token lands in
+#   # ~/.claude/.credentials.json, which is mounted in). With oauth: true,
+#   # claude-forge warns at session start if the token is missing or expired.
+#   - name: vercel
+#     type: http
+#     url: https://mcp.vercel.com
+#     oauth: true
+#   # Stdio example: a command launched inside the agent container.
+#   - name: my-tool
+#     type: stdio
+#     command: my-mcp-server
+#     args: ["--flag"]
+#     env:
+#       API_KEY: "${MY_TOOL_API_KEY}"
+
 # Kubernetes MCP server integration.
 # When enabled, a shared MCP server container gives agents read-only
 # access to your clusters via short-lived ServiceAccount tokens.

--- a/cmd/claude-forge/main.go
+++ b/cmd/claude-forge/main.go
@@ -222,17 +222,20 @@ defaults:
   worktree: false
 
 # Custom MCP servers exposed to the agent, in addition to the built-in
-# github (and optional kubernetes) servers.
+# github (and optional kubernetes) servers. ${VAR} references in string
+# fields are expanded from the host environment at session start, so tokens
+# stay out of this file.
 #
-# Each entry is either a remote server (http/sse, reached over the network)
-# or a stdio server (a command run inside the agent container). ${VAR}
-# references are expanded from the host environment at session start, so
-# tokens stay out of this file.
+# Each entry is one of:
+#   type: http|sse   remote server reached over the network (url [+ headers])
+#   type: stdio      a command run inside the agent container
+#   type: container  a server claude-forge runs as a per-session sidecar,
+#                    reached at http://<name>:<port><path>
 #
 # mcp_servers:
 #   # Remote example with a static token in a header.
 #   - name: example
-#     type: http                       # http (default) | sse | stdio
+#     type: http
 #     url: https://mcp.example.com
 #     headers:
 #       Authorization: "Bearer ${EXAMPLE_TOKEN}"
@@ -251,6 +254,23 @@ defaults:
 #     args: ["--flag"]
 #     env:
 #       API_KEY: "${MY_TOOL_API_KEY}"
+#   # Container example: an image that serves MCP over HTTP, run as a sidecar.
+#   - name: my-sidecar
+#     type: container
+#     image: ghcr.io/example/some-mcp:latest
+#     port: 8080
+#     path: /mcp
+#   # Wrapped-stdio example: claude-forge runs the command in a sidecar and
+#   # bridges its stdio to HTTP (default image node:22-slim; override with
+#   # image: for other runtimes/CLIs). Mounts are host:container[:ro].
+#   - name: gcloud
+#     type: container
+#     command: npx
+#     args: ["-y", "@google-cloud/gcloud-mcp"]
+#     env:
+#       CLOUDSDK_CORE_PROJECT: "${GCP_PROJECT}"
+#     mounts:
+#       - "~/.config/gcloud:/root/.config/gcloud:ro"
 
 # Kubernetes MCP server integration.
 # When enabled, a shared MCP server container gives agents read-only

--- a/cmd/claude-forge/main.go
+++ b/cmd/claude-forge/main.go
@@ -255,26 +255,23 @@ defaults:
 #     env:
 #       API_KEY: "${MY_TOOL_API_KEY}"
 #   # Container example: an image that serves MCP over HTTP, run as a sidecar.
-#   # scope: session (default) runs one per session; scope: global runs a single
-#   # shared instance reused across all sessions (for session-independent servers).
-#   - name: my-sidecar
-#     type: container
-#     scope: session                   # session (default) | global
-#     image: ghcr.io/example/some-mcp:latest
-#     port: 8080
-#     path: /mcp
-#   # Wrapped-stdio example: claude-forge runs the command in a sidecar and
-#   # bridges its stdio to HTTP (default image node:22-slim; override with
-#   # image: for other runtimes/CLIs). Mounts are host:container[:ro].
+#   # scope defaults to global (one shared instance reused across all sessions);
+#   # use scope: session for a per-session instance that needs isolation.
 #   - name: gcloud
 #     type: container
-#     scope: global
-#     command: npx
+#     command: npx                     # wrapped stdio; omit + set image/port for a native HTTP image
 #     args: ["-y", "@google-cloud/gcloud-mcp"]
 #     env:
 #       CLOUDSDK_CORE_PROJECT: "${GCP_PROJECT}"
-#     mounts:
+#     mounts:                          # host:container[:ro]
 #       - "~/.config/gcloud:/root/.config/gcloud:ro"
+#   # Per-session (isolated) example: a native image serving MCP over HTTP.
+#   - name: my-sidecar
+#     type: container
+#     scope: session                   # global (default) | session
+#     image: ghcr.io/example/some-mcp:latest
+#     port: 8080
+#     path: /mcp
 
 # Kubernetes MCP server integration.
 # When enabled, a shared MCP server container gives agents read-only

--- a/cmd/claude-forge/main.go
+++ b/cmd/claude-forge/main.go
@@ -255,8 +255,11 @@ defaults:
 #     env:
 #       API_KEY: "${MY_TOOL_API_KEY}"
 #   # Container example: an image that serves MCP over HTTP, run as a sidecar.
+#   # scope: session (default) runs one per session; scope: global runs a single
+#   # shared instance reused across all sessions (for session-independent servers).
 #   - name: my-sidecar
 #     type: container
+#     scope: session                   # session (default) | global
 #     image: ghcr.io/example/some-mcp:latest
 #     port: 8080
 #     path: /mcp
@@ -265,6 +268,7 @@ defaults:
 #   # image: for other runtimes/CLIs). Mounts are host:container[:ro].
 #   - name: gcloud
 #     type: container
+#     scope: global
 #     command: npx
 #     args: ["-y", "@google-cloud/gcloud-mcp"]
 #     env:

--- a/internal/forge/claudecode/claudecode.go
+++ b/internal/forge/claudecode/claudecode.go
@@ -411,10 +411,58 @@ func DetectCacheDirs(homeDir string) []CacheDir {
 	return result
 }
 
-// MCPServerConfig represents an MCP server entry in settings.json.
+// MCPServerConfig represents an MCP server entry in settings.json and
+// .claude.json. It covers both remote (http/sse) servers reached over the
+// network and stdio servers launched as a command inside the agent container.
 type MCPServerConfig struct {
 	Type string `json:"type"`
-	URL  string `json:"url"`
+
+	// Remote (http/sse) fields.
+	URL     string            `json:"url,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
+
+	// Stdio fields.
+	Command string            `json:"command,omitempty"`
+	Args    []string          `json:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+}
+
+// settingsMap renders the server as the JSON object Claude Code expects in the
+// mcpServers map. Stdio servers emit command/args/env; remote servers emit
+// url/headers with the transport type.
+func (c MCPServerConfig) settingsMap() map[string]any {
+	if c.Command != "" {
+		m := map[string]any{"type": "stdio", "command": c.Command}
+		if len(c.Args) > 0 {
+			m["args"] = c.Args
+		}
+		if len(c.Env) > 0 {
+			m["env"] = c.Env
+		}
+		return m
+	}
+
+	typ := c.Type
+	if typ == "" {
+		typ = "http"
+	}
+	m := map[string]any{"type": typ, "url": c.URL}
+	if len(c.Headers) > 0 {
+		m["headers"] = c.Headers
+	}
+	return m
+}
+
+// projectMap renders the server for the .claude.json project registration.
+// Remote entries are normalized to the "http" transport (Claude Code's
+// project-level registration expects "http"/"sse"), preserving prior behavior
+// where the legacy "url" type was written as "http".
+func (c MCPServerConfig) projectMap() map[string]any {
+	m := c.settingsMap()
+	if typ, _ := m["type"].(string); typ == "url" {
+		m["type"] = "http"
+	}
+	return m
 }
 
 // UpdateMCPServers reads settings.json from configDir, replaces the
@@ -442,10 +490,7 @@ func UpdateMCPServers(configDir string, servers map[string]MCPServerConfig) erro
 
 	mcpServers := make(map[string]any, len(servers))
 	for name, cfg := range servers {
-		mcpServers[name] = map[string]any{
-			"type": cfg.Type,
-			"url":  cfg.URL,
-		}
+		mcpServers[name] = cfg.settingsMap()
 	}
 	settings["mcpServers"] = mcpServers
 
@@ -491,10 +536,7 @@ func RegisterProjectMCPServers(configDir string, servers map[string]MCPServerCon
 	} else {
 		mcpServers := make(map[string]any, len(servers))
 		for name, cfg := range servers {
-			mcpServers[name] = map[string]any{
-				"type": "http",
-				"url":  cfg.URL,
-			}
+			mcpServers[name] = cfg.projectMap()
 		}
 		workProject["mcpServers"] = mcpServers
 	}

--- a/internal/forge/claudecode/claudecode_test.go
+++ b/internal/forge/claudecode/claudecode_test.go
@@ -1229,3 +1229,91 @@ func TestUpdateMCPServers(t *testing.T) {
 		assert.Contains(t, err.Error(), "failed to parse settings.json")
 	})
 }
+
+func TestMCPServerConfig_settingsMap(t *testing.T) {
+	t.Run("remote server with default type and headers", func(t *testing.T) {
+		cfg := MCPServerConfig{
+			URL:     "https://mcp.vercel.com",
+			Headers: map[string]string{"Authorization": "Bearer tok"},
+		}
+		m := cfg.settingsMap()
+		assert.Equal(t, "http", m["type"])
+		assert.Equal(t, "https://mcp.vercel.com", m["url"])
+		assert.Equal(t, map[string]string{"Authorization": "Bearer tok"}, m["headers"])
+		_, hasCmd := m["command"]
+		assert.False(t, hasCmd)
+	})
+
+	t.Run("legacy url type is preserved in settings", func(t *testing.T) {
+		cfg := MCPServerConfig{Type: "url", URL: "http://github-mcp:8083/mcp"}
+		m := cfg.settingsMap()
+		assert.Equal(t, "url", m["type"])
+		_, hasHeaders := m["headers"]
+		assert.False(t, hasHeaders)
+	})
+
+	t.Run("sse type is preserved", func(t *testing.T) {
+		cfg := MCPServerConfig{Type: "sse", URL: "http://localhost:8080/sse"}
+		m := cfg.settingsMap()
+		assert.Equal(t, "sse", m["type"])
+	})
+
+	t.Run("stdio server emits command args env", func(t *testing.T) {
+		cfg := MCPServerConfig{
+			Command: "my-mcp",
+			Args:    []string{"--flag"},
+			Env:     map[string]string{"API_KEY": "secret"},
+		}
+		m := cfg.settingsMap()
+		assert.Equal(t, "stdio", m["type"])
+		assert.Equal(t, "my-mcp", m["command"])
+		assert.Equal(t, []string{"--flag"}, m["args"])
+		assert.Equal(t, map[string]string{"API_KEY": "secret"}, m["env"])
+		_, hasURL := m["url"]
+		assert.False(t, hasURL)
+	})
+}
+
+func TestMCPServerConfig_projectMap(t *testing.T) {
+	t.Run("legacy url type normalized to http", func(t *testing.T) {
+		cfg := MCPServerConfig{Type: "url", URL: "http://github-mcp:8083/mcp"}
+		m := cfg.projectMap()
+		assert.Equal(t, "http", m["type"])
+	})
+
+	t.Run("stdio unchanged", func(t *testing.T) {
+		cfg := MCPServerConfig{Command: "my-mcp"}
+		m := cfg.projectMap()
+		assert.Equal(t, "stdio", m["type"])
+		assert.Equal(t, "my-mcp", m["command"])
+	})
+}
+
+func TestUpdateMCPServers_CustomShapes(t *testing.T) {
+	configDir := t.TempDir()
+
+	servers := map[string]MCPServerConfig{
+		"vercel": {Type: "http", URL: "https://mcp.vercel.com", Headers: map[string]string{"Authorization": "Bearer tok"}},
+		"local":  {Type: "stdio", Command: "my-mcp", Args: []string{"--flag"}, Env: map[string]string{"K": "v"}},
+	}
+
+	require.NoError(t, UpdateMCPServers(configDir, servers))
+
+	data, err := os.ReadFile(filepath.Join(configDir, "settings.json"))
+	require.NoError(t, err)
+
+	var settings map[string]any
+	require.NoError(t, json.Unmarshal(data, &settings))
+	mcpServers := settings["mcpServers"].(map[string]any)
+
+	vercel := mcpServers["vercel"].(map[string]any)
+	assert.Equal(t, "http", vercel["type"])
+	assert.Equal(t, "https://mcp.vercel.com", vercel["url"])
+	assert.Equal(t, map[string]any{"Authorization": "Bearer tok"}, vercel["headers"])
+
+	local := mcpServers["local"].(map[string]any)
+	assert.Equal(t, "stdio", local["type"])
+	assert.Equal(t, "my-mcp", local["command"])
+	assert.Equal(t, []any{"--flag"}, local["args"])
+	assert.Equal(t, map[string]any{"K": "v"}, local["env"])
+}

--- a/internal/forge/claudecode/mcpauth.go
+++ b/internal/forge/claudecode/mcpauth.go
@@ -1,0 +1,108 @@
+package claudecode
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// MCPOAuthStatus is the result of a preflight check for a remote MCP server's
+// OAuth credentials.
+type MCPOAuthStatus int
+
+const (
+	// MCPOAuthValid means a usable token is stored (unexpired, or refreshable).
+	MCPOAuthValid MCPOAuthStatus = iota
+	// MCPOAuthMissing means no token is stored for the server.
+	MCPOAuthMissing
+	// MCPOAuthExpired means a token is stored but expired and not refreshable.
+	MCPOAuthExpired
+)
+
+// MCPOAuthKey reproduces the key Claude Code uses to index a remote MCP
+// server's OAuth credentials inside the "mcpOAuth" map of
+// ~/.claude/.credentials.json. Claude Code computes it as:
+//
+//	`${name}|${sha256hex(JSON.stringify({type, url, headers}))[:16]}`
+//
+// where the JSON is produced by a plain JSON.stringify (object key order:
+// type, url, headers; headers defaults to {}). Matching this exactly lets the
+// preflight look up precisely the record the container's Claude Code will read.
+//
+// Note: JavaScript's JSON.stringify preserves header insertion order whereas
+// Go sorts map keys, so the computed key only matches for servers with zero or
+// one header — which is the norm for OAuth servers (they carry no static
+// headers).
+func MCPOAuthKey(name, typ, url string, headers map[string]string) string {
+	if headers == nil {
+		headers = map[string]string{}
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false) // match JS JSON.stringify (no &,<,> escaping)
+	_ = enc.Encode(struct {
+		Type    string            `json:"type"`
+		URL     string            `json:"url"`
+		Headers map[string]string `json:"headers"`
+	}{typ, url, headers})
+	payload := strings.TrimRight(buf.String(), "\n")
+
+	sum := sha256.Sum256([]byte(payload))
+	return name + "|" + hex.EncodeToString(sum[:])[:16]
+}
+
+// CheckMCPOAuth reports whether a valid OAuth token for the given remote MCP
+// server is present in claudeDir/.credentials.json. nowMs is the current time
+// in Unix milliseconds (injected for testability). A token with a refresh
+// token is treated as valid even past its access-token expiry, since Claude
+// Code refreshes it automatically.
+func CheckMCPOAuth(claudeDir, name, typ, url string, headers map[string]string, nowMs int64) (MCPOAuthStatus, error) {
+	path := filepath.Join(claudeDir, ".credentials.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return MCPOAuthMissing, nil
+		}
+		return MCPOAuthMissing, fmt.Errorf("failed to read credentials: %w", err)
+	}
+
+	var creds struct {
+		MCPOAuth map[string]map[string]any `json:"mcpOAuth"`
+	}
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return MCPOAuthMissing, fmt.Errorf("failed to parse credentials: %w", err)
+	}
+
+	rec := creds.MCPOAuth[MCPOAuthKey(name, typ, url, headers)]
+	if rec == nil {
+		return MCPOAuthMissing, nil
+	}
+
+	access, _ := rec["accessToken"].(string)
+	refresh, _ := rec["refreshToken"].(string)
+	if access == "" && refresh == "" {
+		// Tokenless stub — Claude Code treats these as unauthenticated.
+		return MCPOAuthMissing, nil
+	}
+	if refresh != "" {
+		return MCPOAuthValid, nil
+	}
+
+	switch v := rec["expiresAt"].(type) {
+	case float64:
+		if int64(v) <= nowMs {
+			return MCPOAuthExpired, nil
+		}
+	case string:
+		if t, err := time.Parse(time.RFC3339, v); err == nil && t.UnixMilli() <= nowMs {
+			return MCPOAuthExpired, nil
+		}
+	}
+	return MCPOAuthValid, nil
+}

--- a/internal/forge/claudecode/mcpauth_test.go
+++ b/internal/forge/claudecode/mcpauth_test.go
@@ -1,0 +1,107 @@
+package claudecode
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMCPOAuthKey(t *testing.T) {
+	// Reference vector computed from Claude Code's algorithm:
+	// `${name}|${sha256hex(JSON.stringify({type,url,headers}))[:16]}`.
+	assert.Equal(t, "vercel|511b08192b045b3d",
+		MCPOAuthKey("vercel", "http", "https://mcp.vercel.com", nil))
+
+	// nil and empty headers hash identically (both serialize to {}).
+	assert.Equal(t,
+		MCPOAuthKey("x", "http", "https://x.com", nil),
+		MCPOAuthKey("x", "http", "https://x.com", map[string]string{}))
+
+	// Name is a prefix, hash distinguishes different URLs.
+	a := MCPOAuthKey("x", "http", "https://a.com", nil)
+	b := MCPOAuthKey("x", "http", "https://b.com", nil)
+	assert.NotEqual(t, a, b)
+}
+
+func writeCreds(t *testing.T, dir, body string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(body), 0o600))
+}
+
+func TestCheckMCPOAuth(t *testing.T) {
+	const now = int64(4_000_000_000_000) // ~year 2096, after any ISO date used below
+	key := MCPOAuthKey("vercel", "http", "https://mcp.vercel.com", nil)
+
+	t.Run("missing file", func(t *testing.T) {
+		st, err := CheckMCPOAuth(t.TempDir(), "vercel", "http", "https://mcp.vercel.com", nil, now)
+		require.NoError(t, err)
+		assert.Equal(t, MCPOAuthMissing, st)
+	})
+
+	t.Run("no mcpOAuth section", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCreds(t, dir, `{"claudeAiOauth":{"accessToken":"x"}}`)
+		st, err := CheckMCPOAuth(dir, "vercel", "http", "https://mcp.vercel.com", nil, now)
+		require.NoError(t, err)
+		assert.Equal(t, MCPOAuthMissing, st)
+	})
+
+	t.Run("valid unexpired token", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCreds(t, dir, fmt.Sprintf(`{"mcpOAuth":{%q:{"accessToken":"a","expiresAt":%d}}}`, key, now+10_000))
+		st, err := CheckMCPOAuth(dir, "vercel", "http", "https://mcp.vercel.com", nil, now)
+		require.NoError(t, err)
+		assert.Equal(t, MCPOAuthValid, st)
+	})
+
+	t.Run("expired but refreshable is valid", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCreds(t, dir, fmt.Sprintf(`{"mcpOAuth":{%q:{"accessToken":"a","refreshToken":"r","expiresAt":%d}}}`, key, now-10_000))
+		st, err := CheckMCPOAuth(dir, "vercel", "http", "https://mcp.vercel.com", nil, now)
+		require.NoError(t, err)
+		assert.Equal(t, MCPOAuthValid, st)
+	})
+
+	t.Run("expired and not refreshable", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCreds(t, dir, fmt.Sprintf(`{"mcpOAuth":{%q:{"accessToken":"a","expiresAt":%d}}}`, key, now-1))
+		st, err := CheckMCPOAuth(dir, "vercel", "http", "https://mcp.vercel.com", nil, now)
+		require.NoError(t, err)
+		assert.Equal(t, MCPOAuthExpired, st)
+	})
+
+	t.Run("expiresAt as ISO string, expired", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCreds(t, dir, fmt.Sprintf(`{"mcpOAuth":{%q:{"accessToken":"a","expiresAt":"2000-01-01T00:00:00Z"}}}`, key))
+		st, err := CheckMCPOAuth(dir, "vercel", "http", "https://mcp.vercel.com", nil, now)
+		require.NoError(t, err)
+		assert.Equal(t, MCPOAuthExpired, st)
+	})
+
+	t.Run("tokenless stub treated as missing", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCreds(t, dir, fmt.Sprintf(`{"mcpOAuth":{%q:{}}}`, key))
+		st, err := CheckMCPOAuth(dir, "vercel", "http", "https://mcp.vercel.com", nil, now)
+		require.NoError(t, err)
+		assert.Equal(t, MCPOAuthMissing, st)
+	})
+
+	t.Run("no expiresAt means valid", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCreds(t, dir, fmt.Sprintf(`{"mcpOAuth":{%q:{"accessToken":"a"}}}`, key))
+		st, err := CheckMCPOAuth(dir, "vercel", "http", "https://mcp.vercel.com", nil, now)
+		require.NoError(t, err)
+		assert.Equal(t, MCPOAuthValid, st)
+	})
+
+	t.Run("invalid JSON errors", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCreds(t, dir, `{invalid`)
+		_, err := CheckMCPOAuth(dir, "vercel", "http", "https://mcp.vercel.com", nil, now)
+		require.Error(t, err)
+	})
+}

--- a/internal/forge/config/config.go
+++ b/internal/forge/config/config.go
@@ -24,9 +24,96 @@ const (
 
 // Config holds the claude-forge configuration.
 type Config struct {
-	Images     ImagesConfig     `yaml:"images"`
-	Defaults   DefaultsConfig   `yaml:"defaults"`
-	Kubernetes KubernetesConfig `yaml:"kubernetes"`
+	Images     ImagesConfig      `yaml:"images"`
+	Defaults   DefaultsConfig    `yaml:"defaults"`
+	Kubernetes KubernetesConfig  `yaml:"kubernetes"`
+	MCPServers []MCPServerConfig `yaml:"mcp_servers"`
+}
+
+// MCPServerConfig configures a custom MCP server exposed to the agent.
+//
+// It is intentionally general: a server is either "remote" (an HTTP/SSE
+// endpoint reached over the network, e.g. a hosted Vercel MCP server) or
+// "stdio" (a command launched inside the agent container). Remote servers set
+// URL (and optionally Headers); stdio servers set Command (and optionally Args
+// and Env).
+//
+// String values in URL, Headers, Command, Args, and Env support ${VAR}
+// expansion against the host environment at session start, so secrets such as
+// API tokens can be referenced without being committed to config.yaml.
+type MCPServerConfig struct {
+	// Name is the identifier Claude Code uses for the server (must be unique).
+	Name string `yaml:"name"`
+	// Type is the MCP transport: "http" (default) or "sse" for remote servers,
+	// "stdio" for command-based servers. It is inferred when omitted: "stdio"
+	// if Command is set, otherwise "http".
+	Type string `yaml:"type"`
+
+	// Remote (http/sse) fields.
+	URL     string            `yaml:"url"`
+	Headers map[string]string `yaml:"headers"`
+
+	// OAuth marks a remote server that authenticates via an interactive OAuth
+	// flow (rather than a static token in Headers). OAuth cannot complete inside
+	// the headless container, so the token must be obtained once on the host
+	// (its tokens live in ~/.claude/.credentials.json, which is mounted into the
+	// container). When set, claude-forge preflights the token at session start
+	// and warns if it is missing or expired.
+	OAuth bool `yaml:"oauth"`
+
+	// Stdio fields.
+	Command string            `yaml:"command"`
+	Args    []string          `yaml:"args"`
+	Env     map[string]string `yaml:"env"`
+}
+
+// reservedMCPNames are server names owned by claude-forge's built-in
+// integrations; a custom server may not shadow them.
+var reservedMCPNames = map[string]bool{
+	"github":     true,
+	"kubernetes": true,
+}
+
+// IsStdio reports whether the server is launched as a command (stdio transport)
+// rather than reached as a remote endpoint.
+func (m MCPServerConfig) IsStdio() bool {
+	return m.Type == "stdio" || (m.Type == "" && m.Command != "")
+}
+
+// validateMCPServers checks that every configured custom MCP server is
+// well-formed: named, uniquely named, not shadowing a built-in, and carrying
+// the fields its transport requires.
+func validateMCPServers(servers []MCPServerConfig) error {
+	seen := make(map[string]bool, len(servers))
+	for i, s := range servers {
+		if s.Name == "" {
+			return fmt.Errorf("mcp_servers[%d]: name is required", i)
+		}
+		if reservedMCPNames[s.Name] {
+			return fmt.Errorf("mcp_servers[%d]: name %q is reserved for a built-in server", i, s.Name)
+		}
+		if seen[s.Name] {
+			return fmt.Errorf("mcp_servers[%d]: duplicate name %q", i, s.Name)
+		}
+		seen[s.Name] = true
+
+		if s.IsStdio() {
+			if s.Command == "" {
+				return fmt.Errorf("mcp_servers[%q]: command is required for a stdio server", s.Name)
+			}
+			if s.OAuth {
+				return fmt.Errorf("mcp_servers[%q]: oauth is only valid for http/sse servers", s.Name)
+			}
+		} else {
+			if s.URL == "" {
+				return fmt.Errorf("mcp_servers[%q]: url is required for an http/sse server", s.Name)
+			}
+			if s.Type != "" && s.Type != "http" && s.Type != "sse" {
+				return fmt.Errorf("mcp_servers[%q]: type must be \"http\", \"sse\", or \"stdio\", got %q", s.Name, s.Type)
+			}
+		}
+	}
+	return nil
 }
 
 // ImagesConfig holds Docker image configuration.
@@ -102,6 +189,10 @@ func Load(configDir string) (*Config, error) {
 	}
 	if cfg.Kubernetes.Image == "" {
 		cfg.Kubernetes.Image = DefaultKubernetesMCPImage
+	}
+
+	if err := validateMCPServers(cfg.MCPServers); err != nil {
+		return nil, err
 	}
 
 	return cfg, nil

--- a/internal/forge/config/config.go
+++ b/internal/forge/config/config.go
@@ -98,12 +98,15 @@ type MCPServerConfig struct {
 	Mounts []string `yaml:"mounts"` // host:container[:ro] bind mounts for the sidecar
 
 	// Scope controls how a container server's instance is reused:
-	//   "session" (default) — one sidecar per session, torn down with it.
-	//   "global"            — a single shared instance reused across all
-	//                         sessions (like the Kubernetes MCP). Use this for
-	//                         session-independent servers so N sessions don't
-	//                         spawn N copies. Global servers outlive individual
-	//                         sessions and are managed via `mcp restart`.
+	//   "global" (default) — a single shared instance reused across all sessions
+	//                         (like the Kubernetes MCP), so N sessions don't
+	//                         spawn N copies. Global servers are shared across
+	//                         projects, outlive individual sessions, and are
+	//                         managed via `mcp restart` rather than per-session
+	//                         cleanup — so they must not depend on any one
+	//                         session's or project's secrets.
+	//   "session"          — one sidecar per session, torn down with it. Use for
+	//                         servers that need per-session/per-project isolation.
 	Scope string `yaml:"scope"`
 }
 
@@ -133,9 +136,10 @@ func (m MCPServerConfig) IsWrappedStdio() bool {
 }
 
 // IsGlobal reports whether a container server runs as a single shared instance
-// reused across sessions rather than a per-session sidecar.
+// reused across sessions rather than a per-session sidecar. Global is the
+// default scope for container servers; only an explicit "session" opts out.
 func (m MCPServerConfig) IsGlobal() bool {
-	return m.IsContainer() && m.Scope == "global"
+	return m.IsContainer() && m.Scope != "session"
 }
 
 // validateMCPServers checks that every configured custom MCP server is

--- a/internal/forge/config/config.go
+++ b/internal/forge/config/config.go
@@ -20,6 +20,20 @@ const (
 
 	// DefaultKubernetesMCPImage is the default Docker image for the Kubernetes MCP server.
 	DefaultKubernetesMCPImage = "ghcr.io/containers/kubernetes-mcp-server:latest"
+
+	// DefaultMCPWrapperImage is the default base image used to wrap a stdio MCP
+	// server command in a stdio→HTTP bridge (Node, so `npx -y supergateway` and
+	// npx-based servers work out of the box). Override per-server via `image`
+	// when the wrapped command needs a different runtime or extra CLIs.
+	DefaultMCPWrapperImage = "node:22-slim"
+
+	// DefaultMCPPort is the sidecar port used for wrapped stdio servers when the
+	// server config does not specify one.
+	DefaultMCPPort = 8080
+
+	// DefaultMCPPath is the HTTP path a container MCP sidecar is reached at when
+	// the server config does not specify one.
+	DefaultMCPPath = "/mcp"
 )
 
 // Config holds the claude-forge configuration.
@@ -32,21 +46,31 @@ type Config struct {
 
 // MCPServerConfig configures a custom MCP server exposed to the agent.
 //
-// It is intentionally general: a server is either "remote" (an HTTP/SSE
-// endpoint reached over the network, e.g. a hosted Vercel MCP server) or
-// "stdio" (a command launched inside the agent container). Remote servers set
-// URL (and optionally Headers); stdio servers set Command (and optionally Args
-// and Env).
+// It is intentionally general and covers every way an MCP server can run:
 //
-// String values in URL, Headers, Command, Args, and Env support ${VAR}
+//   - "http"/"sse": a remote endpoint reached over the network (e.g. a hosted
+//     Vercel MCP server). Set URL (and optionally Headers, or OAuth).
+//   - "stdio": a command launched by Claude Code inside the agent container.
+//     Set Command (and optionally Args, Env). The command must exist in the
+//     agent image.
+//   - "container": a server claude-forge runs as a per-session sidecar
+//     container on the session network, reached over HTTP at
+//     http://<name>:<port><path>. Either the Image serves MCP over HTTP
+//     directly (set Image + Port), or a stdio Command is wrapped in a
+//     stdio→HTTP bridge (set Command; Image defaults to a Node base image).
+//
+// String values in URL, Headers, Command, Args, Env, and Mounts support ${VAR}
 // expansion against the host environment at session start, so secrets such as
 // API tokens can be referenced without being committed to config.yaml.
 type MCPServerConfig struct {
 	// Name is the identifier Claude Code uses for the server (must be unique).
+	// For "container" servers it also becomes the sidecar's network alias, so
+	// it must be a valid DNS label.
 	Name string `yaml:"name"`
 	// Type is the MCP transport: "http" (default) or "sse" for remote servers,
-	// "stdio" for command-based servers. It is inferred when omitted: "stdio"
-	// if Command is set, otherwise "http".
+	// "stdio" for command-based servers run in the agent, or "container" for a
+	// sidecar container. It is inferred when omitted: "stdio" if Command is set,
+	// otherwise "http".
 	Type string `yaml:"type"`
 
 	// Remote (http/sse) fields.
@@ -61,10 +85,17 @@ type MCPServerConfig struct {
 	// and warns if it is missing or expired.
 	OAuth bool `yaml:"oauth"`
 
-	// Stdio fields.
+	// Stdio / wrapped-command fields. For "stdio" the command runs in the agent
+	// container; for "container" it is wrapped in a stdio→HTTP bridge sidecar.
 	Command string            `yaml:"command"`
 	Args    []string          `yaml:"args"`
 	Env     map[string]string `yaml:"env"`
+
+	// Container (sidecar) fields.
+	Image  string   `yaml:"image"`  // sidecar image; defaults to the Node wrapper image for wrapped commands
+	Port   int      `yaml:"port"`   // container port serving MCP over HTTP
+	Path   string   `yaml:"path"`   // HTTP path; defaults to /mcp
+	Mounts []string `yaml:"mounts"` // host:container[:ro] bind mounts for the sidecar
 }
 
 // reservedMCPNames are server names owned by claude-forge's built-in
@@ -74,10 +105,22 @@ var reservedMCPNames = map[string]bool{
 	"kubernetes": true,
 }
 
-// IsStdio reports whether the server is launched as a command (stdio transport)
-// rather than reached as a remote endpoint.
+// IsContainer reports whether claude-forge runs the server as a sidecar container.
+func (m MCPServerConfig) IsContainer() bool {
+	return m.Type == "container"
+}
+
+// IsStdio reports whether the server is launched as a command inside the agent
+// container (stdio transport) rather than reached as a remote endpoint or run
+// as a sidecar.
 func (m MCPServerConfig) IsStdio() bool {
 	return m.Type == "stdio" || (m.Type == "" && m.Command != "")
+}
+
+// IsWrappedStdio reports whether a container server wraps a stdio command in a
+// stdio→HTTP bridge (as opposed to an image that serves MCP over HTTP itself).
+func (m MCPServerConfig) IsWrappedStdio() bool {
+	return m.IsContainer() && m.Command != ""
 }
 
 // validateMCPServers checks that every configured custom MCP server is
@@ -97,20 +140,58 @@ func validateMCPServers(servers []MCPServerConfig) error {
 		}
 		seen[s.Name] = true
 
-		if s.IsStdio() {
+		switch {
+		case s.IsContainer():
+			if s.OAuth {
+				return fmt.Errorf("mcp_servers[%q]: oauth is only valid for http/sse servers", s.Name)
+			}
+			// The name becomes the sidecar's DNS alias and URL host.
+			if err := validateDNSLabel(s.Name); err != nil {
+				return fmt.Errorf("mcp_servers[%q]: %w", s.Name, err)
+			}
+			if s.Command == "" {
+				// Native image that serves MCP over HTTP itself.
+				if s.Image == "" {
+					return fmt.Errorf("mcp_servers[%q]: image is required for a container server (or set command to wrap a stdio server)", s.Name)
+				}
+				if s.Port <= 0 {
+					return fmt.Errorf("mcp_servers[%q]: port is required for a container server that serves HTTP", s.Name)
+				}
+			}
+		case s.IsStdio():
 			if s.Command == "" {
 				return fmt.Errorf("mcp_servers[%q]: command is required for a stdio server", s.Name)
 			}
 			if s.OAuth {
 				return fmt.Errorf("mcp_servers[%q]: oauth is only valid for http/sse servers", s.Name)
 			}
-		} else {
+		default:
 			if s.URL == "" {
 				return fmt.Errorf("mcp_servers[%q]: url is required for an http/sse server", s.Name)
 			}
 			if s.Type != "" && s.Type != "http" && s.Type != "sse" {
-				return fmt.Errorf("mcp_servers[%q]: type must be \"http\", \"sse\", or \"stdio\", got %q", s.Name, s.Type)
+				return fmt.Errorf("mcp_servers[%q]: type must be \"http\", \"sse\", \"stdio\", or \"container\", got %q", s.Name, s.Type)
 			}
+		}
+	}
+	return nil
+}
+
+// validateDNSLabel checks that s is a valid RFC 1123 DNS label (lowercase
+// alphanumerics and hyphens, not starting or ending with a hyphen, at most 63
+// characters) so it can be used as a Docker network alias and URL host.
+func validateDNSLabel(s string) error {
+	if len(s) == 0 || len(s) > 63 {
+		return fmt.Errorf("name must be 1-63 characters to be used as a container hostname")
+	}
+	for i, r := range s {
+		isLower := r >= 'a' && r <= 'z'
+		isDigit := r >= '0' && r <= '9'
+		if !isLower && !isDigit && r != '-' {
+			return fmt.Errorf("name must be a DNS label (lowercase letters, digits, hyphens) to be used as a container hostname")
+		}
+		if r == '-' && (i == 0 || i == len(s)-1) {
+			return fmt.Errorf("name must not start or end with a hyphen to be used as a container hostname")
 		}
 	}
 	return nil

--- a/internal/forge/config/config.go
+++ b/internal/forge/config/config.go
@@ -96,6 +96,15 @@ type MCPServerConfig struct {
 	Port   int      `yaml:"port"`   // container port serving MCP over HTTP
 	Path   string   `yaml:"path"`   // HTTP path; defaults to /mcp
 	Mounts []string `yaml:"mounts"` // host:container[:ro] bind mounts for the sidecar
+
+	// Scope controls how a container server's instance is reused:
+	//   "session" (default) — one sidecar per session, torn down with it.
+	//   "global"            — a single shared instance reused across all
+	//                         sessions (like the Kubernetes MCP). Use this for
+	//                         session-independent servers so N sessions don't
+	//                         spawn N copies. Global servers outlive individual
+	//                         sessions and are managed via `mcp restart`.
+	Scope string `yaml:"scope"`
 }
 
 // reservedMCPNames are server names owned by claude-forge's built-in
@@ -123,6 +132,12 @@ func (m MCPServerConfig) IsWrappedStdio() bool {
 	return m.IsContainer() && m.Command != ""
 }
 
+// IsGlobal reports whether a container server runs as a single shared instance
+// reused across sessions rather than a per-session sidecar.
+func (m MCPServerConfig) IsGlobal() bool {
+	return m.IsContainer() && m.Scope == "global"
+}
+
 // validateMCPServers checks that every configured custom MCP server is
 // well-formed: named, uniquely named, not shadowing a built-in, and carrying
 // the fields its transport requires.
@@ -140,10 +155,17 @@ func validateMCPServers(servers []MCPServerConfig) error {
 		}
 		seen[s.Name] = true
 
+		if s.Scope != "" && !s.IsContainer() {
+			return fmt.Errorf("mcp_servers[%q]: scope is only valid for container servers", s.Name)
+		}
+
 		switch {
 		case s.IsContainer():
 			if s.OAuth {
 				return fmt.Errorf("mcp_servers[%q]: oauth is only valid for http/sse servers", s.Name)
+			}
+			if s.Scope != "" && s.Scope != "session" && s.Scope != "global" {
+				return fmt.Errorf("mcp_servers[%q]: scope must be \"session\" or \"global\", got %q", s.Name, s.Scope)
 			}
 			// The name becomes the sidecar's DNS alias and URL host.
 			if err := validateDNSLabel(s.Name); err != nil {

--- a/internal/forge/config/config_test.go
+++ b/internal/forge/config/config_test.go
@@ -188,3 +188,90 @@ func TestLoad_PartialGatewayOnly(t *testing.T) {
 	assert.Equal(t, DefaultAgentImage, got.Images.Agent)
 	assert.Equal(t, "my-gateway:latest", got.Images.Gateway)
 }
+
+func TestLoad_MCPServers(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	configYAML := `mcp_servers:
+  - name: vercel
+    type: http
+    url: https://mcp.vercel.com
+    headers:
+      Authorization: "Bearer ${VERCEL_TOKEN}"
+  - name: local
+    type: stdio
+    command: my-mcp
+    args: ["--flag"]
+    env:
+      API_KEY: "${MY_KEY}"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "config.yaml"), []byte(configYAML), 0o644))
+
+	got, err := Load(tmpDir)
+	require.NoError(t, err)
+	require.Len(t, got.MCPServers, 2)
+
+	assert.Equal(t, "vercel", got.MCPServers[0].Name)
+	assert.Equal(t, "https://mcp.vercel.com", got.MCPServers[0].URL)
+	assert.Equal(t, "Bearer ${VERCEL_TOKEN}", got.MCPServers[0].Headers["Authorization"])
+	assert.False(t, got.MCPServers[0].IsStdio())
+
+	assert.Equal(t, "local", got.MCPServers[1].Name)
+	assert.True(t, got.MCPServers[1].IsStdio())
+	assert.Equal(t, []string{"--flag"}, got.MCPServers[1].Args)
+}
+
+func TestLoad_MCPServers_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		configYAML  string
+		errContains string
+	}{
+		{
+			name:        "missing name",
+			configYAML:  "mcp_servers:\n  - url: https://example.com\n",
+			errContains: "name is required",
+		},
+		{
+			name:        "reserved name",
+			configYAML:  "mcp_servers:\n  - name: github\n    url: https://example.com\n",
+			errContains: "reserved",
+		},
+		{
+			name:        "duplicate name",
+			configYAML:  "mcp_servers:\n  - name: a\n    url: https://a.com\n  - name: a\n    url: https://b.com\n",
+			errContains: "duplicate name",
+		},
+		{
+			name:        "remote without url",
+			configYAML:  "mcp_servers:\n  - name: a\n    type: http\n",
+			errContains: "url is required",
+		},
+		{
+			name:        "stdio without command",
+			configYAML:  "mcp_servers:\n  - name: a\n    type: stdio\n",
+			errContains: "command is required",
+		},
+		{
+			name:        "invalid type",
+			configYAML:  "mcp_servers:\n  - name: a\n    type: grpc\n    url: https://a.com\n",
+			errContains: "type must be",
+		},
+		{
+			name:        "oauth on stdio server",
+			configYAML:  "mcp_servers:\n  - name: a\n    type: stdio\n    command: x\n    oauth: true\n",
+			errContains: "oauth is only valid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "config.yaml"), []byte(tt.configYAML), 0o644))
+
+			_, err := Load(tmpDir)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errContains)
+		})
+	}
+}

--- a/internal/forge/config/config_test.go
+++ b/internal/forge/config/config_test.go
@@ -262,6 +262,36 @@ func TestLoad_MCPServers_ValidationErrors(t *testing.T) {
 			configYAML:  "mcp_servers:\n  - name: a\n    type: stdio\n    command: x\n    oauth: true\n",
 			errContains: "oauth is only valid",
 		},
+		{
+			name:        "container missing image and command",
+			configYAML:  "mcp_servers:\n  - name: a\n    type: container\n    port: 8080\n",
+			errContains: "image is required for a container server",
+		},
+		{
+			name:        "container native missing port",
+			configYAML:  "mcp_servers:\n  - name: a\n    type: container\n    image: img:1\n",
+			errContains: "port is required",
+		},
+		{
+			name:        "container name not a dns label",
+			configYAML:  "mcp_servers:\n  - name: My_Server\n    type: container\n    image: img:1\n    port: 8080\n",
+			errContains: "DNS label",
+		},
+		{
+			name:        "container name trailing hyphen",
+			configYAML:  "mcp_servers:\n  - name: srv-\n    type: container\n    image: img:1\n    port: 8080\n",
+			errContains: "start or end with a hyphen",
+		},
+		{
+			name:        "container name too long",
+			configYAML:  "mcp_servers:\n  - name: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n    type: container\n    image: img:1\n    port: 8080\n",
+			errContains: "1-63 characters",
+		},
+		{
+			name:        "oauth on container server",
+			configYAML:  "mcp_servers:\n  - name: a\n    type: container\n    image: img:1\n    port: 8080\n    oauth: true\n",
+			errContains: "oauth is only valid",
+		},
 	}
 
 	for _, tt := range tests {
@@ -274,4 +304,33 @@ func TestLoad_MCPServers_ValidationErrors(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.errContains)
 		})
 	}
+}
+
+func TestLoad_MCPServers_Container(t *testing.T) {
+	tmpDir := t.TempDir()
+	configYAML := `mcp_servers:
+  - name: native
+    type: container
+    image: ghcr.io/x/mcp:1
+    port: 9000
+    path: /mcp
+  - name: wrapped
+    type: container
+    command: my-mcp
+    args: ["--flag"]
+    mounts:
+      - "~/.config/gcloud:/creds:ro"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "config.yaml"), []byte(configYAML), 0o644))
+
+	got, err := Load(tmpDir)
+	require.NoError(t, err)
+	require.Len(t, got.MCPServers, 2)
+
+	assert.True(t, got.MCPServers[0].IsContainer())
+	assert.False(t, got.MCPServers[0].IsWrappedStdio())
+	assert.Equal(t, 9000, got.MCPServers[0].Port)
+
+	assert.True(t, got.MCPServers[1].IsWrappedStdio())
+	assert.Equal(t, []string{"~/.config/gcloud:/creds:ro"}, got.MCPServers[1].Mounts)
 }

--- a/internal/forge/config/config_test.go
+++ b/internal/forge/config/config_test.go
@@ -321,6 +321,7 @@ func TestLoad_MCPServers_Container(t *testing.T) {
 	configYAML := `mcp_servers:
   - name: native
     type: container
+    scope: session
     image: ghcr.io/x/mcp:1
     port: 9000
     path: /mcp
@@ -344,8 +345,10 @@ func TestLoad_MCPServers_Container(t *testing.T) {
 	assert.True(t, got.MCPServers[1].IsWrappedStdio())
 	assert.Equal(t, []string{"~/.config/gcloud:/creds:ro"}, got.MCPServers[1].Mounts)
 
-	// Scope: session by default, opt-in global.
+	// Explicit scope: session opts out of the default global scope.
 	assert.False(t, got.MCPServers[0].IsGlobal())
+	// No scope defaults to global.
+	assert.True(t, got.MCPServers[1].IsGlobal())
 }
 
 func TestLoad_MCPServers_GlobalScope(t *testing.T) {

--- a/internal/forge/config/config_test.go
+++ b/internal/forge/config/config_test.go
@@ -288,6 +288,16 @@ func TestLoad_MCPServers_ValidationErrors(t *testing.T) {
 			errContains: "1-63 characters",
 		},
 		{
+			name:        "scope on non-container server",
+			configYAML:  "mcp_servers:\n  - name: a\n    type: http\n    url: https://a.com\n    scope: global\n",
+			errContains: "scope is only valid for container servers",
+		},
+		{
+			name:        "invalid scope value",
+			configYAML:  "mcp_servers:\n  - name: a\n    type: container\n    image: img:1\n    port: 8080\n    scope: cluster\n",
+			errContains: "scope must be",
+		},
+		{
 			name:        "oauth on container server",
 			configYAML:  "mcp_servers:\n  - name: a\n    type: container\n    image: img:1\n    port: 8080\n    oauth: true\n",
 			errContains: "oauth is only valid",
@@ -333,4 +343,24 @@ func TestLoad_MCPServers_Container(t *testing.T) {
 
 	assert.True(t, got.MCPServers[1].IsWrappedStdio())
 	assert.Equal(t, []string{"~/.config/gcloud:/creds:ro"}, got.MCPServers[1].Mounts)
+
+	// Scope: session by default, opt-in global.
+	assert.False(t, got.MCPServers[0].IsGlobal())
+}
+
+func TestLoad_MCPServers_GlobalScope(t *testing.T) {
+	tmpDir := t.TempDir()
+	configYAML := `mcp_servers:
+  - name: gcloud
+    type: container
+    scope: global
+    command: npx
+    args: ["-y", "@google-cloud/gcloud-mcp"]
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "config.yaml"), []byte(configYAML), 0o644))
+	got, err := Load(tmpDir)
+	require.NoError(t, err)
+	require.Len(t, got.MCPServers, 1)
+	assert.True(t, got.MCPServers[0].IsGlobal())
+	assert.True(t, got.MCPServers[0].IsWrappedStdio())
 }

--- a/internal/forge/container/client.go
+++ b/internal/forge/container/client.go
@@ -699,6 +699,7 @@ func (c *Client) ListForgeContainers(ctx context.Context) ([]ContainerInfo, erro
 	filterArgs.Add("name", "forge-gateway-")
 	filterArgs.Add("name", "forge-github-mcp-")
 	filterArgs.Add("name", "forge-k8s-mcp")
+	filterArgs.Add("name", "forge-mcp-")
 
 	containers, err := c.docker.ContainerList(ctx, container.ListOptions{
 		All:     true,

--- a/internal/forge/container/client_test.go
+++ b/internal/forge/container/client_test.go
@@ -1247,6 +1247,7 @@ func TestListForgeContainers_Filters(t *testing.T) {
 			expectedFilters.Add("name", "forge-gateway-")
 			expectedFilters.Add("name", "forge-github-mcp-")
 			expectedFilters.Add("name", "forge-k8s-mcp")
+			expectedFilters.Add("name", "forge-mcp-")
 			assert.Equal(t, expectedFilters, opts.Filters)
 
 			return []container.Summary{}, nil

--- a/internal/forge/orchestrator.go
+++ b/internal/forge/orchestrator.go
@@ -269,6 +269,14 @@ func (o *Orchestrator) Start(ctx context.Context, opts StartOptions) (*Session, 
 		mcpServers["kubernetes"] = claudecode.MCPServerConfig{Type: "url", URL: "http://k8s-mcp:" + kube.MCPServerPort + "/mcp"}
 	}
 
+	// Merge user-configured custom MCP servers (e.g. a hosted Vercel MCP).
+	// ${VAR} references in URLs, headers, commands, args, and env are expanded
+	// against the host environment now so secrets stay out of config.yaml.
+	for _, s := range cfg.MCPServers {
+		mcpServers[s.Name] = customMCPServer(s)
+		o.Log("Custom MCP: %s", s.Name)
+	}
+
 	if err := claudecode.UpdateMCPServers(o.ConfigDir, mcpServers); err != nil {
 		o.Cleanup(ctx, sess)
 		return nil, fmt.Errorf("failed to update MCP settings: %w", err)
@@ -278,6 +286,13 @@ func (o *Orchestrator) Start(ctx context.Context, opts StartOptions) (*Session, 
 		o.Cleanup(ctx, sess)
 		return nil, fmt.Errorf("failed to register MCP servers in .claude.json: %w", err)
 	}
+
+	// Preflight OAuth-based MCP servers: the interactive OAuth flow cannot run
+	// inside the headless container, so warn (non-fatally) when a required token
+	// is missing or expired rather than letting the server silently fail to
+	// connect mid-session. Tokens are looked up in the same credentials file
+	// that is mounted into the container.
+	o.warnUnauthenticatedMCP(cfg)
 
 	// For fresh sessions, pin the Claude session ID so the resulting JSONL and
 	// the sidecar metadata file share a known identifier.
@@ -523,6 +538,76 @@ func readGHToken(ghConfigDir string) string {
 		return gh.OAuthToken
 	}
 	return ""
+}
+
+// customMCPServer converts a user-configured MCP server into the settings
+// shape written for Claude Code, expanding ${VAR} references in every string
+// field against the host environment.
+func customMCPServer(s config.MCPServerConfig) claudecode.MCPServerConfig {
+	out := claudecode.MCPServerConfig{Type: s.Type}
+	if s.IsStdio() {
+		out.Type = "stdio"
+		out.Command = os.ExpandEnv(s.Command)
+		for _, a := range s.Args {
+			out.Args = append(out.Args, os.ExpandEnv(a))
+		}
+		out.Env = expandEnvMap(s.Env)
+		return out
+	}
+
+	if out.Type == "" {
+		out.Type = "http"
+	}
+	out.URL = os.ExpandEnv(s.URL)
+	out.Headers = expandEnvMap(s.Headers)
+	return out
+}
+
+// expandEnvMap returns a copy of m with ${VAR} references in each value
+// expanded against the host environment. Returns nil for an empty map so the
+// omitempty JSON tags drop the field entirely.
+func expandEnvMap(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = os.ExpandEnv(v)
+	}
+	return out
+}
+
+// warnUnauthenticatedMCP checks each OAuth-based custom MCP server for a valid
+// stored token and logs a warning for any that is missing or expired. It never
+// fails the session — an unauthenticated server simply won't connect until the
+// user authenticates on the host.
+func (o *Orchestrator) warnUnauthenticatedMCP(cfg *config.Config) {
+	nowMs := time.Now().UnixMilli()
+	for _, s := range cfg.MCPServers {
+		if !s.OAuth {
+			continue
+		}
+		typ := s.Type
+		if typ == "" {
+			typ = "http"
+		}
+		url := os.ExpandEnv(s.URL)
+		// OAuth servers carry no static headers, so the lookup uses an empty set.
+		status, err := claudecode.CheckMCPOAuth(o.ClaudeDir, s.Name, typ, url, nil, nowMs)
+		if err != nil {
+			o.Log("Warning: could not check OAuth token for MCP %q: %v", s.Name, err)
+			continue
+		}
+		switch status {
+		case claudecode.MCPOAuthMissing:
+			o.Log("Warning: MCP server %q needs OAuth but no token was found; it will be unavailable this session.", s.Name)
+			o.Log("         Authenticate once on the host, then restart the session:")
+			o.Log("           claude mcp add --transport %s %s %s", typ, s.Name, url)
+			o.Log("           claude   # then run: /mcp -> %s -> Authenticate", s.Name)
+		case claudecode.MCPOAuthExpired:
+			o.Log("Warning: MCP server %q OAuth token is expired and not refreshable; re-authenticate on the host via 'claude' -> /mcp.", s.Name)
+		}
+	}
 }
 
 // startKubernetesMCP ensures the shared Kubernetes MCP service is running.

--- a/internal/forge/orchestrator.go
+++ b/internal/forge/orchestrator.go
@@ -263,9 +263,9 @@ func (o *Orchestrator) Start(ctx context.Context, opts StartOptions) (*Session, 
 		}
 	}
 
-	// Start custom "container" MCP servers as per-session sidecars before
+	// Start custom "container" MCP servers (per-session or global) before
 	// writing settings, so we only advertise the ones that actually came up.
-	sidecarRegs := o.startCustomSidecars(ctx, cfg, sess)
+	sidecarRegs, usedSharedMCP := o.startCustomSidecars(ctx, cfg, sess)
 
 	// Write MCP server config to settings.json for the agent
 	mcpServers := map[string]claudecode.MCPServerConfig{
@@ -407,9 +407,11 @@ func (o *Orchestrator) Start(ctx context.Context, opts StartOptions) (*Session, 
 		})
 	}
 
-	// Build extra networks for the agent (connect before start so DNS is ready)
+	// Build extra networks for the agent (connect before start so DNS is ready).
+	// The agent joins forge-shared when any shared service is running there:
+	// the Kubernetes MCP and/or global custom MCP sidecars.
 	var extraNetworks []container.NetworkAttachment
-	if k8sRunning {
+	if k8sRunning || usedSharedMCP {
 		extraNetworks = append(extraNetworks, container.NetworkAttachment{
 			NetworkName: "forge-shared",
 		})
@@ -598,80 +600,171 @@ func expandEnvMap(m map[string]string) map[string]string {
 // sidecar on the session network and returns the HTTP registrations for the
 // ones that came up. Failures are logged and skipped so a single bad server
 // doesn't abort the session (matching the Kubernetes MCP behavior).
-func (o *Orchestrator) startCustomSidecars(ctx context.Context, cfg *config.Config, sess *Session) map[string]claudecode.MCPServerConfig {
+func (o *Orchestrator) startCustomSidecars(ctx context.Context, cfg *config.Config, sess *Session) (map[string]claudecode.MCPServerConfig, bool) {
 	regs := map[string]claudecode.MCPServerConfig{}
+	usedShared := false
 	for _, s := range cfg.MCPServers {
 		if !s.IsContainer() {
 			continue
 		}
-
-		port := s.Port
-		if port == 0 {
-			port = config.DefaultMCPPort
-		}
-		path := s.Path
-		if path == "" {
-			path = config.DefaultMCPPath
-		}
-
-		image := s.Image
-		var cmd []string
-		if s.IsWrappedStdio() {
-			if image == "" {
-				image = config.DefaultMCPWrapperImage
+		var reg claudecode.MCPServerConfig
+		var ok bool
+		if s.IsGlobal() {
+			reg, ok = o.ensureGlobalSidecar(ctx, s)
+			if ok {
+				usedShared = true
 			}
-			cmd = supergatewayCmd(s, port, path)
 		} else {
-			// Native image that serves MCP over HTTP itself; pass through any args.
-			for _, a := range s.Args {
-				cmd = append(cmd, os.ExpandEnv(a))
-			}
+			reg, ok = o.startSessionSidecar(ctx, s, sess)
 		}
-
-		mounts, err := o.parseSidecarMounts(s.Mounts)
-		if err != nil {
-			o.Log("Warning: MCP sidecar %q: %v; skipping", s.Name, err)
-			continue
-		}
-
-		if exists, err := o.Containers.ImageExists(ctx, image); err == nil && !exists {
-			o.Log("Pulling image: %s", image)
-			if err := o.Containers.PullImage(ctx, image); err != nil {
-				o.Log("Warning: MCP sidecar %q: failed to pull image %s: %v; skipping", s.Name, image, err)
-				continue
-			}
-		}
-
-		containerName := fmt.Sprintf("forge-mcp-%s-%s-%s", s.Name, sess.ProjectID, sess.SessionID)
-		o.Log("Starting MCP sidecar: %s", s.Name)
-		id, err := o.Containers.StartSharedService(ctx, container.SharedServiceOptions{
-			Name:        containerName,
-			Image:       image,
-			NetworkName: sess.NetworkName,
-			Alias:       s.Name,
-			Env:         expandEnvMap(s.Env),
-			Mounts:      mounts,
-			Cmd:         cmd,
-		})
-		if err != nil {
-			o.Log("Warning: MCP sidecar %q failed to start: %v; skipping", s.Name, err)
-			continue
-		}
-		// Record for cleanup as soon as it exists, even if readiness fails.
-		sess.SidecarNames = append(sess.SidecarNames, containerName)
-
-		if err := o.Containers.WaitForReady(ctx, id, 60*time.Second); err != nil {
-			logs, _ := o.Containers.ContainerLogs(ctx, id)
-			o.Log("Warning: MCP sidecar %q not ready: %v; skipping\n%s", s.Name, err, logs)
-			continue
-		}
-
-		regs[s.Name] = claudecode.MCPServerConfig{
-			Type: "http",
-			URL:  fmt.Sprintf("http://%s:%d%s", s.Name, port, path),
+		if ok {
+			regs[s.Name] = reg
 		}
 	}
-	return regs
+	return regs, usedShared
+}
+
+// sidecarRuntime resolves the image, container command, port, path, and mounts
+// for a container MCP server, applying defaults and ${VAR} expansion.
+func (o *Orchestrator) sidecarRuntime(s config.MCPServerConfig) (image string, cmd []string, port int, path string, mounts []mount.Mount, err error) {
+	port = s.Port
+	if port == 0 {
+		port = config.DefaultMCPPort
+	}
+	path = s.Path
+	if path == "" {
+		path = config.DefaultMCPPath
+	}
+	image = s.Image
+	if s.IsWrappedStdio() {
+		if image == "" {
+			image = config.DefaultMCPWrapperImage
+		}
+		cmd = supergatewayCmd(s, port, path)
+	} else {
+		// Native image that serves MCP over HTTP itself; pass through any args.
+		for _, a := range s.Args {
+			cmd = append(cmd, os.ExpandEnv(a))
+		}
+	}
+	mounts, err = o.parseSidecarMounts(s.Mounts)
+	return
+}
+
+// ensureImage pulls image if it isn't present locally. Returns false (with a
+// warning) only when a needed pull fails.
+func (o *Orchestrator) ensureImage(ctx context.Context, name, image string) bool {
+	if exists, err := o.Containers.ImageExists(ctx, image); err == nil && !exists {
+		o.Log("Pulling image: %s", image)
+		if err := o.Containers.PullImage(ctx, image); err != nil {
+			o.Log("Warning: MCP sidecar %q: failed to pull image %s: %v; skipping", name, image, err)
+			return false
+		}
+	}
+	return true
+}
+
+// sidecarReg builds the HTTP registration for a sidecar reached at its alias.
+func sidecarReg(name string, port int, path string) claudecode.MCPServerConfig {
+	return claudecode.MCPServerConfig{
+		Type: "http",
+		URL:  fmt.Sprintf("http://%s:%d%s", name, port, path),
+	}
+}
+
+// startSessionSidecar starts a per-session container MCP server on the session
+// network and records it for cleanup. Returns the registration and whether it
+// came up.
+func (o *Orchestrator) startSessionSidecar(ctx context.Context, s config.MCPServerConfig, sess *Session) (claudecode.MCPServerConfig, bool) {
+	image, cmd, port, path, mounts, err := o.sidecarRuntime(s)
+	if err != nil {
+		o.Log("Warning: MCP sidecar %q: %v; skipping", s.Name, err)
+		return claudecode.MCPServerConfig{}, false
+	}
+	if !o.ensureImage(ctx, s.Name, image) {
+		return claudecode.MCPServerConfig{}, false
+	}
+
+	containerName := fmt.Sprintf("forge-mcp-%s-%s-%s", s.Name, sess.ProjectID, sess.SessionID)
+	o.Log("Starting MCP sidecar: %s", s.Name)
+	id, err := o.Containers.StartSharedService(ctx, container.SharedServiceOptions{
+		Name:        containerName,
+		Image:       image,
+		NetworkName: sess.NetworkName,
+		Alias:       s.Name,
+		Env:         expandEnvMap(s.Env),
+		Mounts:      mounts,
+		Cmd:         cmd,
+	})
+	if err != nil {
+		o.Log("Warning: MCP sidecar %q failed to start: %v; skipping", s.Name, err)
+		return claudecode.MCPServerConfig{}, false
+	}
+	// Record for cleanup as soon as it exists, even if readiness fails.
+	sess.SidecarNames = append(sess.SidecarNames, containerName)
+
+	if err := o.Containers.WaitForReady(ctx, id, 60*time.Second); err != nil {
+		logs, _ := o.Containers.ContainerLogs(ctx, id)
+		o.Log("Warning: MCP sidecar %q not ready: %v; skipping\n%s", s.Name, err, logs)
+		return claudecode.MCPServerConfig{}, false
+	}
+	return sidecarReg(s.Name, port, path), true
+}
+
+// globalSidecarName is the stable container name for a global (shared) MCP
+// server, independent of any session.
+func globalSidecarName(serverName string) string {
+	return "forge-mcp-global-" + serverName
+}
+
+// ensureGlobalSidecar starts a global container MCP server as a shared singleton
+// on the forge-shared network, reusing it if already running. Global servers are
+// not tracked for per-session cleanup; they persist across sessions and are
+// managed via RestartSharedMCP.
+func (o *Orchestrator) ensureGlobalSidecar(ctx context.Context, s config.MCPServerConfig) (claudecode.MCPServerConfig, bool) {
+	image, cmd, port, path, mounts, err := o.sidecarRuntime(s)
+	if err != nil {
+		o.Log("Warning: MCP sidecar %q: %v; skipping", s.Name, err)
+		return claudecode.MCPServerConfig{}, false
+	}
+
+	if _, err := o.Containers.EnsureSharedNetwork(ctx, "forge-shared"); err != nil {
+		o.Log("Warning: MCP sidecar %q: failed to ensure shared network: %v; skipping", s.Name, err)
+		return claudecode.MCPServerConfig{}, false
+	}
+
+	name := globalSidecarName(s.Name)
+	if running, err := o.Containers.IsContainerRunning(ctx, name); err == nil && running {
+		o.Log("Global MCP already running: %s", s.Name)
+		return sidecarReg(s.Name, port, path), true
+	}
+	// Remove a stale (crashed/exited) instance so we can recreate it.
+	_ = o.Containers.RemoveContainer(ctx, name)
+
+	if !o.ensureImage(ctx, s.Name, image) {
+		return claudecode.MCPServerConfig{}, false
+	}
+
+	o.Log("Starting global MCP: %s", s.Name)
+	id, err := o.Containers.StartSharedService(ctx, container.SharedServiceOptions{
+		Name:        name,
+		Image:       image,
+		NetworkName: "forge-shared",
+		Alias:       s.Name,
+		Env:         expandEnvMap(s.Env),
+		Mounts:      mounts,
+		Cmd:         cmd,
+	})
+	if err != nil {
+		o.Log("Warning: global MCP %q failed to start: %v; skipping", s.Name, err)
+		return claudecode.MCPServerConfig{}, false
+	}
+	if err := o.Containers.WaitForReady(ctx, id, 60*time.Second); err != nil {
+		logs, _ := o.Containers.ContainerLogs(ctx, id)
+		o.Log("Warning: global MCP %q not ready: %v; skipping\n%s", s.Name, err, logs)
+		return claudecode.MCPServerConfig{}, false
+	}
+	return sidecarReg(s.Name, port, path), true
 }
 
 // supergatewayCmd builds the container command that wraps a stdio MCP server in
@@ -841,24 +934,46 @@ func (o *Orchestrator) RestartSharedMCP(ctx context.Context) error {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 
-	if !cfg.Kubernetes.Enabled {
+	var globals []config.MCPServerConfig
+	for _, s := range cfg.MCPServers {
+		if s.IsGlobal() {
+			globals = append(globals, s)
+		}
+	}
+
+	if !cfg.Kubernetes.Enabled && len(globals) == 0 {
 		o.Log("No shared MCP servers configured.")
 		return nil
 	}
 
-	k8sMCPName := "forge-k8s-mcp"
-	running, err := o.Containers.IsContainerRunning(ctx, k8sMCPName)
-	if err != nil {
-		return fmt.Errorf("failed to check k8s-mcp status: %w", err)
-	}
-	if running {
-		o.Log("Stopping: %s", k8sMCPName)
-		_ = o.Containers.StopContainer(ctx, k8sMCPName)
-		_ = o.Containers.RemoveContainer(ctx, k8sMCPName)
+	if cfg.Kubernetes.Enabled {
+		k8sMCPName := "forge-k8s-mcp"
+		running, err := o.Containers.IsContainerRunning(ctx, k8sMCPName)
+		if err != nil {
+			return fmt.Errorf("failed to check k8s-mcp status: %w", err)
+		}
+		if running {
+			o.Log("Stopping: %s", k8sMCPName)
+			_ = o.Containers.StopContainer(ctx, k8sMCPName)
+			_ = o.Containers.RemoveContainer(ctx, k8sMCPName)
+		}
+		if err := o.startKubernetesMCP(ctx, cfg); err != nil {
+			return fmt.Errorf("failed to restart Kubernetes MCP: %w", err)
+		}
 	}
 
-	if err := o.startKubernetesMCP(ctx, cfg); err != nil {
-		return fmt.Errorf("failed to restart Kubernetes MCP: %w", err)
+	// Restart global custom MCP sidecars: stop the existing instance so
+	// ensureGlobalSidecar recreates it fresh.
+	for _, s := range globals {
+		name := globalSidecarName(s.Name)
+		if running, _ := o.Containers.IsContainerRunning(ctx, name); running {
+			o.Log("Stopping: %s", name)
+			_ = o.Containers.StopContainer(ctx, name)
+		}
+		_ = o.Containers.RemoveContainer(ctx, name)
+		if _, ok := o.ensureGlobalSidecar(ctx, s); !ok {
+			o.Log("Warning: failed to restart global MCP %q", s.Name)
+		}
 	}
 
 	return nil

--- a/internal/forge/orchestrator.go
+++ b/internal/forge/orchestrator.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -66,6 +67,7 @@ type Session struct {
 	NetworkName   string
 	SessionID     string
 	ProjectID     string
+	SidecarNames  []string // custom MCP sidecar container names, for cleanup
 }
 
 // Start creates a new claude-forge session: loads config, identifies the project,
@@ -261,6 +263,10 @@ func (o *Orchestrator) Start(ctx context.Context, opts StartOptions) (*Session, 
 		}
 	}
 
+	// Start custom "container" MCP servers as per-session sidecars before
+	// writing settings, so we only advertise the ones that actually came up.
+	sidecarRegs := o.startCustomSidecars(ctx, cfg, sess)
+
 	// Write MCP server config to settings.json for the agent
 	mcpServers := map[string]claudecode.MCPServerConfig{
 		"github": {Type: "url", URL: "http://github-mcp:8083/mcp"},
@@ -272,9 +278,16 @@ func (o *Orchestrator) Start(ctx context.Context, opts StartOptions) (*Session, 
 	// Merge user-configured custom MCP servers (e.g. a hosted Vercel MCP).
 	// ${VAR} references in URLs, headers, commands, args, and env are expanded
 	// against the host environment now so secrets stay out of config.yaml.
+	// Container servers are handled as sidecars above.
 	for _, s := range cfg.MCPServers {
+		if s.IsContainer() {
+			continue
+		}
 		mcpServers[s.Name] = customMCPServer(s)
 		o.Log("Custom MCP: %s", s.Name)
+	}
+	for name, reg := range sidecarRegs {
+		mcpServers[name] = reg
 	}
 
 	if err := claudecode.UpdateMCPServers(o.ConfigDir, mcpServers); err != nil {
@@ -448,6 +461,10 @@ func (o *Orchestrator) Cleanup(ctx context.Context, sess *Session) {
 	_ = o.Containers.RemoveContainer(ctx, sess.AgentName)
 	_ = o.Containers.StopContainer(ctx, sess.GitHubMCPName)
 	_ = o.Containers.RemoveContainer(ctx, sess.GitHubMCPName)
+	for _, name := range sess.SidecarNames {
+		_ = o.Containers.StopContainer(ctx, name)
+		_ = o.Containers.RemoveContainer(ctx, name)
+	}
 	_ = o.Containers.StopContainer(ctx, sess.GatewayName)
 	_ = o.Containers.RemoveContainer(ctx, sess.GatewayName)
 	_ = o.Containers.RemoveNetwork(ctx, sess.NetworkName)
@@ -575,6 +592,133 @@ func expandEnvMap(m map[string]string) map[string]string {
 		out[k] = os.ExpandEnv(v)
 	}
 	return out
+}
+
+// startCustomSidecars starts each type:"container" MCP server as a per-session
+// sidecar on the session network and returns the HTTP registrations for the
+// ones that came up. Failures are logged and skipped so a single bad server
+// doesn't abort the session (matching the Kubernetes MCP behavior).
+func (o *Orchestrator) startCustomSidecars(ctx context.Context, cfg *config.Config, sess *Session) map[string]claudecode.MCPServerConfig {
+	regs := map[string]claudecode.MCPServerConfig{}
+	for _, s := range cfg.MCPServers {
+		if !s.IsContainer() {
+			continue
+		}
+
+		port := s.Port
+		if port == 0 {
+			port = config.DefaultMCPPort
+		}
+		path := s.Path
+		if path == "" {
+			path = config.DefaultMCPPath
+		}
+
+		image := s.Image
+		var cmd []string
+		if s.IsWrappedStdio() {
+			if image == "" {
+				image = config.DefaultMCPWrapperImage
+			}
+			cmd = supergatewayCmd(s, port, path)
+		} else {
+			// Native image that serves MCP over HTTP itself; pass through any args.
+			for _, a := range s.Args {
+				cmd = append(cmd, os.ExpandEnv(a))
+			}
+		}
+
+		mounts, err := o.parseSidecarMounts(s.Mounts)
+		if err != nil {
+			o.Log("Warning: MCP sidecar %q: %v; skipping", s.Name, err)
+			continue
+		}
+
+		if exists, err := o.Containers.ImageExists(ctx, image); err == nil && !exists {
+			o.Log("Pulling image: %s", image)
+			if err := o.Containers.PullImage(ctx, image); err != nil {
+				o.Log("Warning: MCP sidecar %q: failed to pull image %s: %v; skipping", s.Name, image, err)
+				continue
+			}
+		}
+
+		containerName := fmt.Sprintf("forge-mcp-%s-%s-%s", s.Name, sess.ProjectID, sess.SessionID)
+		o.Log("Starting MCP sidecar: %s", s.Name)
+		id, err := o.Containers.StartSharedService(ctx, container.SharedServiceOptions{
+			Name:        containerName,
+			Image:       image,
+			NetworkName: sess.NetworkName,
+			Alias:       s.Name,
+			Env:         expandEnvMap(s.Env),
+			Mounts:      mounts,
+			Cmd:         cmd,
+		})
+		if err != nil {
+			o.Log("Warning: MCP sidecar %q failed to start: %v; skipping", s.Name, err)
+			continue
+		}
+		// Record for cleanup as soon as it exists, even if readiness fails.
+		sess.SidecarNames = append(sess.SidecarNames, containerName)
+
+		if err := o.Containers.WaitForReady(ctx, id, 60*time.Second); err != nil {
+			logs, _ := o.Containers.ContainerLogs(ctx, id)
+			o.Log("Warning: MCP sidecar %q not ready: %v; skipping\n%s", s.Name, err, logs)
+			continue
+		}
+
+		regs[s.Name] = claudecode.MCPServerConfig{
+			Type: "http",
+			URL:  fmt.Sprintf("http://%s:%d%s", s.Name, port, path),
+		}
+	}
+	return regs
+}
+
+// supergatewayCmd builds the container command that wraps a stdio MCP server in
+// supergateway's stdio→streamable-HTTP bridge. The child command inherits the
+// sidecar's environment, so secrets are passed via Env rather than a flag.
+func supergatewayCmd(s config.MCPServerConfig, port int, path string) []string {
+	child := os.ExpandEnv(s.Command)
+	for _, a := range s.Args {
+		child += " " + os.ExpandEnv(a)
+	}
+	return []string{
+		"npx", "-y", "supergateway",
+		"--stdio", child,
+		"--outputTransport", "streamableHttp",
+		"--port", strconv.Itoa(port),
+		"--streamableHttpPath", path,
+		"--healthEndpoint", "/healthz",
+	}
+}
+
+// parseSidecarMounts converts "host:container[:ro]" specs into bind mounts,
+// expanding ${VAR} and a leading ~/ against the host environment.
+func (o *Orchestrator) parseSidecarMounts(specs []string) ([]mount.Mount, error) {
+	var out []mount.Mount
+	for _, spec := range specs {
+		expanded := os.ExpandEnv(spec)
+		parts := strings.Split(expanded, ":")
+		if len(parts) < 2 || len(parts) > 3 {
+			return nil, fmt.Errorf("invalid mount %q: expected host:container[:ro]", spec)
+		}
+		src := parts[0]
+		if strings.HasPrefix(src, "~/") {
+			src = filepath.Join(o.HomeDir, src[2:])
+		}
+		src, err := filepath.Abs(src)
+		if err != nil {
+			return nil, fmt.Errorf("invalid mount source %q: %w", parts[0], err)
+		}
+		readOnly := len(parts) == 3 && parts[2] == "ro"
+		out = append(out, mount.Mount{
+			Type:     mount.TypeBind,
+			Source:   src,
+			Target:   parts[1],
+			ReadOnly: readOnly,
+		})
+	}
+	return out, nil
 }
 
 // warnUnauthenticatedMCP checks each OAuth-based custom MCP server for a valid
@@ -731,7 +875,13 @@ func (o *Orchestrator) Build(ctx context.Context) error {
 	if cfg.Kubernetes.Enabled {
 		images = append(images, cfg.Kubernetes.Image)
 	}
+	images = append(images, customSidecarImages(cfg)...)
+	seen := make(map[string]bool, len(images))
 	for _, img := range images {
+		if seen[img] {
+			continue
+		}
+		seen[img] = true
 		o.Log("Pulling image: %s", img)
 		if err := o.Containers.PullImage(ctx, img); err != nil {
 			return fmt.Errorf("failed to pull image %s: %w", img, err)
@@ -739,4 +889,24 @@ func (o *Orchestrator) Build(ctx context.Context) error {
 	}
 	o.Log("All images up to date.")
 	return nil
+}
+
+// customSidecarImages returns the images needed by type:"container" MCP servers,
+// substituting the default wrapper image for wrapped stdio servers without an
+// explicit image.
+func customSidecarImages(cfg *config.Config) []string {
+	var images []string
+	for _, s := range cfg.MCPServers {
+		if !s.IsContainer() {
+			continue
+		}
+		img := s.Image
+		if img == "" && s.IsWrappedStdio() {
+			img = config.DefaultMCPWrapperImage
+		}
+		if img != "" {
+			images = append(images, img)
+		}
+	}
+	return images
 }

--- a/internal/forge/orchestrator_test.go
+++ b/internal/forge/orchestrator_test.go
@@ -1727,7 +1727,7 @@ func TestStartCustomSidecars(t *testing.T) {
 
 		o := newOrch(t, mockCM)
 		s := sess()
-		regs := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
+		regs, _ := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
 			{Name: "gcp", Type: "container", Image: "ghcr.io/x/mcp:1", Port: 9000, Path: "/mcp"},
 		}}, s)
 
@@ -1749,7 +1749,7 @@ func TestStartCustomSidecars(t *testing.T) {
 
 		o := newOrch(t, mockCM)
 		s := sess()
-		regs := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
+		regs, _ := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
 			{Name: "tool", Type: "container", Command: "my-mcp", Args: []string{"--flag"}},
 		}}, s)
 
@@ -1769,7 +1769,7 @@ func TestStartCustomSidecars(t *testing.T) {
 
 		o := newOrch(t, mockCM)
 		s := sess()
-		regs := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
+		regs, _ := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
 			{Name: "svc", Type: "container", Image: "img:1", Port: 8080},
 		}}, s)
 		assert.Contains(t, regs, "svc")
@@ -1783,7 +1783,7 @@ func TestStartCustomSidecars(t *testing.T) {
 
 		o := newOrch(t, mockCM)
 		s := sess()
-		regs := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
+		regs, _ := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
 			{Name: "bad", Type: "container", Image: "img:1", Port: 8080},
 		}}, s)
 		assert.Empty(t, regs)
@@ -1800,7 +1800,7 @@ func TestStartCustomSidecars(t *testing.T) {
 
 		o := newOrch(t, mockCM)
 		s := sess()
-		regs := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
+		regs, _ := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
 			{Name: "slow", Type: "container", Image: "img:1", Port: 8080},
 		}}, s)
 		assert.Empty(t, regs)
@@ -1812,7 +1812,7 @@ func TestStartCustomSidecars(t *testing.T) {
 		mockCM := NewMockContainerManager(ctrl)
 		o := newOrch(t, mockCM)
 		s := sess()
-		regs := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
+		regs, _ := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
 			{Name: "remote", Type: "http", URL: "https://x.com"},
 			{Name: "local", Type: "stdio", Command: "x"},
 		}}, s)
@@ -1828,7 +1828,7 @@ func TestStartCustomSidecars_EdgeBranches(t *testing.T) {
 		// No Start/ImageExists expected — bails at mount parsing.
 		o := &Orchestrator{Containers: mockCM, HomeDir: t.TempDir(), Log: func(string, ...any) {}}
 		s := &Session{NetworkName: "net", ProjectID: "p", SessionID: "s"}
-		regs := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
+		regs, _ := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
 			{Name: "svc", Type: "container", Image: "img:1", Port: 8080, Mounts: []string{"bad"}},
 		}}, s)
 		assert.Empty(t, regs)
@@ -1843,9 +1843,135 @@ func TestStartCustomSidecars_EdgeBranches(t *testing.T) {
 		mockCM.EXPECT().WaitForReady(gomock.Any(), "id", gomock.Any()).Return(nil)
 		o := &Orchestrator{Containers: mockCM, HomeDir: t.TempDir(), Log: func(string, ...any) {}}
 		s := &Session{NetworkName: "net", ProjectID: "p", SessionID: "s"}
-		regs := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
+		regs, _ := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
 			{Name: "svc", Type: "container", Image: "img:1", Port: 8080},
 		}}, s)
 		assert.Contains(t, regs, "svc")
+	})
+}
+
+func TestStartCustomSidecars_GlobalScope(t *testing.T) {
+	t.Run("global sidecar runs as shared singleton and signals shared network", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockCM := NewMockContainerManager(ctrl)
+		var got container.SharedServiceOptions
+		mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net", nil)
+		mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-mcp-global-gcloud").Return(false, nil)
+		mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-mcp-global-gcloud").Return(nil)
+		mockCM.EXPECT().ImageExists(gomock.Any(), config.DefaultMCPWrapperImage).Return(true, nil)
+		mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ any, opts container.SharedServiceOptions) (string, error) { got = opts; return "gid", nil })
+		mockCM.EXPECT().WaitForReady(gomock.Any(), "gid", gomock.Any()).Return(nil)
+
+		o := &Orchestrator{Containers: mockCM, HomeDir: t.TempDir(), Log: func(string, ...any) {}}
+		s := &Session{NetworkName: "net", ProjectID: "p", SessionID: "s"}
+		regs, shared := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
+			{Name: "gcloud", Type: "container", Scope: "global", Command: "npx"},
+		}}, s)
+
+		assert.True(t, shared, "global sidecar should signal shared-network use")
+		assert.Equal(t, "http://gcloud:8080/mcp", regs["gcloud"].URL)
+		assert.Equal(t, "forge-shared", got.NetworkName)
+		assert.Equal(t, "forge-mcp-global-gcloud", got.Name)
+		// Global sidecars are not tracked for per-session cleanup.
+		assert.Empty(t, s.SidecarNames)
+	})
+
+	t.Run("global sidecar reused when already running", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockCM := NewMockContainerManager(ctrl)
+		mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net", nil)
+		mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-mcp-global-svc").Return(true, nil)
+		// No RemoveContainer/StartSharedService/WaitForReady — it's reused.
+
+		o := &Orchestrator{Containers: mockCM, HomeDir: t.TempDir(), Log: func(string, ...any) {}}
+		s := &Session{NetworkName: "net", ProjectID: "p", SessionID: "s"}
+		regs, shared := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
+			{Name: "svc", Type: "container", Scope: "global", Image: "img:1", Port: 9000},
+		}}, s)
+
+		assert.True(t, shared)
+		assert.Equal(t, "http://svc:9000/mcp", regs["svc"].URL)
+	})
+}
+
+func TestRestartSharedMCP_GlobalSidecar(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockCM := NewMockContainerManager(ctrl)
+	orch, homeDir := setupOrchestrator(t, mockCM)
+
+	configDir := filepath.Join(homeDir, ".config", "claude-forge")
+	configContent := `mcp_servers:
+  - name: gcloud
+    type: container
+    scope: global
+    command: npx
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configContent), 0o644))
+
+	name := "forge-mcp-global-gcloud"
+	gomock.InOrder(
+		mockCM.EXPECT().IsContainerRunning(gomock.Any(), name).Return(true, nil),  // RestartSharedMCP
+		mockCM.EXPECT().IsContainerRunning(gomock.Any(), name).Return(false, nil), // ensureGlobalSidecar
+	)
+	mockCM.EXPECT().StopContainer(gomock.Any(), name).Return(nil)
+	mockCM.EXPECT().RemoveContainer(gomock.Any(), name).Return(nil).Times(2)
+	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net", nil)
+	mockCM.EXPECT().ImageExists(gomock.Any(), config.DefaultMCPWrapperImage).Return(true, nil)
+	mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).Return("gid", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "gid", gomock.Any()).Return(nil)
+
+	require.NoError(t, orch.RestartSharedMCP(context.Background()))
+}
+
+func TestEnsureGlobalSidecar_Failures(t *testing.T) {
+	newOrch := func(mockCM *MockContainerManager) *Orchestrator {
+		return &Orchestrator{Containers: mockCM, HomeDir: t.TempDir(), Log: func(string, ...any) {}}
+	}
+
+	t.Run("mount error skips before touching containers", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockCM := NewMockContainerManager(ctrl)
+		// No container calls expected.
+		_, ok := newOrch(mockCM).ensureGlobalSidecar(context.Background(),
+			config.MCPServerConfig{Name: "g", Type: "container", Scope: "global", Image: "i:1", Port: 8080, Mounts: []string{"bad"}})
+		assert.False(t, ok)
+	})
+
+	t.Run("shared network error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockCM := NewMockContainerManager(ctrl)
+		mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("", assert.AnError)
+		_, ok := newOrch(mockCM).ensureGlobalSidecar(context.Background(),
+			config.MCPServerConfig{Name: "g", Type: "container", Scope: "global", Image: "i:1", Port: 8080})
+		assert.False(t, ok)
+	})
+
+	t.Run("start failure", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockCM := NewMockContainerManager(ctrl)
+		mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net", nil)
+		mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-mcp-global-g").Return(false, nil)
+		mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-mcp-global-g").Return(nil)
+		mockCM.EXPECT().ImageExists(gomock.Any(), "i:1").Return(true, nil)
+		mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).Return("", assert.AnError)
+		_, ok := newOrch(mockCM).ensureGlobalSidecar(context.Background(),
+			config.MCPServerConfig{Name: "g", Type: "container", Scope: "global", Image: "i:1", Port: 8080})
+		assert.False(t, ok)
+	})
+
+	t.Run("not ready", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockCM := NewMockContainerManager(ctrl)
+		mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net", nil)
+		mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-mcp-global-g").Return(false, nil)
+		mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-mcp-global-g").Return(nil)
+		mockCM.EXPECT().ImageExists(gomock.Any(), "i:1").Return(true, nil)
+		mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).Return("id", nil)
+		mockCM.EXPECT().WaitForReady(gomock.Any(), "id", gomock.Any()).Return(assert.AnError)
+		mockCM.EXPECT().ContainerLogs(gomock.Any(), "id").Return("boom", nil)
+		_, ok := newOrch(mockCM).ensureGlobalSidecar(context.Background(),
+			config.MCPServerConfig{Name: "g", Type: "container", Scope: "global", Image: "i:1", Port: 8080})
+		assert.False(t, ok)
 	})
 }

--- a/internal/forge/orchestrator_test.go
+++ b/internal/forge/orchestrator_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/michael-freling/claude-forge/internal/forge/claudecode"
 	"github.com/michael-freling/claude-forge/internal/forge/config"
 	"github.com/michael-freling/claude-forge/internal/forge/container"
 	"github.com/michael-freling/claude-forge/internal/forge/session"
@@ -1528,4 +1529,129 @@ func TestReadGHToken(t *testing.T) {
 		token := readGHToken(dir)
 		assert.Empty(t, token)
 	})
+}
+
+func TestCustomMCPServer(t *testing.T) {
+	t.Run("remote server expands url and header vars", func(t *testing.T) {
+		t.Setenv("VERCEL_TOKEN", "secret-token")
+		out := customMCPServer(config.MCPServerConfig{
+			Name:    "vercel",
+			Type:    "http",
+			URL:     "https://mcp.vercel.com/${VERCEL_TOKEN}",
+			Headers: map[string]string{"Authorization": "Bearer ${VERCEL_TOKEN}"},
+		})
+		assert.Equal(t, "http", out.Type)
+		assert.Equal(t, "https://mcp.vercel.com/secret-token", out.URL)
+		assert.Equal(t, "Bearer secret-token", out.Headers["Authorization"])
+		assert.Empty(t, out.Command)
+	})
+
+	t.Run("remote server defaults type to http", func(t *testing.T) {
+		out := customMCPServer(config.MCPServerConfig{Name: "x", URL: "https://x.com"})
+		assert.Equal(t, "http", out.Type)
+	})
+
+	t.Run("stdio server expands command args env", func(t *testing.T) {
+		t.Setenv("MY_KEY", "k123")
+		out := customMCPServer(config.MCPServerConfig{
+			Name:    "local",
+			Type:    "stdio",
+			Command: "my-mcp",
+			Args:    []string{"--token", "${MY_KEY}"},
+			Env:     map[string]string{"API_KEY": "${MY_KEY}"},
+		})
+		assert.Equal(t, "stdio", out.Type)
+		assert.Equal(t, "my-mcp", out.Command)
+		assert.Equal(t, []string{"--token", "k123"}, out.Args)
+		assert.Equal(t, "k123", out.Env["API_KEY"])
+		assert.Empty(t, out.URL)
+	})
+
+	t.Run("empty maps become nil", func(t *testing.T) {
+		out := customMCPServer(config.MCPServerConfig{Name: "x", URL: "https://x.com"})
+		assert.Nil(t, out.Headers)
+	})
+}
+
+func TestWarnUnauthenticatedMCP(t *testing.T) {
+	newOrch := func(t *testing.T) (*Orchestrator, *[]string) {
+		t.Helper()
+		claudeDir := t.TempDir()
+		var logs []string
+		o := &Orchestrator{
+			ClaudeDir: claudeDir,
+			Log:       func(format string, args ...any) { logs = append(logs, fmt.Sprintf(format, args...)) },
+		}
+		return o, &logs
+	}
+
+	writeCreds := func(t *testing.T, dir, body string) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(body), 0o600))
+	}
+
+	joined := func(logs []string) string { return strings.Join(logs, "\n") }
+
+	t.Run("non-oauth servers are never checked", func(t *testing.T) {
+		o, logs := newOrch(t)
+		o.warnUnauthenticatedMCP(&config.Config{MCPServers: []config.MCPServerConfig{
+			{Name: "public", Type: "http", URL: "https://x.com"},
+			{Name: "tool", Type: "stdio", Command: "x"},
+		}})
+		assert.Empty(t, *logs)
+	})
+
+	t.Run("warns when oauth token missing", func(t *testing.T) {
+		o, logs := newOrch(t)
+		o.warnUnauthenticatedMCP(&config.Config{MCPServers: []config.MCPServerConfig{
+			{Name: "vercel", Type: "http", URL: "https://mcp.vercel.com", OAuth: true},
+		}})
+		assert.Contains(t, joined(*logs), `MCP server "vercel" needs OAuth`)
+		assert.Contains(t, joined(*logs), "claude mcp add --transport http vercel https://mcp.vercel.com")
+	})
+
+	t.Run("silent when a valid token is present", func(t *testing.T) {
+		o, logs := newOrch(t)
+		key := claudecode.MCPOAuthKey("vercel", "http", "https://mcp.vercel.com", nil)
+		writeCreds(t, o.ClaudeDir, fmt.Sprintf(`{"mcpOAuth":{%q:{"accessToken":"a","refreshToken":"r"}}}`, key))
+		o.warnUnauthenticatedMCP(&config.Config{MCPServers: []config.MCPServerConfig{
+			{Name: "vercel", Type: "http", URL: "https://mcp.vercel.com", OAuth: true},
+		}})
+		assert.Empty(t, *logs)
+	})
+
+	t.Run("warns when token expired", func(t *testing.T) {
+		o, logs := newOrch(t)
+		key := claudecode.MCPOAuthKey("vercel", "http", "https://mcp.vercel.com", nil)
+		writeCreds(t, o.ClaudeDir, fmt.Sprintf(`{"mcpOAuth":{%q:{"accessToken":"a","expiresAt":1}}}`, key))
+		o.warnUnauthenticatedMCP(&config.Config{MCPServers: []config.MCPServerConfig{
+			{Name: "vercel", Type: "http", URL: "https://mcp.vercel.com", OAuth: true},
+		}})
+		assert.Contains(t, joined(*logs), "expired")
+	})
+
+	t.Run("expands env vars in url", func(t *testing.T) {
+		o, logs := newOrch(t)
+		t.Setenv("MCP_HOST", "mcp.vercel.com")
+		o.warnUnauthenticatedMCP(&config.Config{MCPServers: []config.MCPServerConfig{
+			{Name: "vercel", Type: "http", URL: "https://${MCP_HOST}", OAuth: true},
+		}})
+		assert.Contains(t, joined(*logs), "https://mcp.vercel.com")
+	})
+}
+
+func TestWarnUnauthenticatedMCP_ReadError(t *testing.T) {
+	claudeDir := t.TempDir()
+	// Make .credentials.json a directory so ReadFile fails (not IsNotExist).
+	require.NoError(t, os.MkdirAll(filepath.Join(claudeDir, ".credentials.json"), 0o755))
+
+	var logs []string
+	o := &Orchestrator{
+		ClaudeDir: claudeDir,
+		Log:       func(format string, args ...any) { logs = append(logs, fmt.Sprintf(format, args...)) },
+	}
+	o.warnUnauthenticatedMCP(&config.Config{MCPServers: []config.MCPServerConfig{
+		{Name: "vercel", Type: "http", URL: "https://mcp.vercel.com", OAuth: true},
+	}})
+	assert.Contains(t, strings.Join(logs, "\n"), "could not check OAuth token")
 }

--- a/internal/forge/orchestrator_test.go
+++ b/internal/forge/orchestrator_test.go
@@ -1655,3 +1655,197 @@ func TestWarnUnauthenticatedMCP_ReadError(t *testing.T) {
 	}})
 	assert.Contains(t, strings.Join(logs, "\n"), "could not check OAuth token")
 }
+
+func TestSupergatewayCmd(t *testing.T) {
+	t.Setenv("TOK", "secret")
+	cmd := supergatewayCmd(config.MCPServerConfig{
+		Command: "npx",
+		Args:    []string{"-y", "@google-cloud/gcloud-mcp", "--token", "${TOK}"},
+	}, 8080, "/mcp")
+	assert.Equal(t, []string{
+		"npx", "-y", "supergateway",
+		"--stdio", "npx -y @google-cloud/gcloud-mcp --token secret",
+		"--outputTransport", "streamableHttp",
+		"--port", "8080",
+		"--streamableHttpPath", "/mcp",
+		"--healthEndpoint", "/healthz",
+	}, cmd)
+}
+
+func TestParseSidecarMounts(t *testing.T) {
+	home := t.TempDir()
+	o := &Orchestrator{HomeDir: home}
+
+	t.Run("tilde and ro", func(t *testing.T) {
+		m, err := o.parseSidecarMounts([]string{"~/.config/gcloud:/creds:ro"})
+		require.NoError(t, err)
+		require.Len(t, m, 1)
+		assert.Equal(t, filepath.Join(home, ".config/gcloud"), m[0].Source)
+		assert.Equal(t, "/creds", m[0].Target)
+		assert.True(t, m[0].ReadOnly)
+	})
+
+	t.Run("env expansion, read-write", func(t *testing.T) {
+		t.Setenv("SRC", "/tmp/data")
+		m, err := o.parseSidecarMounts([]string{"${SRC}:/data"})
+		require.NoError(t, err)
+		assert.Equal(t, "/tmp/data", m[0].Source)
+		assert.False(t, m[0].ReadOnly)
+	})
+
+	t.Run("invalid spec", func(t *testing.T) {
+		_, err := o.parseSidecarMounts([]string{"justonepart"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected host:container")
+	})
+}
+
+func TestCustomSidecarImages(t *testing.T) {
+	cfg := &config.Config{MCPServers: []config.MCPServerConfig{
+		{Name: "remote", Type: "http", URL: "https://x.com"},
+		{Name: "native", Type: "container", Image: "ghcr.io/x/mcp:1", Port: 8080},
+		{Name: "wrapped", Type: "container", Command: "npx"}, // default wrapper image
+		{Name: "wrapped2", Type: "container", Image: "custom:1", Command: "x"},
+	}}
+	assert.Equal(t, []string{"ghcr.io/x/mcp:1", config.DefaultMCPWrapperImage, "custom:1"}, customSidecarImages(cfg))
+}
+
+func TestStartCustomSidecars(t *testing.T) {
+	newOrch := func(t *testing.T, mockCM *MockContainerManager) *Orchestrator {
+		return &Orchestrator{Containers: mockCM, HomeDir: t.TempDir(), Log: func(string, ...any) {}}
+	}
+	sess := func() *Session { return &Session{NetworkName: "net", ProjectID: "proj", SessionID: "sess"} }
+
+	t.Run("native container registers http url", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockCM := NewMockContainerManager(ctrl)
+		var got container.SharedServiceOptions
+		mockCM.EXPECT().ImageExists(gomock.Any(), "ghcr.io/x/mcp:1").Return(true, nil)
+		mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ any, opts container.SharedServiceOptions) (string, error) { got = opts; return "id1", nil })
+		mockCM.EXPECT().WaitForReady(gomock.Any(), "id1", gomock.Any()).Return(nil)
+
+		o := newOrch(t, mockCM)
+		s := sess()
+		regs := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
+			{Name: "gcp", Type: "container", Image: "ghcr.io/x/mcp:1", Port: 9000, Path: "/mcp"},
+		}}, s)
+
+		assert.Equal(t, "http://gcp:9000/mcp", regs["gcp"].URL)
+		assert.Equal(t, "http", regs["gcp"].Type)
+		assert.Equal(t, []string{"forge-mcp-gcp-proj-sess"}, s.SidecarNames)
+		assert.Equal(t, "net", got.NetworkName)
+		assert.Equal(t, "gcp", got.Alias)
+	})
+
+	t.Run("wrapped stdio uses default image and bridge cmd", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockCM := NewMockContainerManager(ctrl)
+		var got container.SharedServiceOptions
+		mockCM.EXPECT().ImageExists(gomock.Any(), config.DefaultMCPWrapperImage).Return(true, nil)
+		mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ any, opts container.SharedServiceOptions) (string, error) { got = opts; return "id2", nil })
+		mockCM.EXPECT().WaitForReady(gomock.Any(), "id2", gomock.Any()).Return(nil)
+
+		o := newOrch(t, mockCM)
+		s := sess()
+		regs := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
+			{Name: "tool", Type: "container", Command: "my-mcp", Args: []string{"--flag"}},
+		}}, s)
+
+		assert.Equal(t, "http://tool:8080/mcp", regs["tool"].URL)
+		assert.Equal(t, config.DefaultMCPWrapperImage, got.Image)
+		assert.Contains(t, got.Cmd, "supergateway")
+		assert.Contains(t, got.Cmd, "my-mcp --flag")
+	})
+
+	t.Run("pulls image when missing", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockCM := NewMockContainerManager(ctrl)
+		mockCM.EXPECT().ImageExists(gomock.Any(), "img:1").Return(false, nil)
+		mockCM.EXPECT().PullImage(gomock.Any(), "img:1").Return(nil)
+		mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).Return("id3", nil)
+		mockCM.EXPECT().WaitForReady(gomock.Any(), "id3", gomock.Any()).Return(nil)
+
+		o := newOrch(t, mockCM)
+		s := sess()
+		regs := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
+			{Name: "svc", Type: "container", Image: "img:1", Port: 8080},
+		}}, s)
+		assert.Contains(t, regs, "svc")
+	})
+
+	t.Run("start failure is non-fatal and unregistered", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockCM := NewMockContainerManager(ctrl)
+		mockCM.EXPECT().ImageExists(gomock.Any(), gomock.Any()).Return(true, nil)
+		mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).Return("", assert.AnError)
+
+		o := newOrch(t, mockCM)
+		s := sess()
+		regs := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
+			{Name: "bad", Type: "container", Image: "img:1", Port: 8080},
+		}}, s)
+		assert.Empty(t, regs)
+		assert.Empty(t, s.SidecarNames)
+	})
+
+	t.Run("not-ready is skipped but recorded for cleanup", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockCM := NewMockContainerManager(ctrl)
+		mockCM.EXPECT().ImageExists(gomock.Any(), gomock.Any()).Return(true, nil)
+		mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).Return("id4", nil)
+		mockCM.EXPECT().WaitForReady(gomock.Any(), "id4", gomock.Any()).Return(assert.AnError)
+		mockCM.EXPECT().ContainerLogs(gomock.Any(), "id4").Return("boom", nil)
+
+		o := newOrch(t, mockCM)
+		s := sess()
+		regs := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
+			{Name: "slow", Type: "container", Image: "img:1", Port: 8080},
+		}}, s)
+		assert.Empty(t, regs)
+		assert.Equal(t, []string{"forge-mcp-slow-proj-sess"}, s.SidecarNames)
+	})
+
+	t.Run("non-container servers are ignored", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockCM := NewMockContainerManager(ctrl)
+		o := newOrch(t, mockCM)
+		s := sess()
+		regs := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
+			{Name: "remote", Type: "http", URL: "https://x.com"},
+			{Name: "local", Type: "stdio", Command: "x"},
+		}}, s)
+		assert.Empty(t, regs)
+		assert.Empty(t, s.SidecarNames)
+	})
+}
+
+func TestStartCustomSidecars_EdgeBranches(t *testing.T) {
+	t.Run("invalid mount skips server", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockCM := NewMockContainerManager(ctrl)
+		// No Start/ImageExists expected — bails at mount parsing.
+		o := &Orchestrator{Containers: mockCM, HomeDir: t.TempDir(), Log: func(string, ...any) {}}
+		s := &Session{NetworkName: "net", ProjectID: "p", SessionID: "s"}
+		regs := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
+			{Name: "svc", Type: "container", Image: "img:1", Port: 8080, Mounts: []string{"bad"}},
+		}}, s)
+		assert.Empty(t, regs)
+		assert.Empty(t, s.SidecarNames)
+	})
+
+	t.Run("image check error still attempts start", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockCM := NewMockContainerManager(ctrl)
+		mockCM.EXPECT().ImageExists(gomock.Any(), "img:1").Return(false, assert.AnError)
+		mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).Return("id", nil)
+		mockCM.EXPECT().WaitForReady(gomock.Any(), "id", gomock.Any()).Return(nil)
+		o := &Orchestrator{Containers: mockCM, HomeDir: t.TempDir(), Log: func(string, ...any) {}}
+		s := &Session{NetworkName: "net", ProjectID: "p", SessionID: "s"}
+		regs := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
+			{Name: "svc", Type: "container", Image: "img:1", Port: 8080},
+		}}, s)
+		assert.Contains(t, regs, "svc")
+	})
+}

--- a/internal/forge/orchestrator_test.go
+++ b/internal/forge/orchestrator_test.go
@@ -1703,9 +1703,9 @@ func TestParseSidecarMounts(t *testing.T) {
 func TestCustomSidecarImages(t *testing.T) {
 	cfg := &config.Config{MCPServers: []config.MCPServerConfig{
 		{Name: "remote", Type: "http", URL: "https://x.com"},
-		{Name: "native", Type: "container", Image: "ghcr.io/x/mcp:1", Port: 8080},
-		{Name: "wrapped", Type: "container", Command: "npx"}, // default wrapper image
-		{Name: "wrapped2", Type: "container", Image: "custom:1", Command: "x"},
+		{Name: "native", Type: "container", Scope: "session", Image: "ghcr.io/x/mcp:1", Port: 8080},
+		{Name: "wrapped", Type: "container", Scope: "session", Command: "npx"}, // default wrapper image
+		{Name: "wrapped2", Type: "container", Scope: "session", Image: "custom:1", Command: "x"},
 	}}
 	assert.Equal(t, []string{"ghcr.io/x/mcp:1", config.DefaultMCPWrapperImage, "custom:1"}, customSidecarImages(cfg))
 }
@@ -1728,7 +1728,7 @@ func TestStartCustomSidecars(t *testing.T) {
 		o := newOrch(t, mockCM)
 		s := sess()
 		regs, _ := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
-			{Name: "gcp", Type: "container", Image: "ghcr.io/x/mcp:1", Port: 9000, Path: "/mcp"},
+			{Name: "gcp", Type: "container", Scope: "session", Image: "ghcr.io/x/mcp:1", Port: 9000, Path: "/mcp"},
 		}}, s)
 
 		assert.Equal(t, "http://gcp:9000/mcp", regs["gcp"].URL)
@@ -1750,7 +1750,7 @@ func TestStartCustomSidecars(t *testing.T) {
 		o := newOrch(t, mockCM)
 		s := sess()
 		regs, _ := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
-			{Name: "tool", Type: "container", Command: "my-mcp", Args: []string{"--flag"}},
+			{Name: "tool", Type: "container", Scope: "session", Command: "my-mcp", Args: []string{"--flag"}},
 		}}, s)
 
 		assert.Equal(t, "http://tool:8080/mcp", regs["tool"].URL)
@@ -1770,7 +1770,7 @@ func TestStartCustomSidecars(t *testing.T) {
 		o := newOrch(t, mockCM)
 		s := sess()
 		regs, _ := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
-			{Name: "svc", Type: "container", Image: "img:1", Port: 8080},
+			{Name: "svc", Type: "container", Scope: "session", Image: "img:1", Port: 8080},
 		}}, s)
 		assert.Contains(t, regs, "svc")
 	})
@@ -1784,7 +1784,7 @@ func TestStartCustomSidecars(t *testing.T) {
 		o := newOrch(t, mockCM)
 		s := sess()
 		regs, _ := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
-			{Name: "bad", Type: "container", Image: "img:1", Port: 8080},
+			{Name: "bad", Type: "container", Scope: "session", Image: "img:1", Port: 8080},
 		}}, s)
 		assert.Empty(t, regs)
 		assert.Empty(t, s.SidecarNames)
@@ -1801,7 +1801,7 @@ func TestStartCustomSidecars(t *testing.T) {
 		o := newOrch(t, mockCM)
 		s := sess()
 		regs, _ := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
-			{Name: "slow", Type: "container", Image: "img:1", Port: 8080},
+			{Name: "slow", Type: "container", Scope: "session", Image: "img:1", Port: 8080},
 		}}, s)
 		assert.Empty(t, regs)
 		assert.Equal(t, []string{"forge-mcp-slow-proj-sess"}, s.SidecarNames)
@@ -1829,7 +1829,7 @@ func TestStartCustomSidecars_EdgeBranches(t *testing.T) {
 		o := &Orchestrator{Containers: mockCM, HomeDir: t.TempDir(), Log: func(string, ...any) {}}
 		s := &Session{NetworkName: "net", ProjectID: "p", SessionID: "s"}
 		regs, _ := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
-			{Name: "svc", Type: "container", Image: "img:1", Port: 8080, Mounts: []string{"bad"}},
+			{Name: "svc", Type: "container", Scope: "session", Image: "img:1", Port: 8080, Mounts: []string{"bad"}},
 		}}, s)
 		assert.Empty(t, regs)
 		assert.Empty(t, s.SidecarNames)
@@ -1844,7 +1844,7 @@ func TestStartCustomSidecars_EdgeBranches(t *testing.T) {
 		o := &Orchestrator{Containers: mockCM, HomeDir: t.TempDir(), Log: func(string, ...any) {}}
 		s := &Session{NetworkName: "net", ProjectID: "p", SessionID: "s"}
 		regs, _ := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
-			{Name: "svc", Type: "container", Image: "img:1", Port: 8080},
+			{Name: "svc", Type: "container", Scope: "session", Image: "img:1", Port: 8080},
 		}}, s)
 		assert.Contains(t, regs, "svc")
 	})
@@ -1875,6 +1875,27 @@ func TestStartCustomSidecars_GlobalScope(t *testing.T) {
 		assert.Equal(t, "forge-mcp-global-gcloud", got.Name)
 		// Global sidecars are not tracked for per-session cleanup.
 		assert.Empty(t, s.SidecarNames)
+	})
+
+	t.Run("no scope defaults to global", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockCM := NewMockContainerManager(ctrl)
+		mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net", nil)
+		mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-mcp-global-svc").Return(false, nil)
+		mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-mcp-global-svc").Return(nil)
+		mockCM.EXPECT().ImageExists(gomock.Any(), "img:1").Return(true, nil)
+		mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).Return("id", nil)
+		mockCM.EXPECT().WaitForReady(gomock.Any(), "id", gomock.Any()).Return(nil)
+
+		o := &Orchestrator{Containers: mockCM, HomeDir: t.TempDir(), Log: func(string, ...any) {}}
+		s := &Session{NetworkName: "net", ProjectID: "p", SessionID: "s"}
+		regs, shared := o.startCustomSidecars(context.Background(), &config.Config{MCPServers: []config.MCPServerConfig{
+			{Name: "svc", Type: "container", Image: "img:1", Port: 8080}, // no scope
+		}}, s)
+
+		assert.True(t, shared)
+		assert.Contains(t, regs, "svc")
+		assert.Empty(t, s.SidecarNames, "global sidecars are not tracked for per-session cleanup")
 	})
 
 	t.Run("global sidecar reused when already running", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a general `mcp_servers` list to `config.yaml` so any MCP server can be exposed to the agent — not just the built-in github/kubernetes ones — covering every way an MCP server can run. `${VAR}` references in string fields are expanded from the host environment at session start, keeping secrets out of the file.

- **Remote** (`type: http`/`sse`) — connect to a URL with optional `headers`. For hosted OAuth servers (e.g. Vercel), `oauth: true` triggers a **preflight**: claude-forge reproduces Claude Code's own `mcpOAuth` credential-map key (`name|sha256(JSON.stringify({type,url,headers}))[:16]`) and, at session start, warns (non-blocking) when the token in the mounted `~/.claude/.credentials.json` is missing or expired. Verified from inside the agent container that outbound HTTPS to remote MCP endpoints works (the git gateway only proxies git).
- **Stdio** (`type: stdio`) — a command Claude Code spawns inside the agent container.
- **Container** (`type: container`) — claude-forge runs the server as a **sidecar** on the Docker network, reached at `http://<name>:<port><path>`. Either a native image that serves MCP over HTTP (`image` + `port`), or a **wrapped stdio** command bridged to HTTP via [supergateway](https://github.com/supercorp-ai/supergateway) (default base image `node:22-slim`, `env`/`mounts` supported). This lets any locally-hostable MCP server run without baking it into the agent image.
- **Scope** (`scope:`, container only) — `global` (**default**) runs one shared instance reused across all sessions (like the Kubernetes MCP); `session` runs a per-session sidecar for isolation. Remote servers are inherently global (no container). Custom sidecars now appear in `claude-forge status`, and `mcp restart` restarts global ones.

## Changes
- **config**: `MCPServerConfig` (http/sse/stdio/container) + validation (unique/DNS-safe names, no shadowing built-ins, transport- and scope-appropriate fields)
- **claudecode**: settings/`.claude.json` writers emit headers/command/args/env; `CheckMCPOAuth`/`MCPOAuthKey` preflight helpers
- **orchestrator**: merge custom servers with env expansion; per-session and global sidecar lifecycle (`startCustomSidecars`, `ensureGlobalSidecar`, `supergatewayCmd`); OAuth warnings; agent joins `forge-shared` when a global sidecar runs; `RestartSharedMCP` covers global sidecars
- **container**: `ListForgeContainers` includes `forge-mcp-*`
- **docs**: `init` template + README

## Testing
- `go test ./...` passes; new unit tests cover OAuth key derivation (against a computed reference vector) and all status branches, sidecar start/reuse/failure/not-ready paths for both scopes, scope/config validation, and env expansion. Total coverage **91.1%** (≥90% gate); `go vet` + `gofmt` clean.

## Notes / limitations
- **Not exercised end-to-end against real Docker** (unavailable in the dev environment) — the sidecar/network lifecycle and supergateway flags are unit-tested against the mock container manager. A `forge_e2e` test that starts a real `type: container` sidecar (both scopes) is the recommended follow-up before merge.
- OAuth token carry-over relies on host and container sharing the file-based credential store (Linux/WSL); on macOS the token lives in the Keychain, not the mounted file. Documented in the README.
- A default-`global` container server is shared across projects and outlives sessions (managed via `mcp restart`); use `scope: session` for isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)