### PR TITLE
fix: prune deletes by last activity, standalone --keep, orphaned sidecar sweep

### DIFF
--- a/cmd/claude-forge/main.go
+++ b/cmd/claude-forge/main.go
@@ -528,20 +528,19 @@ removal hint is printed instead. Use --dry-run to preview.`,
 				return fmt.Errorf("failed to scan for orphaned sidecars: %w", err)
 			}
 			var orphans []string
-			for _, id := range allOrphans {
-				info, err := os.Stat(filepath.Join(sessionDir, id+".json"))
-				if err != nil || now.Sub(info.ModTime()) < orphanSidecarGrace {
+			for _, o := range allOrphans {
+				if now.Sub(o.ModTime) < orphanSidecarGrace {
 					continue
 				}
-				orphans = append(orphans, id)
+				orphans = append(orphans, o.ID)
 			}
 			for _, id := range orphans {
 				if dryRun {
 					fmt.Fprintf(w, "would delete orphaned sidecar  %s\n", id)
 					continue
 				}
-				if err := os.Remove(filepath.Join(sessionDir, id+".json")); err != nil && !os.IsNotExist(err) {
-					return fmt.Errorf("failed to remove orphaned sidecar: %w", err)
+				if err := session.DeleteSidecar(sessionDir, id); err != nil {
+					return err
 				}
 				fmt.Fprintf(w, "deleted orphaned sidecar  %s\n", id)
 			}
@@ -587,35 +586,21 @@ func printWorktreeHints(w io.Writer, sessionDir string, pruned []session.Session
 	if err != nil {
 		return
 	}
-	hinted := make(map[string]bool)
+	seen := make(map[string]bool)
 	for _, s := range pruned {
 		name := s.WorktreeName()
-		if name == "" || hinted[name] {
+		if name == "" || seen[name] {
 			continue
 		}
-		if hasTranscripts(filepath.Join(sessionDir, s.Subdir)) {
+		seen[name] = true
+		if session.HasTranscripts(filepath.Join(sessionDir, s.Subdir)) {
 			continue // another session, parseable or not, still references it
 		}
 		if _, err := os.Stat(filepath.Join(cwd, ".claude-worktrees", name)); err != nil {
 			continue
 		}
-		hinted[name] = true
 		fmt.Fprintf(w, "note: worktree .claude-worktrees/%s was left in place; remove it with: git worktree remove .claude-worktrees/%s\n", name, name)
 	}
-}
-
-// hasTranscripts reports whether dir contains any transcript (.jsonl) file.
-func hasTranscripts(dir string) bool {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return false
-	}
-	for _, e := range entries {
-		if !e.IsDir() && strings.HasSuffix(e.Name(), ".jsonl") {
-			return true
-		}
-	}
-	return false
 }
 
 // newResumeCmd creates the "resume" subcommand.

--- a/cmd/claude-forge/main.go
+++ b/cmd/claude-forge/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -426,6 +427,13 @@ func parseAge(s string) (time.Duration, error) {
 	return time.ParseDuration(s)
 }
 
+// orphanSidecarGrace protects the name sidecar of a just-started session: the
+// orchestrator writes <id>.json as soon as the agent container starts, but
+// Claude Code only creates <id>.jsonl once the conversation records its first
+// line, which for an interactive session can be minutes later. A sidecar is
+// treated as orphaned only once its mtime is older than this grace period.
+const orphanSidecarGrace = time.Hour
+
 // newPruneCmd creates the "prune" subcommand.
 func newPruneCmd() *cobra.Command {
 	var (
@@ -438,12 +446,32 @@ func newPruneCmd() *cobra.Command {
 		Use:   "prune",
 		Short: "Delete old Claude Code sessions for the current project",
 		Long: `Prune removes session transcripts (and their name sidecars) for the
-current project. By default it deletes sessions older than 30 days. Narrow
-or widen the window with --older-than, and protect the N most recent
-sessions with --keep. Use --dry-run to preview.`,
+current project. Session age is measured by last activity (the transcript's
+modification time), not by when the session started.
+
+By default, sessions inactive for 30 or more days are deleted. --keep N on
+its own disables that age window: it keeps the N most recently active
+sessions and deletes all the rest. When both --keep and --older-than are
+given, only sessions that are beyond the N most recently active AND older
+than the age are deleted.
+
+Orphaned name sidecars (a <id>.json whose transcript no longer exists) are
+always swept, except sidecars written within the last hour: a just-started
+session has a sidecar before its transcript exists. Git worktrees left
+behind by pruned worktree sessions are never removed automatically; a
+removal hint is printed instead. Use --dry-run to preview.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			keepSet := cmd.Flags().Changed("keep")
+			ageSet := cmd.Flags().Changed("older-than")
+			if keepSet && keep < 0 {
+				return fmt.Errorf("--keep must be >= 0")
+			}
+			// --keep alone disables the default 30d age window; an explicit
+			// --older-than alongside --keep means both conditions must hold.
+			applyAge := ageSet || !keepSet
+
 			var maxAge time.Duration
-			if olderThan != "" {
+			if applyAge {
 				var err error
 				maxAge, err = parseAge(olderThan)
 				if err != nil {
@@ -460,50 +488,134 @@ sessions with --keep. Use --dry-run to preview.`,
 				return fmt.Errorf("failed to list sessions: %w", err)
 			}
 
