### PR TITLE
fix: skip installed plugins at session start and disable auto-updater

### DIFF
--- a/cmd/claude-forge/main.go
+++ b/cmd/claude-forge/main.go
@@ -817,7 +817,7 @@ var syncHostPlugins = func(homeDir string, force bool) error {
 			if err := enablePluginsInSettings(configDir, syncPlugins); err != nil {
 				return fmt.Errorf("failed to update settings: %w", err)
 			}
-			fmt.Printf("All %d plugins already installed.\n", len(syncPlugins))
+			fmt.Printf("All %d plugins already installed (run \"claude-forge plugins sync\" to update them).\n", len(syncPlugins))
 			return nil
 		}
 	}

--- a/cmd/claude-forge/main.go
+++ b/cmd/claude-forge/main.go
@@ -813,48 +813,45 @@ var syncHostPlugins = func(homeDir string, force bool) error {
 				installPlugins = append(installPlugins, plugin)
 			}
 		}
-		if len(installPlugins) == 0 {
-			if err := enablePluginsInSettings(configDir, syncPlugins); err != nil {
-				return fmt.Errorf("failed to update settings: %w", err)
-			}
-			fmt.Printf("All %d plugins already installed (run \"claude-forge plugins sync\" to update them).\n", len(syncPlugins))
-			return nil
+	}
+
+	if len(installPlugins) == 0 {
+		fmt.Printf("All %d plugins already installed (run \"claude-forge plugins sync\" to update them).\n", len(syncPlugins))
+	} else {
+		containerName := "forge-plugins-sync"
+		fmt.Printf("Syncing %d of %d plugins...\n", len(installPlugins), len(syncPlugins))
+
+		// Start a temporary container with the plugins dir mounted
+		uid := os.Getuid()
+		gid := os.Getgid()
+		runArgs := []string{
+			"run", "--rm", "--name", containerName,
+			"-e", fmt.Sprintf("FORGE_UID=%d", uid),
+			"-e", fmt.Sprintf("FORGE_GID=%d", gid),
+			"-e", "DISABLE_AUTOUPDATER=1",
+			"-v", pluginsDir + ":/home/user/.claude/plugins",
 		}
-	}
 
-	containerName := "forge-plugins-sync"
-	fmt.Printf("Syncing %d of %d plugins...\n", len(installPlugins), len(syncPlugins))
+		// Build commands: add marketplaces, update, then install each plugin
+		var installCmds []string
+		for _, src := range mpInfo.Sources {
+			installCmds = append(installCmds, fmt.Sprintf("claude plugins marketplace add %s || true", src))
+		}
+		installCmds = append(installCmds, "claude plugins marketplace update")
+		for _, plugin := range installPlugins {
+			installCmds = append(installCmds, fmt.Sprintf("claude plugins install %s || true", plugin))
+		}
+		shellCmd := strings.Join(installCmds, " && ")
 
-	// Start a temporary container with the plugins dir mounted
-	uid := os.Getuid()
-	gid := os.Getgid()
-	runArgs := []string{
-		"run", "--rm", "--name", containerName,
-		"-e", fmt.Sprintf("FORGE_UID=%d", uid),
-		"-e", fmt.Sprintf("FORGE_GID=%d", gid),
-		"-e", "DISABLE_AUTOUPDATER=1",
-		"-v", pluginsDir + ":/home/user/.claude/plugins",
-	}
+		runArgs = append(runArgs, cfg.Images.Agent, "bash", "-c", shellCmd)
 
-	// Build commands: add marketplaces, update, then install each plugin
-	var installCmds []string
-	for _, src := range mpInfo.Sources {
-		installCmds = append(installCmds, fmt.Sprintf("claude plugins marketplace add %s || true", src))
-	}
-	installCmds = append(installCmds, "claude plugins marketplace update")
-	for _, plugin := range installPlugins {
-		installCmds = append(installCmds, fmt.Sprintf("claude plugins install %s || true", plugin))
-	}
-	shellCmd := strings.Join(installCmds, " && ")
+		dockerCmd := exec.Command("docker", runArgs...)
+		dockerCmd.Stdout = os.Stdout
+		dockerCmd.Stderr = os.Stderr
 
