### PR TITLE
fix: grant pods/log in rendered RBAC manifest

### DIFF
--- a/internal/forge/kube/carveouts.go
+++ b/internal/forge/kube/carveouts.go
@@ -33,6 +33,16 @@ func DeniedSubresources() []string {
 	}
 }
 
+// GrantedSubresources returns core-group namespaced subresources that are
+// always granted when their parent resource is discovered. Discovery via
+// `kubectl api-resources` never lists subresources, and an RBAC grant on the
+// parent resource does not extend to them, so they must be added explicitly.
+func GrantedSubresources() []string {
+	return []string{
+		"pods/log",
+	}
+}
+
 // DeniedVerbs returns verbs that are filtered from all rules.
 func DeniedVerbs() []string {
 	return []string{

--- a/internal/forge/kube/carveouts_test.go
+++ b/internal/forge/kube/carveouts_test.go
@@ -27,6 +27,14 @@ func TestIsSubresourceDenied(t *testing.T) {
 	assert.False(t, IsSubresourceDenied("pods/log"))
 }
 
+func TestGrantedSubresources(t *testing.T) {
+	granted := GrantedSubresources()
+	assert.Contains(t, granted, "pods/log")
+	for _, sub := range granted {
+		assert.False(t, IsSubresourceDenied(sub))
+	}
+}
+
 func TestFilterVerbs(t *testing.T) {
 	result := FilterVerbs([]string{"get", "list", "impersonate", "watch"})
 	assert.Equal(t, []string{"get", "list", "watch"}, result)

--- a/internal/forge/kube/render.go
+++ b/internal/forge/kube/render.go
@@ -102,7 +102,7 @@ func buildRules(resources []APIResource) []PolicyRule {
 	// Discovery via `kubectl api-resources` never lists subresources, so
 	// allowed ones (e.g. pods/log) are granted here alongside their parent.
 	for _, sub := range GrantedSubresources() {
-		parent := strings.SplitN(sub, "/", 2)[0]
+		parent, _, _ := strings.Cut(sub, "/")
 		if coreNamespaced[parent] {
 			coreNamespaced[sub] = true
 		}

--- a/internal/forge/kube/render.go
+++ b/internal/forge/kube/render.go
@@ -99,6 +99,15 @@ func buildRules(resources []APIResource) []PolicyRule {
 		}
 	}
 
+	// Discovery via `kubectl api-resources` never lists subresources, so
+	// allowed ones (e.g. pods/log) are granted here alongside their parent.
+	for _, sub := range GrantedSubresources() {
+		parent := strings.SplitN(sub, "/", 2)[0]
+		if coreNamespaced[parent] {
+			coreNamespaced[sub] = true
+		}
+	}
+
 	var rules []PolicyRule
 	fullVerbs := FilterVerbs([]string{"*"})
 

--- a/internal/forge/kube/render_test.go
+++ b/internal/forge/kube/render_test.go
@@ -62,6 +62,31 @@ func TestBuildRules_SkipsDeniedSubresources(t *testing.T) {
 	assert.NotContains(t, rules[0].Resources, "serviceaccounts/token")
 }
 
+func TestBuildRules_GrantsSubresourcesWithParent(t *testing.T) {
+	// kubectl api-resources never lists subresources; pods/log must be
+	// granted whenever pods is discovered.
+	resources := []APIResource{
+		{APIGroup: "", Resource: "pods", Namespaced: true, Verbs: []string{"*"}},
+		{APIGroup: "", Resource: "configmaps", Namespaced: true, Verbs: []string{"*"}},
+	}
+
+	rules := buildRules(resources)
+
+	require.Len(t, rules, 1)
+	assert.Contains(t, rules[0].Resources, "pods/log")
+}
+
+func TestBuildRules_SkipsSubresourcesWithoutParent(t *testing.T) {
+	resources := []APIResource{
+		{APIGroup: "", Resource: "configmaps", Namespaced: true, Verbs: []string{"*"}},
+	}
+
+	rules := buildRules(resources)
+
+	require.Len(t, rules, 1)
+	assert.NotContains(t, rules[0].Resources, "pods/log")
+}
+
 func TestBuildRules_ClusterScopedReadOnly(t *testing.T) {
 	resources := []APIResource{
 		{APIGroup: "", Resource: "namespaces", Namespaced: false, Verbs: []string{"*"}},


### PR DESCRIPTION
## Summary

The `claude-forge kube render` command never emitted `pods/log` in the generated ClusterRole, even though the kubectl-support proposal explicitly intends it to be granted (its example output includes it, and only `pods/exec`/`pods/attach` are carved out as "interactive pod access").

Root cause: `discoverResources` shells out to `kubectl api-resources`, which only lists top-level resources — subresources like `pods/log` are never returned, so they never reach `buildRules`. Since a Kubernetes RBAC grant on `pods` does not extend to `pods/log`, the kubernetes-mcp-server's `pods_log` tool gets `403 Forbidden` against a rendered manifest.

## Changes

- Add `GrantedSubresources()` to `internal/forge/kube/carveouts.go`, listing core-group subresources that must be granted explicitly (currently `pods/log`).
- In `buildRules`, append each granted subresource to the core namespaced rule when its parent resource was discovered.

## Test plan

- [x] New unit tests: `pods/log` is granted when `pods` is discovered, and not granted when `pods` is absent; `GrantedSubresources()` entries never overlap the deny list.
- [x] `go test -race ./...` passes.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)