-			// sessions are sorted most-recent-first.
+			// List sorts by CreatedAt, but --keep protects by recency of
+			// activity, so re-sort by LastActive (most recent first).
+			sort.Slice(sessions, func(i, j int) bool {
+				return sessions[i].LastActive.After(sessions[j].LastActive)
+			})
+
 			now := time.Now()
 			var toPrune []session.Session
 			for i, s := range sessions {
-				if keep >= 0 && i < keep {
-					continue // protected: among the N newest
+				if keepSet && i < keep {
+					continue // protected: among the N most recently active
 				}
-				if olderThan != "" && now.Sub(s.CreatedAt) < maxAge {
-					continue // not old enough
+				if applyAge && now.Sub(s.LastActive) < maxAge {
+					continue // recently active
 				}
 				toPrune = append(toPrune, s)
 			}
 
 			w := cmd.OutOrStdout()
-			if len(toPrune) == 0 {
-				fmt.Fprintln(w, "No sessions to prune.")
-				return nil
-			}
-
 			for _, s := range toPrune {
 				if dryRun {
-					fmt.Fprintf(w, "would delete  %s  %s  %s\n", s.ID, s.CreatedAt.Format(time.RFC3339), s.Name)
+					fmt.Fprintf(w, "would delete  %s  %s  %s\n", s.ID, s.LastActive.Format(time.RFC3339), s.Name)
 					continue
 				}
 				if err := session.Delete(sessionDir, s); err != nil {
 					return err
 				}
-				fmt.Fprintf(w, "deleted  %s  %s  %s\n", s.ID, s.CreatedAt.Format(time.RFC3339), s.Name)
+				fmt.Fprintf(w, "deleted  %s  %s  %s\n", s.ID, s.LastActive.Format(time.RFC3339), s.Name)
+			}
+
+			// Sidecars whose transcript was deleted by other means are never
+			// listed, so sweep them here even when no transcripts were pruned.
+			// Recently written sidecars are skipped: a just-started session has
+			// a sidecar before Claude Code creates its transcript, and sweeping
+			// it would strip the live session's name.
+			allOrphans, err := session.OrphanedSidecars(sessionDir)
+			if err != nil {
+				return fmt.Errorf("failed to scan for orphaned sidecars: %w", err)
+			}
+			var orphans []string
+			for _, id := range allOrphans {
+				info, err := os.Stat(filepath.Join(sessionDir, id+".json"))
+				if err != nil || now.Sub(info.ModTime()) < orphanSidecarGrace {
+					continue
+				}
+				orphans = append(orphans, id)
+			}
+			for _, id := range orphans {
+				if dryRun {
+					fmt.Fprintf(w, "would delete orphaned sidecar  %s\n", id)
+					continue
+				}
+				if err := os.Remove(filepath.Join(sessionDir, id+".json")); err != nil && !os.IsNotExist(err) {
+					return fmt.Errorf("failed to remove orphaned sidecar: %w", err)
+				}
+				fmt.Fprintf(w, "deleted orphaned sidecar  %s\n", id)
+			}
+
+			if len(toPrune) == 0 && len(orphans) == 0 {
+				fmt.Fprintln(w, "No sessions to prune.")
+				return nil
 			}
 
 			verb := "Deleted"
 			if dryRun {
 				verb = "Would delete"
 			}
-			fmt.Fprintf(w, "%s %d session(s).\n", verb, len(toPrune))
+			summary := fmt.Sprintf("%s %d session(s)", verb, len(toPrune))
+			if len(orphans) > 0 {
+				summary += fmt.Sprintf(" and %d orphaned sidecar(s)", len(orphans))
+			}
+			fmt.Fprintln(w, summary+".")
+
+			if !dryRun {
+				printWorktreeHints(w, sessionDir, toPrune)
+			}
 			return nil
 		},
 	}
 
-	cmd.Flags().StringVar(&olderThan, "older-than", "30d", "Delete sessions older than this age (e.g. 30d, 720h)")
-	cmd.Flags().IntVar(&keep, "keep", -1, "Keep the N most recent sessions, delete the rest")
+	cmd.Flags().StringVar(&olderThan, "older-than", "30d", "Delete sessions whose last activity is older than this age (e.g. 30d, 720h)")
+	cmd.Flags().IntVar(&keep, "keep", -1, "Keep the N most recently active sessions; alone it overrides the default age window, with --older-than both must match")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show what would be deleted without deleting")
 
 	return cmd
+}
+
+// printWorktreeHints notes git worktrees orphaned by pruned worktree sessions.
+// Worktrees may hold uncommitted work, so they are never removed automatically:
+// a hint is printed only when the worktree's session subdirectory retains no
+// transcript files and the worktree directory still exists under the current
+// project. "Still referenced" is decided from the filesystem rather than the
+// parsed session list, so transcripts List cannot parse (e.g. a just-launched
+// session's still-empty JSONL) also suppress the hint.
+func printWorktreeHints(w io.Writer, sessionDir string, pruned []session.Session) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+	hinted := make(map[string]bool)
+	for _, s := range pruned {
+		name := s.WorktreeName()
+		if name == "" || hinted[name] {
+			continue
+		}
+		if hasTranscripts(filepath.Join(sessionDir, s.Subdir)) {
+			continue // another session, parseable or not, still references it
+		}
+		if _, err := os.Stat(filepath.Join(cwd, ".claude-worktrees", name)); err != nil {
+			continue
+		}
+		hinted[name] = true
+		fmt.Fprintf(w, "note: worktree .claude-worktrees/%s was left in place; remove it with: git worktree remove .claude-worktrees/%s\n", name, name)
+	}
+}
+
+// hasTranscripts reports whether dir contains any transcript (.jsonl) file.
+func hasTranscripts(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".jsonl") {
+			return true
+		}
+	}
+	return false
 }
 
 // newResumeCmd creates the "resume" subcommand.

--- a/cmd/claude-forge/main_test.go
+++ b/cmd/claude-forge/main_test.go
@@ -121,14 +121,27 @@ func ageFile(t *testing.T, path string, age time.Duration) {
 	require.NoError(t, os.Chtimes(path, old, old))
 }
 