-	runArgs = append(runArgs, cfg.Images.Agent, "bash", "-c", shellCmd)
-
-	dockerCmd := exec.Command("docker", runArgs...)
-	dockerCmd.Stdout = os.Stdout
-	dockerCmd.Stderr = os.Stderr
-
-	if err := dockerCmd.Run(); err != nil {
-		return fmt.Errorf("plugin sync failed: %w", err)
+		if err := dockerCmd.Run(); err != nil {
+			return fmt.Errorf("plugin sync failed: %w", err)
+		}
 	}
 
 	// Write enabledPlugins to settings.json so the agent container picks them up
@@ -862,22 +859,15 @@ var syncHostPlugins = func(homeDir string, force bool) error {
 		return fmt.Errorf("failed to update settings: %w", err)
 	}
 
-	fmt.Println("Plugin sync complete.")
+	if len(installPlugins) > 0 {
+		fmt.Println("Plugin sync complete.")
+	}
 	return nil
 }
 
-// readHostPlugins reads the host's installed_plugins.json and returns plugin
-// identifiers in "name@marketplace" format.
-func readHostPlugins(homeDir string) ([]string, error) {
-	pluginsPath := filepath.Join(homeDir, ".claude", "plugins", "installed_plugins.json")
-	data, err := os.ReadFile(pluginsPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("failed to read installed_plugins.json: %w", err)
-	}
-
+// parseInstalledPlugins parses installed_plugins.json content and returns the
+// plugin keys in "name@marketplace" format.
+func parseInstalledPlugins(data []byte) ([]string, error) {
 	var file struct {
 		Plugins map[string]any `json:"plugins"`
 	}
@@ -892,6 +882,20 @@ func readHostPlugins(homeDir string) ([]string, error) {
 	return plugins, nil
 }
 
+// readHostPlugins reads the host's installed_plugins.json and returns plugin
+// identifiers in "name@marketplace" format.
+func readHostPlugins(homeDir string) ([]string, error) {
+	pluginsPath := filepath.Join(homeDir, ".claude", "plugins", "installed_plugins.json")
+	data, err := os.ReadFile(pluginsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read installed_plugins.json: %w", err)
+	}
+	return parseInstalledPlugins(data)
+}
+
 // readForgeInstalledPlugins reads installed_plugins.json from forge's
 // persistent plugins directory and returns the set of installed plugin keys.
 // Returns an empty set on any error so sync falls back to reinstalling.
@@ -902,14 +906,11 @@ func readForgeInstalledPlugins(pluginsDir string) map[string]bool {
 		return installed
 	}
 
-	var file struct {
-		Plugins map[string]any `json:"plugins"`
-	}
-	if err := json.Unmarshal(data, &file); err != nil {
+	plugins, err := parseInstalledPlugins(data)
+	if err != nil {
 		return installed
 	}
-
-	for key := range file.Plugins {
+	for _, key := range plugins {
 		installed[key] = true
 	}
 	return installed

--- a/cmd/claude-forge/main.go
+++ b/cmd/claude-forge/main.go
@@ -97,7 +97,7 @@ func startSession(skipPermissions, worktree bool, prompt, resumeID, resumeSubdir
 	// Sync the host's locally installed Claude Code plugins into forge's plugin
 	// directory so they are available in the session without a manual sync.
 	// Best-effort: a failure here should not block starting the session.
-	if err := syncHostPlugins(orch.HomeDir); err != nil {
+	if err := syncHostPlugins(orch.HomeDir, false); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: plugin sync failed: %v\n", err)
 	}
 
@@ -728,7 +728,10 @@ func newPluginsSyncCmd() *cobra.Command {
 		Short: "Sync host plugins into forge's plugin directory",
 		Long: `Reads ~/.claude/plugins/installed_plugins.json from the host, starts a
 temporary container, and runs "claude plugins install" for each plugin.
-Plugins persist in ~/.claude-forge/plugins/ across sessions.`,
+Plugins persist in ~/.claude-forge/plugins/ across sessions.
+
+Reinstalls all plugins, even ones already present, so it also picks up
+updates. Session start only installs plugins missing from the cache.`,
 		RunE: pluginsSyncRun,
 	}
 }
@@ -738,14 +741,17 @@ var pluginsSyncRun = func(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get home directory: %w", err)
 	}
-	return syncHostPlugins(homeDir)
+	return syncHostPlugins(homeDir, true)
 }
 
-// syncHostPlugins reinstalls the host's locally installed Claude Code plugins
+// syncHostPlugins installs the host's locally installed Claude Code plugins
 // into forge's persistent plugins directory (~/.claude-forge/plugins) by running
 // "claude plugins install" inside a temporary container. It is a no-op when the
 // host has no plugins. Used by "plugins sync" and automatically at session start.
-var syncHostPlugins = func(homeDir string) error {
+// When force is false, plugins already present in the persistent directory are
+// skipped so repeated session starts don't reinstall everything; force reinstalls
+// all plugins to pick up updates.
+var syncHostPlugins = func(homeDir string, force bool) error {
 	plugins, err := readHostPlugins(homeDir)
 	if err != nil {
 		return err
@@ -796,8 +802,28 @@ var syncHostPlugins = func(homeDir string) error {
 		return nil
 	}
 
+	// Skip plugins already installed in the persistent plugins directory so
+	// session start doesn't reinstall everything on every run.
+	installPlugins := syncPlugins
+	if !force {
+		installed := readForgeInstalledPlugins(pluginsDir)
+		installPlugins = nil
+		for _, plugin := range syncPlugins {
+			if !installed[plugin] {
+				installPlugins = append(installPlugins, plugin)
+			}
+		}
+		if len(installPlugins) == 0 {
+			if err := enablePluginsInSettings(configDir, syncPlugins); err != nil {
+				return fmt.Errorf("failed to update settings: %w", err)
+			}
+			fmt.Printf("All %d plugins already installed.\n", len(syncPlugins))
+			return nil
+		}
+	}
+
 	containerName := "forge-plugins-sync"
-	fmt.Printf("Syncing %d plugins...\n", len(syncPlugins))
+	fmt.Printf("Syncing %d of %d plugins...\n", len(installPlugins), len(syncPlugins))
 
 	// Start a temporary container with the plugins dir mounted
 	uid := os.Getuid()
@@ -806,6 +832,7 @@ var syncHostPlugins = func(homeDir string) error {
 		"run", "--rm", "--name", containerName,
 		"-e", fmt.Sprintf("FORGE_UID=%d", uid),
 		"-e", fmt.Sprintf("FORGE_GID=%d", gid),
+		"-e", "DISABLE_AUTOUPDATER=1",
 		"-v", pluginsDir + ":/home/user/.claude/plugins",
 	}
 
@@ -815,7 +842,7 @@ var syncHostPlugins = func(homeDir string) error {
 		installCmds = append(installCmds, fmt.Sprintf("claude plugins marketplace add %s || true", src))
 	}
 	installCmds = append(installCmds, "claude plugins marketplace update")
-	for _, plugin := range syncPlugins {
+	for _, plugin := range installPlugins {
 		installCmds = append(installCmds, fmt.Sprintf("claude plugins install %s || true", plugin))
 	}
 	shellCmd := strings.Join(installCmds, " && ")
@@ -863,6 +890,29 @@ func readHostPlugins(homeDir string) ([]string, error) {
 		plugins = append(plugins, key)
 	}
 	return plugins, nil
+}
+
+// readForgeInstalledPlugins reads installed_plugins.json from forge's
+// persistent plugins directory and returns the set of installed plugin keys.
+// Returns an empty set on any error so sync falls back to reinstalling.
+func readForgeInstalledPlugins(pluginsDir string) map[string]bool {
+	installed := make(map[string]bool)
+	data, err := os.ReadFile(filepath.Join(pluginsDir, "installed_plugins.json"))
+	if err != nil {
+		return installed
+	}
+
+	var file struct {
+		Plugins map[string]any `json:"plugins"`
+	}
+	if err := json.Unmarshal(data, &file); err != nil {
+		return installed
+	}
+
+	for key := range file.Plugins {
+		installed[key] = true
+	}
+	return installed
 }
 
 // enablePluginsInSettings reads settings.json from configDir, adds an

--- a/cmd/claude-forge/main_test.go
+++ b/cmd/claude-forge/main_test.go
@@ -1037,6 +1037,39 @@ func TestPluginsSyncCmd_WithPlugins(t *testing.T) {
 	assert.Equal(t, []string{"gopls-lsp@claude-plugins-official"}, capturedPlugins)
 }
 
+func TestSyncHostPlugins_SkipsWhenAllInstalled(t *testing.T) {
+	homeDir := t.TempDir()
+
+	hostPluginsDir := filepath.Join(homeDir, ".claude", "plugins")
+	require.NoError(t, os.MkdirAll(hostPluginsDir, 0o755))
+	pluginsJSON := `{"version": 2, "plugins": {"gopls-lsp@claude-plugins-official": [{}]}}`
+	require.NoError(t, os.WriteFile(filepath.Join(hostPluginsDir, "installed_plugins.json"), []byte(pluginsJSON), 0o644))
+	marketplaces := `{"claude-plugins-official": {"source": {"source": "github", "repo": "anthropics/claude-code"}}}`
+	require.NoError(t, os.WriteFile(filepath.Join(hostPluginsDir, "known_marketplaces.json"), []byte(marketplaces), 0o644))
+
+	// The persistent forge plugins dir already contains the plugin, so sync
+	// must return before starting any container.
+	forgePluginsDir := filepath.Join(homeDir, ".claude-forge", "plugins")
+	require.NoError(t, os.MkdirAll(forgePluginsDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(forgePluginsDir, "installed_plugins.json"), []byte(pluginsJSON), 0o644))
+
+	configDir := filepath.Join(homeDir, ".config", "claude-forge")
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "settings.json"), []byte("{}"), 0o644))
+
+	err := syncHostPlugins(homeDir, false)
+	require.NoError(t, err)
+
+	// enabledPlugins is still written so settings stay in sync.
+	data, err := os.ReadFile(filepath.Join(configDir, "settings.json"))
+	require.NoError(t, err)
+	var settings map[string]any
+	require.NoError(t, json.Unmarshal(data, &settings))
+	enabled, ok := settings["enabledPlugins"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, enabled["gopls-lsp@claude-plugins-official"])
+}
+
 func TestReadHostMarketplaces(t *testing.T) {
 	t.Run("reads github sources and names", func(t *testing.T) {
 		dir := t.TempDir()
@@ -1088,6 +1121,38 @@ func TestReadHostMarketplaces(t *testing.T) {
 		info := readHostMarketplaces(t.TempDir())
 		assert.Empty(t, info.Sources)
 		assert.Empty(t, info.Names)
+	})
+}
+
+func TestReadForgeInstalledPlugins(t *testing.T) {
+	t.Run("returns installed plugin keys", func(t *testing.T) {
+		pluginsDir := t.TempDir()
+		content := `{
+			"version": 2,
+			"plugins": {
+				"gopls-lsp@claude-plugins-official": [{"version": "1.0.0"}],
+				"my-plugin@my-marketplace": [{"version": "0.1.0"}]
+			}
+		}`
+		require.NoError(t, os.WriteFile(filepath.Join(pluginsDir, "installed_plugins.json"), []byte(content), 0o644))
+
+		installed := readForgeInstalledPlugins(pluginsDir)
+		assert.Len(t, installed, 2)
+		assert.True(t, installed["gopls-lsp@claude-plugins-official"])
+		assert.True(t, installed["my-plugin@my-marketplace"])
+	})
+
+	t.Run("returns empty set when file missing", func(t *testing.T) {
+		installed := readForgeInstalledPlugins(t.TempDir())
+		assert.Empty(t, installed)
+	})
+
+	t.Run("returns empty set for invalid json", func(t *testing.T) {
+		pluginsDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(pluginsDir, "installed_plugins.json"), []byte("not json"), 0o644))
+
+		installed := readForgeInstalledPlugins(pluginsDir)
+		assert.Empty(t, installed)
 	})
 }
 

--- a/cmd/claude-forge/start_session_test.go
+++ b/cmd/claude-forge/start_session_test.go
@@ -120,17 +120,20 @@ func TestStartSession_PluginSyncFailureNonFatal(t *testing.T) {
 
 	originalSync := syncHostPlugins
 	var syncedHomeDir string
-	syncHostPlugins = func(h string) error {
+	var syncedForce bool
+	syncHostPlugins = func(h string, force bool) error {
 		syncedHomeDir = h
+		syncedForce = force
 		return errors.New("boom")
 	}
 	t.Cleanup(func() { syncHostPlugins = originalSync })
 
 	err = startSession(true, false, "do a task", "", "", false, nil, "", "")
 	require.NoError(t, err)
-	// Sync was invoked with the orchestrator's home dir, and its failure was
-	// tolerated.
+	// Sync was invoked with the orchestrator's home dir without forcing a
+	// reinstall, and its failure was tolerated.
 	require.Equal(t, homeDir, syncedHomeDir)
+	require.False(t, syncedForce)
 }
 
 func runGitIn(t *testing.T, dir string, args ...string) {

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -37,14 +37,23 @@ RUN apt-get update && apt-get install -y software-properties-common \
     tar unzip openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
-# Claude Code (latest)
-RUN npm install -g @anthropic-ai/claude-code
+# Create non-root user (entrypoint adjusts UID/GID at startup)
+RUN useradd -m -s /bin/bash user
+
+# Claude Code (latest) via the standalone installer, installed as the runtime
+# user. An npm -g install lives in a root-owned prefix, and Claude Code warns
+# "Auto-update failed: no write permission to npm prefix" at startup even with
+# auto-updates disabled. The native install under /home/user is writable by
+# the user (the entrypoint chowns /home/user), so the warning never fires;
+# DISABLE_AUTOUPDATER=1 set by the orchestrator keeps the pinned version.
+USER user
+RUN HOME=/home/user bash -c 'curl -fsSL https://claude.ai/install.sh | bash'
+USER root
+ENV PATH="/home/user/.local/bin:${PATH}"
+RUN ln -sf /home/user/.local/bin/claude /usr/local/bin/claude
 
 # Copy claude-forge binary (built in CI or locally)
 COPY claude-forge /usr/local/bin/claude-forge
-
-# Create non-root user (entrypoint adjusts UID/GID at startup)
-RUN useradd -m -s /bin/bash user
 
 # Entrypoint handles UID/GID mapping and runs as the user
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -45,7 +45,8 @@ RUN useradd -m -s /bin/bash user
 # "Auto-update failed: no write permission to npm prefix" at startup even with
 # auto-updates disabled. The native install under /home/user is writable by
 # the user (the entrypoint chowns /home/user), so the warning never fires;
-# DISABLE_AUTOUPDATER=1 set by the orchestrator keeps the pinned version.
+# DISABLE_AUTOUPDATER=1 set by the orchestrator keeps the version installed
+# at image build time (nothing pins a specific version here).
 USER user
 RUN HOME=/home/user bash -c 'curl -fsSL https://claude.ai/install.sh | bash'
 USER root

--- a/docs/content/docs/secure-sandbox/architecture/secure-sandbox-architecture.md
+++ b/docs/content/docs/secure-sandbox/architecture/secure-sandbox-architecture.md
@@ -477,14 +477,18 @@ RUN apt-get update && apt-get install -y \
     tar unzip openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
-# Claude Code
-RUN npm install -g @anthropic-ai/claude-code
+RUN useradd -m -s /bin/bash user
+
+# Claude Code (standalone installer, owned by the runtime user so the
+# auto-update npm-prefix warning never fires)
+USER user
+RUN HOME=/home/user bash -c 'curl -fsSL https://claude.ai/install.sh | bash'
+USER root
+ENV PATH="/home/user/.local/bin:${PATH}"
 
 # forge-gh (aliased as gh)
 COPY forge-gh /usr/local/bin/forge-gh
 RUN ln -s /usr/local/bin/forge-gh /usr/local/bin/gh
-
-RUN useradd -m -s /bin/bash user
 USER user
 WORKDIR /work
 ENTRYPOINT ["claude"]

--- a/docs/content/docs/secure-sandbox/architecture/secure-sandbox-architecture.md
+++ b/docs/content/docs/secure-sandbox/architecture/secure-sandbox-architecture.md
@@ -485,6 +485,7 @@ USER user
 RUN HOME=/home/user bash -c 'curl -fsSL https://claude.ai/install.sh | bash'
 USER root
 ENV PATH="/home/user/.local/bin:${PATH}"
+RUN ln -sf /home/user/.local/bin/claude /usr/local/bin/claude
 
 # forge-gh (aliased as gh)
 COPY forge-gh /usr/local/bin/forge-gh

--- a/internal/forge/claudecode/claudecode.go
+++ b/internal/forge/claudecode/claudecode.go
@@ -97,6 +97,11 @@ func buildEnv(opts Options) map[string]string {
 	env := map[string]string{
 		"HOME":                "/home/user",
 		"GIT_TERMINAL_PROMPT": "0",
+		// The image pins the Claude Code version and the npm prefix is not
+		// writable by the container user; without this the auto-updater runs
+		// anyway (the legacy autoUpdaterStatus settings key is ignored by
+		// newer versions) and reports "no write permission to npm prefix".
+		"DISABLE_AUTOUPDATER": "1",
 	}
 	if opts.AuthType == "api_key" {
 		env["ANTHROPIC_API_KEY"] = opts.AuthToken

--- a/internal/forge/claudecode/claudecode.go
+++ b/internal/forge/claudecode/claudecode.go
@@ -58,6 +58,10 @@ type Options struct {
 // BuildContainerConfig constructs the full container configuration from options.
 // This is the main entry point -- it generates env vars, command args, volume mounts,
 // and gitconfig content that the Docker client needs to start the agent container.
+//
+// NOTE: the orchestrator does not consume this yet -- orchestrator.go builds
+// its own env/cmd/mounts independently (see agentEnv in Orchestrator.Start).
+// Until StartAgent is wired to use this, keep the two in sync.
 func BuildContainerConfig(opts Options) (*ContainerConfig, error) {
 	if err := validate(opts); err != nil {
 		return nil, err
@@ -97,10 +101,11 @@ func buildEnv(opts Options) map[string]string {
 	env := map[string]string{
 		"HOME":                "/home/user",
 		"GIT_TERMINAL_PROMPT": "0",
-		// The image pins the Claude Code version and the npm prefix is not
-		// writable by the container user; without this the auto-updater runs
-		// anyway (the legacy autoUpdaterStatus settings key is ignored by
-		// newer versions) and reports "no write permission to npm prefix".
+		// Keep Claude Code at the version installed at image build time;
+		// without this the auto-updater updates the install in-place (the
+		// legacy autoUpdaterStatus settings key is ignored by newer versions)
+		// and, on npm-based images with a root-owned prefix, warns
+		// "no write permission to npm prefix".
 		"DISABLE_AUTOUPDATER": "1",
 	}
 	if opts.AuthType == "api_key" {

--- a/internal/forge/claudecode/claudecode_test.go
+++ b/internal/forge/claudecode/claudecode_test.go
@@ -51,6 +51,7 @@ func TestBuildContainerConfig_FullOptions(t *testing.T) {
 	// Env vars
 	assert.Equal(t, "/home/user", cfg.Env["HOME"])
 	assert.Equal(t, "0", cfg.Env["GIT_TERMINAL_PROMPT"])
+	assert.Equal(t, "1", cfg.Env["DISABLE_AUTOUPDATER"])
 	assert.Equal(t, "sk-ant-test", cfg.Env["ANTHROPIC_API_KEY"])
 	assert.Empty(t, cfg.Env["CLAUDE_CODE_OAUTH_TOKEN"])
 

--- a/internal/forge/orchestrator.go
+++ b/internal/forge/orchestrator.go
@@ -356,6 +356,11 @@ func (o *Orchestrator) Start(ctx context.Context, opts StartOptions) (*Session, 
 		"GIT_TERMINAL_PROMPT": "0",
 		"FORGE_PROJECT_OWNER": proj.Owner,
 		"FORGE_PROJECT_REPO":  proj.Repo,
+		// The image pins the Claude Code version and the npm prefix is not
+		// writable by the container user; without this the auto-updater runs
+		// anyway (the legacy autoUpdaterStatus settings key is ignored by
+		// newer versions) and reports "no write permission to npm prefix".
+		"DISABLE_AUTOUPDATER": "1",
 	}
 	switch creds.AuthType {
 	case "api_key":

--- a/internal/forge/orchestrator.go
+++ b/internal/forge/orchestrator.go
@@ -356,10 +356,11 @@ func (o *Orchestrator) Start(ctx context.Context, opts StartOptions) (*Session, 
 		"GIT_TERMINAL_PROMPT": "0",
 		"FORGE_PROJECT_OWNER": proj.Owner,
 		"FORGE_PROJECT_REPO":  proj.Repo,
-		// The image pins the Claude Code version and the npm prefix is not
-		// writable by the container user; without this the auto-updater runs
-		// anyway (the legacy autoUpdaterStatus settings key is ignored by
-		// newer versions) and reports "no write permission to npm prefix".
+		// Keep Claude Code at the version installed at image build time;
+		// without this the auto-updater updates the install in-place (the
+		// legacy autoUpdaterStatus settings key is ignored by newer versions)
+		// and, on npm-based images with a root-owned prefix, warns
+		// "no write permission to npm prefix".
 		"DISABLE_AUTOUPDATER": "1",
 	}
 	switch creds.AuthType {

--- a/internal/forge/orchestrator_test.go
+++ b/internal/forge/orchestrator_test.go
@@ -73,6 +73,7 @@ func TestStart_Success(t *testing.T) {
 			assert.Equal(t, projectDir, opts.ProjectDir)
 			assert.Contains(t, opts.Env, "ANTHROPIC_API_KEY")
 			assert.Equal(t, "sk-ant-test-key-123", opts.Env["ANTHROPIC_API_KEY"])
+			assert.Equal(t, "1", opts.Env["DISABLE_AUTOUPDATER"])
 			assert.Contains(t, opts.Cmd, "--dangerously-skip-permissions")
 			return "agent-id", nil
 		})


### PR DESCRIPTION
## Summary
- Session start no longer reinstalls every host plugin on each `claude-forge start`: plugins already present in the persistent `~/.claude-forge/plugins/` directory (read from its `installed_plugins.json`) are skipped, and when everything is cached no sync container is started at all. If only some plugins are missing, only those are installed.
- `claude-forge plugins sync` keeps force-reinstalling everything so plugin updates can still be pulled explicitly; the session-start skip message points at this escape hatch (`run "claude-forge plugins sync" to update them`), since the cache matches on plugin key only and does not detect host-side version upgrades.
- The agent container showed `✘ Auto-update failed: no write permission to npm prefix` on every session. Root cause (per [Claude Code setup docs](https://code.claude.com/docs/en/setup.md)): this is a startup check that fires for npm global installs in a non-writable prefix **even when the auto-updater is disabled**, and the legacy `"autoUpdaterStatus": "disabled"` settings key is ignored by newer versions. Two-part fix:
  - The agent image now installs Claude Code via the standalone native installer under `/home/user` (owned by the runtime user; the entrypoint chowns `/home/user`), so the npm-prefix check never fires. The docs snippet in `secure-sandbox-architecture.md` is updated to match.
  - `DISABLE_AUTOUPDATER=1` is set in the orchestrator's `agentEnv` (the real agent-start path — `claudecode.BuildContainerConfig` has no production caller, per review), in `claudecode.buildEnv` to keep the two env maps in sync, and in the plugin-sync container, so the now-writable native install can't self-update past the image's pinned version.

## Test plan
- `TestSyncHostPlugins_SkipsWhenAllInstalled` verifies the cached path writes `enabledPlugins` and returns before any docker invocation
- `TestReadForgeInstalledPlugins` covers the new cache reader (valid, missing, invalid JSON)
- `DISABLE_AUTOUPDATER` asserted on the real `StartAgent` path (`orchestrator_test.go`) and in `TestBuildContainerConfig`
- Full suite passes with `-race`; coverage 90.6% (threshold 90%)
- CI builds the agent image on this PR (`go.yml`), verifying the new installer step
- ⚠️ Pending: e2e run against real images on a host with docker (`go test -tags=forge_e2e -v -race -timeout 15m ./test/e2e/forge/...`); note the fix only takes effect after merge publishes the rebuilt `claude-forge-agent:latest` image and the binary is reinstalled

🤖 Generated with [Claude Code](https://claude.com/claude-code)