+// seedSession writes a transcript in dir and pushes its mtime age into the
+// past (zero age leaves it recently active). Prune's age policy reads only the
+// mtime, so the transcript's CreatedAt is an arbitrary recent time; tests
+// about the CreatedAt/mtime distinction seed their files explicitly instead.
+func seedSession(t *testing.T, dir, name string, age time.Duration) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	recent := time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)
+	writeSessionFile(t, path, recent, strings.TrimSuffix(name, ".jsonl"))
+	if age > 0 {
+		ageFile(t, path, age)
+	}
+	return path
+}
+
 func TestPruneCmd(t *testing.T) {
 	t.Run("defaults to older-than 30 days", func(t *testing.T) {
 		sessionDir := pruneSetup(t)
-		oldFile := filepath.Join(sessionDir, "-work", "old.jsonl")
-		writeSessionFile(t, oldFile, "2020-01-01T00:00:00Z", "old")
-		ageFile(t, oldFile, 31*24*time.Hour)
-		recent := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
-		writeSessionFile(t, filepath.Join(sessionDir, "-work", "new.jsonl"), recent, "new")
+		workDir := filepath.Join(sessionDir, "-work")
+		oldFile := seedSession(t, workDir, "old.jsonl", 31*24*time.Hour)
+		seedSession(t, workDir, "new.jsonl", 0)
 
 		cmd := newPruneCmd()
 		cmd.SetArgs([]string{}) // no flags → default 30d window
@@ -157,12 +170,9 @@ func TestPruneCmd(t *testing.T) {
 
 	t.Run("older-than dry-run keeps files", func(t *testing.T) {
 		sessionDir := pruneSetup(t)
-		oldFile := filepath.Join(sessionDir, "-work", "old.jsonl")
-		writeSessionFile(t, oldFile, "2020-01-01T00:00:00Z", "old one")
-		ageFile(t, oldFile, 31*24*time.Hour)
-		recent := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
-		newFile := filepath.Join(sessionDir, "-work", "new.jsonl")
-		writeSessionFile(t, newFile, recent, "new one")
+		workDir := filepath.Join(sessionDir, "-work")
+		oldFile := seedSession(t, workDir, "old.jsonl", 31*24*time.Hour)
+		newFile := seedSession(t, workDir, "new.jsonl", 0)
 
 		cmd := newPruneCmd()
 		cmd.SetArgs([]string{"--older-than", "30d", "--dry-run"})
@@ -177,13 +187,10 @@ func TestPruneCmd(t *testing.T) {
 
 	t.Run("older-than deletes old transcript and sidecar", func(t *testing.T) {
 		sessionDir := pruneSetup(t)
-		oldFile := filepath.Join(sessionDir, "-work", "old.jsonl")
-		writeSessionFile(t, oldFile, "2020-01-01T00:00:00Z", "old one")
-		ageFile(t, oldFile, 31*24*time.Hour)
+		workDir := filepath.Join(sessionDir, "-work")
+		oldFile := seedSession(t, workDir, "old.jsonl", 31*24*time.Hour)
 		require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "old.json"), []byte(`{"name":"gone"}`), 0o644))
-		recent := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
-		newFile := filepath.Join(sessionDir, "-work", "new.jsonl")
-		writeSessionFile(t, newFile, recent, "new one")
+		newFile := seedSession(t, workDir, "new.jsonl", 0)
 
 		cmd := newPruneCmd()
 		cmd.SetArgs([]string{"--older-than", "30d"})
@@ -197,15 +204,13 @@ func TestPruneCmd(t *testing.T) {
 
 	t.Run("keep alone protects most recently active, ignores age", func(t *testing.T) {
 		sessionDir := pruneSetup(t)
-		recent := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+		workDir := filepath.Join(sessionDir, "-work")
 		for name, age := range map[string]time.Duration{
 			"a.jsonl": 3 * time.Hour,
 			"b.jsonl": 2 * time.Hour,
 			"c.jsonl": time.Hour,
 		} {
-			path := filepath.Join(sessionDir, "-work", name)
-			writeSessionFile(t, path, recent, name)
-			ageFile(t, path, age)
+			seedSession(t, workDir, name, age)
 		}
 
 		cmd := newPruneCmd()
@@ -222,15 +227,13 @@ func TestPruneCmd(t *testing.T) {
 
 	t.Run("explicit keep and older-than are ANDed", func(t *testing.T) {
 		sessionDir := pruneSetup(t)
-		recent := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+		workDir := filepath.Join(sessionDir, "-work")
 		for name, age := range map[string]time.Duration{
 			"fresh.jsonl": time.Hour,
 			"mid.jsonl":   2 * time.Hour,
 			"old.jsonl":   40 * 24 * time.Hour,
 		} {
-			path := filepath.Join(sessionDir, "-work", name)
-			writeSessionFile(t, path, recent, name)
-			ageFile(t, path, age)
+			seedSession(t, workDir, name, age)
 		}
 
 		cmd := newPruneCmd()
@@ -317,9 +320,7 @@ func TestPruneCmd(t *testing.T) {
 		sessionDir := pruneSetup(t)
 		wtDir := filepath.Join(sessionDir, "-work--claude-worktrees-feature")
 		require.NoError(t, os.MkdirAll(wtDir, 0o755))
-		wtFile := filepath.Join(wtDir, "wt.jsonl")
-		writeSessionFile(t, wtFile, "2020-01-01T00:00:00Z", "wt")
-		ageFile(t, wtFile, 31*24*time.Hour)
+		seedSession(t, wtDir, "wt.jsonl", 31*24*time.Hour)
 		// pruneSetup chdirs into the repo, so the worktree path is relative to cwd.
 		require.NoError(t, os.MkdirAll(filepath.Join(".claude-worktrees", "feature"), 0o755))
 
@@ -336,11 +337,8 @@ func TestPruneCmd(t *testing.T) {
 		sessionDir := pruneSetup(t)
 		wtDir := filepath.Join(sessionDir, "-work--claude-worktrees-feature")
 		require.NoError(t, os.MkdirAll(wtDir, 0o755))
-		oldWt := filepath.Join(wtDir, "old-wt.jsonl")
-		writeSessionFile(t, oldWt, "2020-01-01T00:00:00Z", "old wt")
-		ageFile(t, oldWt, 31*24*time.Hour)
-		recent := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
-		writeSessionFile(t, filepath.Join(wtDir, "new-wt.jsonl"), recent, "new wt")
+		seedSession(t, wtDir, "old-wt.jsonl", 31*24*time.Hour)
+		seedSession(t, wtDir, "new-wt.jsonl", 0)
 		require.NoError(t, os.MkdirAll(filepath.Join(".claude-worktrees", "feature"), 0o755))
 
 		cmd := newPruneCmd()
@@ -355,9 +353,7 @@ func TestPruneCmd(t *testing.T) {
 		sessionDir := pruneSetup(t)
 		wtDir := filepath.Join(sessionDir, "-work--claude-worktrees-feature")
 		require.NoError(t, os.MkdirAll(wtDir, 0o755))
-		oldWt := filepath.Join(wtDir, "old-wt.jsonl")
-		writeSessionFile(t, oldWt, "2020-01-01T00:00:00Z", "old wt")
-		ageFile(t, oldWt, 31*24*time.Hour)
+		seedSession(t, wtDir, "old-wt.jsonl", 31*24*time.Hour)
 		// A just-launched session's transcript exists but has no parseable
 		// timestamp yet, so List skips it; it must still suppress the hint.
 		require.NoError(t, os.WriteFile(filepath.Join(wtDir, "launching.jsonl"), nil, 0o644))
@@ -373,8 +369,7 @@ func TestPruneCmd(t *testing.T) {
 
 	t.Run("nothing to prune", func(t *testing.T) {
 		sessionDir := pruneSetup(t)
-		recent := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
-		writeSessionFile(t, filepath.Join(sessionDir, "-work", "new.jsonl"), recent, "new")
+		seedSession(t, filepath.Join(sessionDir, "-work"), "new.jsonl", 0)
 
 		cmd := newPruneCmd()
 		cmd.SetArgs([]string{"--older-than", "30d"})

--- a/cmd/claude-forge/main_test.go
+++ b/cmd/claude-forge/main_test.go
@@ -114,10 +114,19 @@ func pruneSetup(t *testing.T) string {
 	return sessionDir
 }
 
+// ageFile pushes a file's mtime into the past so prune sees it as inactive.
+func ageFile(t *testing.T, path string, age time.Duration) {
+	t.Helper()
+	old := time.Now().Add(-age)
+	require.NoError(t, os.Chtimes(path, old, old))
+}
+
 func TestPruneCmd(t *testing.T) {
 	t.Run("defaults to older-than 30 days", func(t *testing.T) {
 		sessionDir := pruneSetup(t)
-		writeSessionFile(t, filepath.Join(sessionDir, "-work", "old.jsonl"), "2020-01-01T00:00:00Z", "old")
+		oldFile := filepath.Join(sessionDir, "-work", "old.jsonl")
+		writeSessionFile(t, oldFile, "2020-01-01T00:00:00Z", "old")
+		ageFile(t, oldFile, 31*24*time.Hour)
 		recent := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
 		writeSessionFile(t, filepath.Join(sessionDir, "-work", "new.jsonl"), recent, "new")
 
@@ -126,7 +135,7 @@ func TestPruneCmd(t *testing.T) {
 		out := captureStdout(t, func() { require.NoError(t, cmd.Execute()) })
 
 		assert.Contains(t, out, "Deleted 1 session")
-		assert.NoFileExists(t, filepath.Join(sessionDir, "-work", "old.jsonl"))
+		assert.NoFileExists(t, oldFile)
 		assert.FileExists(t, filepath.Join(sessionDir, "-work", "new.jsonl"))
 	})
 
@@ -150,6 +159,7 @@ func TestPruneCmd(t *testing.T) {
 		sessionDir := pruneSetup(t)
 		oldFile := filepath.Join(sessionDir, "-work", "old.jsonl")
 		writeSessionFile(t, oldFile, "2020-01-01T00:00:00Z", "old one")
+		ageFile(t, oldFile, 31*24*time.Hour)
 		recent := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
 		newFile := filepath.Join(sessionDir, "-work", "new.jsonl")
 		writeSessionFile(t, newFile, recent, "new one")
@@ -169,6 +179,7 @@ func TestPruneCmd(t *testing.T) {
 		sessionDir := pruneSetup(t)
 		oldFile := filepath.Join(sessionDir, "-work", "old.jsonl")
 		writeSessionFile(t, oldFile, "2020-01-01T00:00:00Z", "old one")
+		ageFile(t, oldFile, 31*24*time.Hour)
 		require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "old.json"), []byte(`{"name":"gone"}`), 0o644))
 		recent := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
 		newFile := filepath.Join(sessionDir, "-work", "new.jsonl")
@@ -184,20 +195,180 @@ func TestPruneCmd(t *testing.T) {
 		assert.FileExists(t, newFile) // recent one survives
 	})
 
-	t.Run("keep protects newest", func(t *testing.T) {
+	t.Run("keep alone protects most recently active, ignores age", func(t *testing.T) {
 		sessionDir := pruneSetup(t)
-		writeSessionFile(t, filepath.Join(sessionDir, "-work", "a.jsonl"), "2026-01-01T00:00:00Z", "a")
-		writeSessionFile(t, filepath.Join(sessionDir, "-work", "b.jsonl"), "2026-02-01T00:00:00Z", "b")
-		writeSessionFile(t, filepath.Join(sessionDir, "-work", "c.jsonl"), "2026-03-01T00:00:00Z", "c")
+		recent := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+		for name, age := range map[string]time.Duration{
+			"a.jsonl": 3 * time.Hour,
+			"b.jsonl": 2 * time.Hour,
+			"c.jsonl": time.Hour,
+		} {
+			path := filepath.Join(sessionDir, "-work", name)
+			writeSessionFile(t, path, recent, name)
+			ageFile(t, path, age)
+		}
 
 		cmd := newPruneCmd()
 		cmd.SetArgs([]string{"--keep", "1"})
 		out := captureStdout(t, func() { require.NoError(t, cmd.Execute()) })
 
+		// All sessions are hours old — far inside the default 30d window — yet
+		// --keep alone still prunes everything beyond the most recently active.
 		assert.Contains(t, out, "Deleted 2 session")
-		assert.FileExists(t, filepath.Join(sessionDir, "-work", "c.jsonl"))   // newest kept
-		assert.NoFileExists(t, filepath.Join(sessionDir, "-work", "a.jsonl")) // older pruned
+		assert.FileExists(t, filepath.Join(sessionDir, "-work", "c.jsonl"))   // most recently active kept
+		assert.NoFileExists(t, filepath.Join(sessionDir, "-work", "a.jsonl")) // less recent pruned
 		assert.NoFileExists(t, filepath.Join(sessionDir, "-work", "b.jsonl"))
+	})
+
+	t.Run("explicit keep and older-than are ANDed", func(t *testing.T) {
+		sessionDir := pruneSetup(t)
+		recent := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+		for name, age := range map[string]time.Duration{
+			"fresh.jsonl": time.Hour,
+			"mid.jsonl":   2 * time.Hour,
+			"old.jsonl":   40 * 24 * time.Hour,
+		} {
+			path := filepath.Join(sessionDir, "-work", name)
+			writeSessionFile(t, path, recent, name)
+			ageFile(t, path, age)
+		}
+
+		cmd := newPruneCmd()
+		cmd.SetArgs([]string{"--keep", "1", "--older-than", "30d"})
+		out := captureStdout(t, func() { require.NoError(t, cmd.Execute()) })
+
+		// mid is beyond --keep 1 but not older than 30d, so only old goes.
+		assert.Contains(t, out, "Deleted 1 session")
+		assert.FileExists(t, filepath.Join(sessionDir, "-work", "fresh.jsonl"))
+		assert.FileExists(t, filepath.Join(sessionDir, "-work", "mid.jsonl"))
+		assert.NoFileExists(t, filepath.Join(sessionDir, "-work", "old.jsonl"))
+	})
+
+	t.Run("negative keep errors", func(t *testing.T) {
+		cmd := newPruneCmd()
+		cmd.SetArgs([]string{"--keep", "-1"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--keep must be >= 0")
+	})
+
+	t.Run("age is last activity, not session start", func(t *testing.T) {
+		sessionDir := pruneSetup(t)
+		// Started years ago but resumed recently: fresh mtime → survives.
+		resumed := filepath.Join(sessionDir, "-work", "resumed.jsonl")
+		writeSessionFile(t, resumed, "2020-01-01T00:00:00Z", "resumed")
+		// Started recently per its first timestamp but long inactive: old
+		// mtime → pruned.
+		stale := filepath.Join(sessionDir, "-work", "stale.jsonl")
+		recent := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+		writeSessionFile(t, stale, recent, "stale")
+		ageFile(t, stale, 31*24*time.Hour)
+
+		cmd := newPruneCmd()
+		cmd.SetArgs([]string{})
+		out := captureStdout(t, func() { require.NoError(t, cmd.Execute()) })
+
+		assert.Contains(t, out, "Deleted 1 session")
+		assert.FileExists(t, resumed)
+		assert.NoFileExists(t, stale)
+	})
+
+	t.Run("sweeps orphaned sidecars", func(t *testing.T) {
+		sessionDir := pruneSetup(t)
+		const orphanID = "12345678-1234-4234-8234-123456789abc"
+		orphan := filepath.Join(sessionDir, orphanID+".json")
+		require.NoError(t, os.WriteFile(orphan, []byte(`{"name":"gone"}`), 0o644))
+		ageFile(t, orphan, 2*time.Hour) // past the just-started grace period
+		// Non-UUID .json files are never swept.
+		other := filepath.Join(sessionDir, "settings.json")
+		require.NoError(t, os.WriteFile(other, []byte(`{}`), 0o644))
+
+		cmd := newPruneCmd()
+		cmd.SetArgs([]string{"--dry-run"})
+		out := captureStdout(t, func() { require.NoError(t, cmd.Execute()) })
+		assert.Contains(t, out, "would delete orphaned sidecar  "+orphanID)
+		assert.FileExists(t, orphan) // dry-run: nothing removed
+
+		cmd = newPruneCmd()
+		cmd.SetArgs([]string{})
+		out = captureStdout(t, func() { require.NoError(t, cmd.Execute()) })
+		assert.Contains(t, out, "deleted orphaned sidecar  "+orphanID)
+		assert.Contains(t, out, "1 orphaned sidecar(s)")
+		assert.NoFileExists(t, orphan)
+		assert.FileExists(t, other)
+	})
+
+	t.Run("fresh orphan sidecar survives the sweep", func(t *testing.T) {
+		sessionDir := pruneSetup(t)
+		// A just-started session writes its sidecar before Claude Code creates
+		// the transcript; the fresh mtime must protect it from the sweep.
+		const freshID = "abcdefab-abcd-4bcd-8bcd-abcdefabcdef"
+		fresh := filepath.Join(sessionDir, freshID+".json")
+		require.NoError(t, os.WriteFile(fresh, []byte(`{"name":"live"}`), 0o644))
+
+		cmd := newPruneCmd()
+		cmd.SetArgs([]string{})
+		out := captureStdout(t, func() { require.NoError(t, cmd.Execute()) })
+		assert.Contains(t, out, "No sessions to prune.")
+		assert.FileExists(t, fresh)
+	})
+
+	t.Run("worktree hint when last referencing session is pruned", func(t *testing.T) {
+		sessionDir := pruneSetup(t)
+		wtDir := filepath.Join(sessionDir, "-work--claude-worktrees-feature")
+		require.NoError(t, os.MkdirAll(wtDir, 0o755))
+		wtFile := filepath.Join(wtDir, "wt.jsonl")
+		writeSessionFile(t, wtFile, "2020-01-01T00:00:00Z", "wt")
+		ageFile(t, wtFile, 31*24*time.Hour)
+		// pruneSetup chdirs into the repo, so the worktree path is relative to cwd.
+		require.NoError(t, os.MkdirAll(filepath.Join(".claude-worktrees", "feature"), 0o755))
+
+		cmd := newPruneCmd()
+		cmd.SetArgs([]string{})
+		out := captureStdout(t, func() { require.NoError(t, cmd.Execute()) })
+
+		assert.Contains(t, out, "git worktree remove .claude-worktrees/feature")
+		// The worktree itself is never removed automatically.
+		assert.DirExists(t, filepath.Join(".claude-worktrees", "feature"))
+	})
+
+	t.Run("no worktree hint while another session references it", func(t *testing.T) {
+		sessionDir := pruneSetup(t)
+		wtDir := filepath.Join(sessionDir, "-work--claude-worktrees-feature")
+		require.NoError(t, os.MkdirAll(wtDir, 0o755))
+		oldWt := filepath.Join(wtDir, "old-wt.jsonl")
+		writeSessionFile(t, oldWt, "2020-01-01T00:00:00Z", "old wt")
+		ageFile(t, oldWt, 31*24*time.Hour)
+		recent := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+		writeSessionFile(t, filepath.Join(wtDir, "new-wt.jsonl"), recent, "new wt")
+		require.NoError(t, os.MkdirAll(filepath.Join(".claude-worktrees", "feature"), 0o755))
+
+		cmd := newPruneCmd()
+		cmd.SetArgs([]string{})
+		out := captureStdout(t, func() { require.NoError(t, cmd.Execute()) })
+
+		assert.Contains(t, out, "Deleted 1 session")
+		assert.NotContains(t, out, "git worktree remove")
+	})
+
+	t.Run("no worktree hint while an unparseable transcript remains", func(t *testing.T) {
+		sessionDir := pruneSetup(t)
+		wtDir := filepath.Join(sessionDir, "-work--claude-worktrees-feature")
+		require.NoError(t, os.MkdirAll(wtDir, 0o755))
+		oldWt := filepath.Join(wtDir, "old-wt.jsonl")
+		writeSessionFile(t, oldWt, "2020-01-01T00:00:00Z", "old wt")
+		ageFile(t, oldWt, 31*24*time.Hour)
+		// A just-launched session's transcript exists but has no parseable
+		// timestamp yet, so List skips it; it must still suppress the hint.
+		require.NoError(t, os.WriteFile(filepath.Join(wtDir, "launching.jsonl"), nil, 0o644))
+		require.NoError(t, os.MkdirAll(filepath.Join(".claude-worktrees", "feature"), 0o755))
+
+		cmd := newPruneCmd()
+		cmd.SetArgs([]string{})
+		out := captureStdout(t, func() { require.NoError(t, cmd.Execute()) })
+
+		assert.Contains(t, out, "Deleted 1 session")
+		assert.NotContains(t, out, "git worktree remove")
 	})
 
 	t.Run("nothing to prune", func(t *testing.T) {

--- a/docs/content/docs/usage.md
+++ b/docs/content/docs/usage.md
@@ -45,18 +45,39 @@ claude-forge resume <session-id> --name "new name"
 
 ## Prune Old Sessions
 
+Session age is measured by **last activity** (the transcript file's
+modification time), so a session started long ago but resumed recently is not
+pruned.
+
 ```bash
-# Delete sessions older than 30 days (default)
+# Delete sessions inactive for 30+ days (default)
 claude-forge prune
 
-# Delete sessions older than a custom age
+# Delete sessions inactive for a custom duration
 claude-forge prune --older-than 7d
 
-# Keep the 10 most recent sessions, delete the rest
+# Keep the 10 most recently active sessions, delete all the rest
+# (used alone, --keep replaces the 30-day default instead of combining with it)
 claude-forge prune --keep 10
+
+# Combine both: only delete sessions that are inactive for 7+ days
+# AND not among the 10 most recently active
+claude-forge prune --older-than 7d --keep 10
 
 # Preview without deleting
 claude-forge prune --dry-run
+```
+
+Prune also cleans up orphaned session-name sidecar files whose transcript no
+longer exists. Sidecars written within the last hour are left alone: a
+just-started session records its name before its transcript exists.
+
+Git worktrees created by `start --worktree` are never removed automatically —
+they may contain uncommitted work. When pruning deletes the last session that
+referenced a worktree, prune prints a hint to remove it yourself:
+
+```bash
+git worktree remove .claude-worktrees/<name>
 ```
 
 ## Manage Containers

--- a/internal/forge/session/session.go
+++ b/internal/forge/session/session.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -37,11 +38,12 @@ func GenerateUUID() (string, error) {
 
 // Session represents a claude-forge session.
 type Session struct {
-	ID        string
-	CreatedAt time.Time
-	FirstMsg  string
-	Name      string // human-readable name from the sidecar metadata file
-	Subdir    string // relative subdirectory within session dir (e.g., "-work", "-work-.claude-worktrees-feature")
+	ID         string
+	CreatedAt  time.Time
+	LastActive time.Time // last activity, taken from the transcript file's mtime
+	FirstMsg   string
+	Name       string // human-readable name from the sidecar metadata file
+	Subdir     string // relative subdirectory within session dir (e.g., "-work", "-work--claude-worktrees-feature")
 }
 
 // Metadata is sidecar information about a session, stored next to the JSONL
@@ -145,7 +147,7 @@ func extractContent(raw json.RawMessage) string {
 // sessionDir is the host path like ~/.claude-forge/<project-id>/, which is
 // bind-mounted to /home/user/.claude/projects in the container. Claude Code
 // stores sessions under <encoded-cwd>/<session-id>.jsonl — typically -work/ for
-// the main workspace and -work-.claude-worktrees-<name>/ for each worktree.
+// the main workspace and -work--claude-worktrees-<name>/ for each worktree.
 //
 // To surface all of those in `resume --list`, List walks one level of
 // subdirectories. .jsonl files placed directly under sessionDir are also
@@ -178,6 +180,12 @@ func List(sessionDir string) ([]Session, error) {
 			}
 			sess.Subdir = subdir
 			sess.Name = readMetadata(sessionDir, sessionID).Name
+			// The transcript is appended on every turn, so its mtime is the
+			// session's last activity. Fall back to the parsed start time.
+			sess.LastActive = sess.CreatedAt
+			if info, err := e.Info(); err == nil {
+				sess.LastActive = info.ModTime()
+			}
 			sessions = append(sessions, *sess)
 		}
 	}
@@ -268,6 +276,61 @@ func Delete(sessionDir string, s Session) error {
 		return fmt.Errorf("failed to remove session metadata: %w", err)
 	}
 	return nil
+}
+
+// sidecarIDPattern matches the UUID-v4-shaped IDs (8-4-4-4-12 lowercase hex)
+// that WriteMetadata is invoked with. Restricting the orphan sweep to this
+// shape guarantees unrelated .json files are never touched.
+var sidecarIDPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+// OrphanedSidecars returns the sorted IDs of top-level sidecar metadata files
+// ("<id>.json" with a UUID-shaped id) whose transcript ("<id>.jsonl") no longer
+// exists, neither at the top level nor in any first-level subdirectory. The
+// transcript's mere presence keeps a sidecar; it need not be parseable. A
+// missing sessionDir yields no orphans.
+func OrphanedSidecars(sessionDir string) ([]string, error) {
+	entries, err := os.ReadDir(sessionDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read session directory: %w", err)
+	}
+
+	hasTranscript := make(map[string]bool)
+	for _, e := range entries {
+		if e.IsDir() {
+			subEntries, err := os.ReadDir(filepath.Join(sessionDir, e.Name()))
+			if err != nil {
+				continue
+			}
+			for _, se := range subEntries {
+				if !se.IsDir() && strings.HasSuffix(se.Name(), ".jsonl") {
+					hasTranscript[strings.TrimSuffix(se.Name(), ".jsonl")] = true
+				}
+			}
+			continue
+		}
+		if strings.HasSuffix(e.Name(), ".jsonl") {
+			hasTranscript[strings.TrimSuffix(e.Name(), ".jsonl")] = true
+		}
+	}
+
+	var orphans []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		id := strings.TrimSuffix(e.Name(), ".json")
+		if !sidecarIDPattern.MatchString(id) {
+			continue
+		}
+		if !hasTranscript[id] {
+			orphans = append(orphans, id)
+		}
+	}
+	sort.Strings(orphans)
+	return orphans, nil
 }
 
 // Find locates a session by exact ID, or failing that by name, across all

--- a/internal/forge/session/session.go
+++ b/internal/forge/session/session.go
@@ -272,7 +272,13 @@ func Delete(sessionDir string, s Session) error {
 	if err := os.Remove(jsonl); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to remove session transcript: %w", err)
 	}
-	if err := os.Remove(metadataPath(sessionDir, s.ID)); err != nil && !os.IsNotExist(err) {
+	return DeleteSidecar(sessionDir, s.ID)
+}
+
+// DeleteSidecar removes a session's sidecar metadata file, if present. A
+// missing file is not an error.
+func DeleteSidecar(sessionDir, sessionID string) error {
+	if err := os.Remove(metadataPath(sessionDir, sessionID)); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to remove session metadata: %w", err)
 	}
 	return nil
@@ -283,12 +289,20 @@ func Delete(sessionDir string, s Session) error {
 // shape guarantees unrelated .json files are never touched.
 var sidecarIDPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
-// OrphanedSidecars returns the sorted IDs of top-level sidecar metadata files
+// OrphanedSidecar identifies a sidecar metadata file with no matching
+// transcript, along with its last modification time so callers can apply an
+// age policy without re-statting the file.
+type OrphanedSidecar struct {
+	ID      string
+	ModTime time.Time
+}
+
+// OrphanedSidecars returns, sorted by ID, the top-level sidecar metadata files
 // ("<id>.json" with a UUID-shaped id) whose transcript ("<id>.jsonl") no longer
 // exists, neither at the top level nor in any first-level subdirectory. The
 // transcript's mere presence keeps a sidecar; it need not be parseable. A
 // missing sessionDir yields no orphans.
-func OrphanedSidecars(sessionDir string) ([]string, error) {
+func OrphanedSidecars(sessionDir string) ([]OrphanedSidecar, error) {
 	entries, err := os.ReadDir(sessionDir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -316,21 +330,38 @@ func OrphanedSidecars(sessionDir string) ([]string, error) {
 		}
 	}
 
-	var orphans []string
+	var orphans []OrphanedSidecar
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
 			continue
 		}
 		id := strings.TrimSuffix(e.Name(), ".json")
-		if !sidecarIDPattern.MatchString(id) {
+		if !sidecarIDPattern.MatchString(id) || hasTranscript[id] {
 			continue
 		}
-		if !hasTranscript[id] {
-			orphans = append(orphans, id)
+		info, err := e.Info()
+		if err != nil {
+			continue // vanished between ReadDir and Info; nothing to sweep
+		}
+		orphans = append(orphans, OrphanedSidecar{ID: id, ModTime: info.ModTime()})
+	}
+	sort.Slice(orphans, func(i, j int) bool { return orphans[i].ID < orphans[j].ID })
+	return orphans, nil
+}
+
+// HasTranscripts reports whether dir contains any transcript (.jsonl) file,
+// parseable or not. A missing or unreadable dir has none.
+func HasTranscripts(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".jsonl") {
+			return true
 		}
 	}
-	sort.Strings(orphans)
-	return orphans, nil
+	return false
 }
 
 // Find locates a session by exact ID, or failing that by name, across all

--- a/internal/forge/session/session_test.go
+++ b/internal/forge/session/session_test.go
@@ -241,9 +241,100 @@ func TestList(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+			// LastActive is the file mtime (set at write time above); clear it
+			// so the table can compare the parsed fields deterministically.
+			for i := range got {
+				assert.False(t, got[i].LastActive.IsZero())
+				got[i].LastActive = time.Time{}
+			}
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestList_PopulatesLastActiveFromMtime(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	workDir := filepath.Join(tmpDir, "-work")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+	jsonl := filepath.Join(workDir, "sess-1.jsonl")
+	require.NoError(t, os.WriteFile(jsonl,
+		[]byte(`{"type":"user","message":{"role":"user","content":"hi"},"timestamp":"2020-01-01T00:00:00Z"}`+"\n"), 0o644))
+
+	// The session started in 2020, but its transcript was touched much later:
+	// LastActive must reflect the mtime, not the first timestamp.
+	lastActive := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(jsonl, lastActive, lastActive))
+
+	got, err := List(tmpDir)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC), got[0].CreatedAt)
+	assert.True(t, got[0].LastActive.Equal(lastActive), "LastActive = %v, want %v", got[0].LastActive, lastActive)
+}
+
+func TestOrphanedSidecars(t *testing.T) {
+	const (
+		orphanID = "11111111-2222-4333-8444-555555555555"
+		keptID   = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+		legacyID = "99999999-8888-4777-8666-555555555555"
+	)
+
+	t.Run("orphan detected", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, orphanID+".json"), []byte(`{"name":"gone"}`), 0o644))
+
+		got, err := OrphanedSidecars(tmpDir)
+		require.NoError(t, err)
+		assert.Equal(t, []string{orphanID}, got)
+	})
+
+	t.Run("sidecar with transcript in subdir is kept", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		workDir := filepath.Join(tmpDir, "-work")
+		require.NoError(t, os.MkdirAll(workDir, 0o755))
+		// The transcript need not be parseable; its presence keeps the sidecar.
+		require.NoError(t, os.WriteFile(filepath.Join(workDir, keptID+".jsonl"), []byte("not json"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, keptID+".json"), []byte(`{"name":"kept"}`), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, orphanID+".json"), []byte(`{"name":"gone"}`), 0o644))
+
+		got, err := OrphanedSidecars(tmpDir)
+		require.NoError(t, err)
+		assert.Equal(t, []string{orphanID}, got)
+	})
+
+	t.Run("sidecar with legacy top-level transcript is kept", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, legacyID+".jsonl"), []byte("{}"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, legacyID+".json"), []byte(`{"name":"legacy"}`), 0o644))
+
+		got, err := OrphanedSidecars(tmpDir)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("non-UUID json ignored", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "settings.json"), []byte(`{}`), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "sess-1.json"), []byte(`{"name":"short-id"}`), 0o644))
+
+		got, err := OrphanedSidecars(tmpDir)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("missing directory", func(t *testing.T) {
+		got, err := OrphanedSidecars(filepath.Join(t.TempDir(), "missing"))
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("unreadable directory errors", func(t *testing.T) {
+		notADir := filepath.Join(t.TempDir(), "file")
+		require.NoError(t, os.WriteFile(notADir, []byte("x"), 0o644))
+		_, err := OrphanedSidecars(notADir)
+		require.Error(t, err)
+	})
 }
 
 func TestList_NonExistentDirectory(t *testing.T) {

--- a/internal/forge/session/session_test.go
+++ b/internal/forge/session/session_test.go
@@ -286,7 +286,9 @@ func TestOrphanedSidecars(t *testing.T) {
 
 		got, err := OrphanedSidecars(tmpDir)
 		require.NoError(t, err)
-		assert.Equal(t, []string{orphanID}, got)
+		require.Len(t, got, 1)
+		assert.Equal(t, orphanID, got[0].ID)
+		assert.False(t, got[0].ModTime.IsZero(), "ModTime should come from the sidecar file")
 	})
 
 	t.Run("sidecar with transcript in subdir is kept", func(t *testing.T) {
@@ -300,7 +302,8 @@ func TestOrphanedSidecars(t *testing.T) {
 
 		got, err := OrphanedSidecars(tmpDir)
 		require.NoError(t, err)
-		assert.Equal(t, []string{orphanID}, got)
+		require.Len(t, got, 1)
+		assert.Equal(t, orphanID, got[0].ID)
 	})
 
 	t.Run("sidecar with legacy top-level transcript is kept", func(t *testing.T) {
@@ -334,6 +337,40 @@ func TestOrphanedSidecars(t *testing.T) {
 		require.NoError(t, os.WriteFile(notADir, []byte("x"), 0o644))
 		_, err := OrphanedSidecars(notADir)
 		require.Error(t, err)
+	})
+}
+
+func TestDeleteSidecar(t *testing.T) {
+	const id = "11111111-2222-4333-8444-555555555555"
+
+	t.Run("removes sidecar", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		require.NoError(t, WriteMetadata(tmpDir, id, Metadata{Name: "doomed"}))
+		require.NoError(t, DeleteSidecar(tmpDir, id))
+		assert.NoFileExists(t, filepath.Join(tmpDir, id+".json"))
+	})
+
+	t.Run("missing sidecar is not an error", func(t *testing.T) {
+		require.NoError(t, DeleteSidecar(t.TempDir(), id))
+	})
+}
+
+func TestHasTranscripts(t *testing.T) {
+	t.Run("transcript present", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "a.jsonl"), []byte("not even json"), 0o644))
+		assert.True(t, HasTranscripts(tmpDir))
+	})
+
+	t.Run("only non-transcript files", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "a.json"), []byte("{}"), 0o644))
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "b.jsonl"), 0o755)) // a directory does not count
+		assert.False(t, HasTranscripts(tmpDir))
+	})
+
+	t.Run("missing directory", func(t *testing.T) {
+		assert.False(t, HasTranscripts(filepath.Join(t.TempDir(), "missing")))
 	})
 }
 


### PR DESCRIPTION
## Summary

`claude-forge prune` left completed sessions behind and could delete the wrong ones. This fixes the prune subcommand only (resume's transcript-forking behavior is intentionally out of scope).

- **`--keep` no longer silently ANDed with the 30-day default.** `prune --keep 5` previously deleted nothing newer than 30 days (the `olderThan != ""` guard was dead code — the flag default is never empty). Now `--keep N` alone keeps the N most recently active sessions and deletes the rest; combining it with an explicit `--older-than` applies both conditions. An explicit negative `--keep` errors.
- **Age is now last activity, not session start.** Age was read from the first timestamp inside the JSONL, so a month-old session resumed yesterday was pruned while day-old forks survived. Prune now sorts and filters by transcript mtime (new `session.Session.LastActive`) and prints that time in its output.
- **Orphaned name sidecars are swept.** A top-level `<uuid>.json` whose transcript no longer exists anywhere is deleted on every prune (new `session.OrphanedSidecars`; non-UUID `.json` files are never touched). A one-hour grace period protects just-started sessions, whose sidecar exists before Claude Code writes the transcript.
- **Worktree hint instead of silent leftovers.** Pruning the last session of a worktree prints a `git worktree remove .claude-worktrees/<name>` hint. The worktree is never removed automatically (it may hold uncommitted work), and the hint is suppressed while any transcript file remains in that worktree's subdirectory — including JSONLs `List` cannot parse yet.

Docs: the "Prune Old Sessions" section of `docs/content/docs/usage.md` now documents the new semantics.

## Test plan

- Updated `TestPruneCmd` (15 subtests): keep-alone ignores the age window, explicit `--keep` + `--older-than` is AND, negative keep errors, mtime-based age in both directions (`os.Chtimes`), orphan sweep in dry-run and real runs (fresh orphans survive, non-UUID `.json` untouched), worktree hint printed/suppressed cases.
- New session package tests: `List` populates `LastActive`, `TestOrphanedSidecars` (subdir and legacy top-level transcripts kept, non-UUID ignored, missing dir).
- `go build`, `go vet`, `gofmt -l`, `go test -race ./...` all green locally; CI-style coverage gate (excluding `mock_` files) at 91.3% (threshold 90%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)