### PR TITLE
fix: keep Kubernetes MCP ServiceAccount tokens fresh across long sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,9 @@ changed its CLI interface across versions.
 ## Key invariants
 
 - Kubernetes MCP runs without `--read-only` or `--disable-destructive` (RBAC is the safety layer)
+- The k8s MCP kubeconfig references SA tokens via `tokenFile` in a mounted
+  directory; rotating credentials means rewriting the token files (at session
+  start and periodically while attached), never restarting the container
 - MCP servers are only written to `settings.json` when actually running
 - `UpdateMCPServers` replaces the map entirely (no stale entries from prior sessions)
 - The host Docker socket is never mounted into the agent; the agent runs

--- a/cmd/claude-forge/main.go
+++ b/cmd/claude-forge/main.go
@@ -127,10 +127,11 @@ func startSession(skipPermissions, worktree bool, prompt, resumeID, resumeSubdir
 
 	// The Kubernetes MCP server's SA tokens expire after ~1h on most clusters
 	// while a session can stay open for days; keep re-minting them for as
-	// long as this process is attached to the session.
+	// long as this process is attached to the session. Quiet in interactive
+	// mode: stdout belongs to the attached TTY there.
 	refreshCtx, stopRefresh := context.WithCancel(ctx)
 	defer stopRefresh()
-	go orch.RunKubeTokenRefresher(refreshCtx)
+	go orch.RunKubeTokenRefresher(refreshCtx, interactive)
 
 	if interactive {
 		// Attach to the agent container's TTY using docker attach.

--- a/cmd/claude-forge/main.go
+++ b/cmd/claude-forge/main.go
@@ -125,6 +125,13 @@ func startSession(skipPermissions, worktree bool, prompt, resumeID, resumeSubdir
 		return err
 	}
 
+	// The Kubernetes MCP server's SA tokens expire after ~1h on most clusters
+	// while a session can stay open for days; keep re-minting them for as
+	// long as this process is attached to the session.
+	refreshCtx, stopRefresh := context.WithCancel(ctx)
+	defer stopRefresh()
+	go orch.RunKubeTokenRefresher(refreshCtx)
+
 	if interactive {
 		// Attach to the agent container's TTY using docker attach.
 		fmt.Println("Claude Code is ready. Attaching to session...")
@@ -284,8 +291,10 @@ docker:
 #     path: /mcp
 
 # Kubernetes MCP server integration.
-# When enabled, a shared MCP server container gives agents read-only
-# access to your clusters via short-lived ServiceAccount tokens.
+# When enabled, a shared MCP server container gives agents access to your
+# clusters via ServiceAccount tokens that claude-forge mints at session start
+# and keeps refreshing while sessions run. token_duration sets the requested
+# token lifetime (default 24h; the API server may cap it lower).
 #
 # Prerequisites:
 #   1. Create RBAC resources:  claude-forge kube render --context <ctx> | kubectl apply -f -
@@ -303,6 +312,7 @@ docker:
 # kubernetes:
 #   enabled: true
 #   image: ` + forgeconfig.DefaultKubernetesMCPImage + `
+#   token_duration: 24h
 #   default_context: my-cluster
 #   contexts:
 #     - host_context: my-cluster
@@ -315,6 +325,7 @@ docker:
 	b.WriteString("# kubernetes:\n")
 	b.WriteString("#   enabled: true\n")
 	b.WriteString("#   image: " + forgeconfig.DefaultKubernetesMCPImage + "\n")
+	b.WriteString("#   token_duration: 24h\n")
 	b.WriteString("#   default_context: " + contexts[0] + "\n")
 	b.WriteString("#   contexts:\n")
 	for _, ctx := range contexts {

--- a/docs/content/docs/configuration.md
+++ b/docs/content/docs/configuration.md
@@ -67,6 +67,10 @@ mcp_servers:
 kubernetes:
   enabled: false
   image: ghcr.io/containers/kubernetes-mcp-server:latest
+  # ServiceAccount token lifetime to request (Go duration, default 24h).
+  # Tokens are re-minted at session start and refreshed while sessions run;
+  # the API server may cap the granted lifetime.
+  token_duration: 24h
   default_context: dev
   contexts:
     - host_context: dev

--- a/docs/content/docs/how-it-works.md
+++ b/docs/content/docs/how-it-works.md
@@ -13,7 +13,9 @@ When you run `claude-forge start`, it:
 5. Starts a **GitHub MCP** sidecar scoped to the current repository
 6. If `kubernetes.enabled` is set, ensures the shared **Kubernetes MCP** server
    is running — a single instance on the `forge-shared` network, reused by
-   every session rather than started per session
+   every session rather than started per session — and re-mints its
+   ServiceAccount tokens, which are then refreshed periodically for as long as
+   the session runs
 7. Starts any custom **container MCP sidecars** from `config.yaml` — on the
    session network (`scope: session`) or the shared network (`scope: global`)
 8. Writes the MCP server list for Claude Code: the built-in `github` server,

--- a/docs/content/docs/mcp-servers/kubernetes.md
+++ b/docs/content/docs/mcp-servers/kubernetes.md
@@ -28,8 +28,11 @@ servers cap the lifetime at 1–48 hours — while Claude Code sessions can stay
 open for days, so claude-forge keeps them fresh automatically:
 
 - **At every session start**, tokens are re-minted, even when the shared MCP
-  server container is already running.
-- **While a session runs**, the CLI refreshes them every 15 minutes.
+  server container is already running. If the `kubernetes.contexts`
+  configuration changed since the server started, the server is recreated so
+  the new contexts take effect.
+- **While a session runs**, the CLI refreshes them every 15 minutes, or every
+  half token lifetime if that is shorter.
 - The generated kubeconfig references each token via `tokenFile` from a
   directory mounted into the container, and the server's Kubernetes client
   re-reads that file on its own — rotation requires no container restart.
@@ -38,9 +41,10 @@ open for days, so claude-forge keeps them fresh automatically:
 (default `24h`, minimum `10m`, any Go duration string). The API server may
 grant less — EKS caps tokens at 24h, GKE at 48h, and a vanilla cluster caps at
 its `--service-account-max-token-expiration` — in which case the request is
-shortened, not rejected. During active sessions the refresh loop makes the
-granted lifetime largely irrelevant; a longer duration widens the safety
-margin for times when no refresh can run, such as the host being asleep.
+shortened, not rejected; if a cluster rejects the request outright,
+claude-forge falls back to the server-default lifetime. A longer duration
+widens the safety margin for times when no refresh can run, such as the host
+being asleep.
 
 If your clusters grant long lifetimes and you prefer effectively long-lived
 credentials, set for example `token_duration: 168h`. Either way the

--- a/docs/content/docs/mcp-servers/kubernetes.md
+++ b/docs/content/docs/mcp-servers/kubernetes.md
@@ -49,3 +49,10 @@ being asleep.
 If your clusters grant long lifetimes and you prefer effectively long-lived
 credentials, set for example `token_duration: 168h`. Either way the
 ServiceAccount's RBAC — not the token lifetime — remains the safety boundary.
+
+On a multi-user host, note the on-disk trade-off: the MCP container runs as a
+non-host uid, so token files must be world-readable (0644) inside
+execute-only (0711) directories. Their names are salted with a 0600
+`.token-salt` file, so other local users cannot list or derive them — but
+anyone who obtains a token path (or root) can read a live, RBAC-scoped
+cluster credential from `~/.config/claude-forge/k8s-mcp/tokens/`.

--- a/docs/content/docs/mcp-servers/kubernetes.md
+++ b/docs/content/docs/mcp-servers/kubernetes.md
@@ -19,3 +19,29 @@ claude-forge kube render --context dev | kubectl apply -f -
 See the `kubernetes` section of the
 [configuration reference]({{< relref "/docs/configuration" >}}) for the
 available options.
+
+## Token lifetime and refresh
+
+The MCP server authenticates to each cluster with a ServiceAccount token
+minted on the host via `kubectl create token`. Tokens expire — most API
+servers cap the lifetime at 1–48 hours — while Claude Code sessions can stay
+open for days, so claude-forge keeps them fresh automatically:
+
+- **At every session start**, tokens are re-minted, even when the shared MCP
+  server container is already running.
+- **While a session runs**, the CLI refreshes them every 15 minutes.
+- The generated kubeconfig references each token via `tokenFile` from a
+  directory mounted into the container, and the server's Kubernetes client
+  re-reads that file on its own — rotation requires no container restart.
+
+`kubernetes.token_duration` sets the lifetime *requested* for each token
+(default `24h`, minimum `10m`, any Go duration string). The API server may
+grant less — EKS caps tokens at 24h, GKE at 48h, and a vanilla cluster caps at
+its `--service-account-max-token-expiration` — in which case the request is
+shortened, not rejected. During active sessions the refresh loop makes the
+granted lifetime largely irrelevant; a longer duration widens the safety
+margin for times when no refresh can run, such as the host being asleep.
+
+If your clusters grant long lifetimes and you prefer effectively long-lived
+credentials, set for example `token_duration: 168h`. Either way the
+ServiceAccount's RBAC — not the token lifetime — remains the safety boundary.

--- a/internal/forge/config/config.go
+++ b/internal/forge/config/config.go
@@ -349,8 +349,12 @@ func Load(configDir string) (*Config, error) {
 	if err := validateMCPServers(cfg.MCPServers); err != nil {
 		return nil, err
 	}
-	if _, err := cfg.Kubernetes.TokenDurationValue(); err != nil {
-		return nil, err
+	// Only validated when the integration is on: a leftover bad value in a
+	// disabled section must not break unrelated commands.
+	if cfg.Kubernetes.Enabled {
+		if _, err := cfg.Kubernetes.TokenDurationValue(); err != nil {
+			return nil, err
+		}
 	}
 
 	return cfg, nil

--- a/internal/forge/config/config.go
+++ b/internal/forge/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -34,6 +35,17 @@ const (
 	// DefaultMCPPath is the HTTP path a container MCP sidecar is reached at when
 	// the server config does not specify one.
 	DefaultMCPPath = "/mcp"
+
+	// DefaultKubeTokenDuration is the SA token lifetime requested for the
+	// Kubernetes MCP server when kubernetes.token_duration is unset. API
+	// servers cap it at their own maximum (often 1h, 24h on EKS, 48h on GKE);
+	// requesting long and letting the server cap covers refresh gaps such as
+	// the host sleeping between refresh ticks.
+	DefaultKubeTokenDuration = 24 * time.Hour
+
+	// MinKubeTokenDuration is the smallest expiration the TokenRequest API
+	// accepts.
+	MinKubeTokenDuration = 10 * time.Minute
 )
 
 // Config holds the claude-forge configuration.
@@ -256,6 +268,28 @@ type KubernetesConfig struct {
 	Image          string             `yaml:"image"`
 	Contexts       []KubeContextEntry `yaml:"contexts"`
 	DefaultContext string             `yaml:"default_context"`
+	// TokenDuration is the SA token lifetime to request, as a Go duration
+	// string (e.g. "1h", "168h"). Defaults to DefaultKubeTokenDuration; the
+	// API server may cap the granted lifetime at its own maximum. Tokens are
+	// re-minted at session start and refreshed while sessions run, so this
+	// only needs to cover gaps between refreshes.
+	TokenDuration string `yaml:"token_duration,omitempty"`
+}
+
+// TokenDurationValue returns the parsed token_duration, or the default when
+// unset.
+func (k KubernetesConfig) TokenDurationValue() (time.Duration, error) {
+	if k.TokenDuration == "" {
+		return DefaultKubeTokenDuration, nil
+	}
+	d, err := time.ParseDuration(k.TokenDuration)
+	if err != nil {
+		return 0, fmt.Errorf("invalid kubernetes.token_duration %q: %w", k.TokenDuration, err)
+	}
+	if d < MinKubeTokenDuration {
+		return 0, fmt.Errorf("kubernetes.token_duration %q is below the %s minimum the Kubernetes TokenRequest API accepts", k.TokenDuration, MinKubeTokenDuration)
+	}
+	return d, nil
 }
 
 // KubeContextEntry configures a single Kubernetes context to expose to the agent.
@@ -313,6 +347,9 @@ func Load(configDir string) (*Config, error) {
 	}
 
 	if err := validateMCPServers(cfg.MCPServers); err != nil {
+		return nil, err
+	}
+	if _, err := cfg.Kubernetes.TokenDurationValue(); err != nil {
 		return nil, err
 	}
 

--- a/internal/forge/config/config_test.go
+++ b/internal/forge/config/config_test.go
@@ -63,9 +63,10 @@ func TestLoad_KubernetesTokenDuration(t *testing.T) {
 		assert.Equal(t, 48*time.Hour, d)
 	})
 
-	t.Run("invalid value fails at load", func(t *testing.T) {
+	t.Run("invalid value fails at load when enabled", func(t *testing.T) {
 		dir := t.TempDir()
 		configYAML := `kubernetes:
+  enabled: true
   token_duration: nope
 `
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(configYAML), 0o644))
@@ -73,6 +74,18 @@ func TestLoad_KubernetesTokenDuration(t *testing.T) {
 		_, err := Load(dir)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "token_duration")
+	})
+
+	t.Run("invalid value is ignored when kubernetes is disabled", func(t *testing.T) {
+		dir := t.TempDir()
+		configYAML := `kubernetes:
+  enabled: false
+  token_duration: nope
+`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(configYAML), 0o644))
+
+		_, err := Load(dir)
+		require.NoError(t, err, "a bad value in a disabled section must not break unrelated commands")
 	})
 }
 

--- a/internal/forge/config/config_test.go
+++ b/internal/forge/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,6 +18,62 @@ func TestDefaultConfig(t *testing.T) {
 	assert.False(t, cfg.Defaults.SkipPermissions)
 	assert.False(t, cfg.Defaults.Worktree)
 	assert.False(t, cfg.Docker.Enabled)
+}
+
+func TestKubernetesConfig_TokenDurationValue(t *testing.T) {
+	t.Run("defaults when unset", func(t *testing.T) {
+		d, err := KubernetesConfig{}.TokenDurationValue()
+		require.NoError(t, err)
+		assert.Equal(t, DefaultKubeTokenDuration, d)
+	})
+
+	t.Run("parses a valid duration", func(t *testing.T) {
+		d, err := KubernetesConfig{TokenDuration: "1h"}.TokenDurationValue()
+		require.NoError(t, err)
+		assert.Equal(t, time.Hour, d)
+	})
+
+	t.Run("rejects an unparseable duration", func(t *testing.T) {
+		_, err := KubernetesConfig{TokenDuration: "one hour"}.TokenDurationValue()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid kubernetes.token_duration")
+	})
+
+	t.Run("rejects durations below the TokenRequest minimum", func(t *testing.T) {
+		_, err := KubernetesConfig{TokenDuration: "5m"}.TokenDurationValue()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "minimum")
+	})
+}
+
+func TestLoad_KubernetesTokenDuration(t *testing.T) {
+	t.Run("valid value is kept", func(t *testing.T) {
+		dir := t.TempDir()
+		configYAML := `kubernetes:
+  enabled: true
+  token_duration: 48h
+`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(configYAML), 0o644))
+
+		cfg, err := Load(dir)
+		require.NoError(t, err)
+		assert.Equal(t, "48h", cfg.Kubernetes.TokenDuration)
+		d, err := cfg.Kubernetes.TokenDurationValue()
+		require.NoError(t, err)
+		assert.Equal(t, 48*time.Hour, d)
+	})
+
+	t.Run("invalid value fails at load", func(t *testing.T) {
+		dir := t.TempDir()
+		configYAML := `kubernetes:
+  token_duration: nope
+`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(configYAML), 0o644))
+
+		_, err := Load(dir)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "token_duration")
+	})
 }
 
 func TestLoad_DockerEnabled(t *testing.T) {

--- a/internal/forge/kube/kubeconfig.go
+++ b/internal/forge/kube/kubeconfig.go
@@ -1,10 +1,14 @@
 package kube
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
+	"path/filepath"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -52,13 +56,19 @@ type namedUser struct {
 }
 
 type userInfo struct {
-	Token string `yaml:"token,omitempty"`
+	TokenFile string `yaml:"tokenFile,omitempty"`
 }
 
 // GenerateKubeconfig reads the user's kubeconfig, extracts the specified
-// contexts, resolves SA tokens via kubectl, and writes a self-contained
-// kubeconfig suitable for mounting into the k8s-mcp container.
-func GenerateKubeconfig(contexts []ContextConfig, kubeconfigPath, defaultContext, outputPath string) error {
+// contexts, mints SA tokens via kubectl, and writes a self-contained
+// kubeconfig plus per-context token files into outputDir, which is
+// bind-mounted into the k8s-mcp container at MCPServerKubeDir.
+//
+// The kubeconfig references each token via tokenFile rather than embedding
+// it: client-go re-reads tokenFile credentials on its own, so rewriting the
+// token files (see RefreshTokens) rotates credentials inside the running
+// container without a restart.
+func GenerateKubeconfig(contexts []ContextConfig, kubeconfigPath, defaultContext, outputDir string, tokenDuration time.Duration) error {
 	data, err := os.ReadFile(kubeconfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to read kubeconfig %s: %w", kubeconfigPath, err)
@@ -91,11 +101,6 @@ func GenerateKubeconfig(contexts []ContextConfig, kubeconfigPath, defaultContext
 			return fmt.Errorf("context %q not found in kubeconfig or its cluster is missing", ctx.HostContext)
 		}
 
-		token, err := resolveToken(ctx, kubeconfigPath)
-		if err != nil {
-			return fmt.Errorf("failed to resolve token for context %q: %w", ctx.HostContext, err)
-		}
-
 		userName := ctx.HostContext + "-sa"
 
 		out.Clusters = append(out.Clusters, namedCluster{
@@ -114,22 +119,106 @@ func GenerateKubeconfig(contexts []ContextConfig, kubeconfigPath, defaultContext
 		})
 		out.Users = append(out.Users, namedUser{
 			Name: userName,
-			User: userInfo{Token: token},
+			// The container-side path of the token file written by RefreshTokens.
+			User: userInfo{TokenFile: path.Join(MCPServerKubeDir, TokensDirName, TokenFileName(ctx.HostContext))},
 		})
+	}
+
+	// The directory (not just the kubeconfig) is bind-mounted, and the
+	// container's user is not necessarily the host user, so everything under
+	// it must be world-readable.
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create kubeconfig dir: %w", err)
+	}
+	if err := os.Chmod(outputDir, 0o755); err != nil {
+		return fmt.Errorf("failed to set kubeconfig dir permissions: %w", err)
+	}
+
+	if err := RefreshTokens(contexts, kubeconfigPath, outputDir, tokenDuration); err != nil {
+		return err
 	}
 
 	outData, err := yaml.Marshal(&out)
 	if err != nil {
 		return fmt.Errorf("failed to marshal generated kubeconfig: %w", err)
 	}
-
-	if err := os.WriteFile(outputPath, outData, 0o644); err != nil {
+	if err := writeFileAtomic(filepath.Join(outputDir, KubeconfigFileName), outData, 0o644); err != nil {
 		return fmt.Errorf("failed to write generated kubeconfig: %w", err)
 	}
-	if err := os.Chmod(outputPath, 0o644); err != nil {
-		return fmt.Errorf("failed to set kubeconfig permissions: %w", err)
+	return nil
+}
+
+// RefreshTokens re-mints the SA tokens referenced by the generated kubeconfig
+// and rewrites the token files under outputDir. Tokens expire (most API
+// servers cap lifetime at 1h-48h regardless of what is requested) while
+// sessions can stay open for days, so this runs at every session start and
+// periodically while a session is attached. The old token stays valid until
+// its own expiry, so rotation never races in-flight requests.
+func RefreshTokens(contexts []ContextConfig, kubeconfigPath, outputDir string, tokenDuration time.Duration) error {
+	tokensDir := filepath.Join(outputDir, TokensDirName)
+	if err := os.MkdirAll(tokensDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create tokens dir: %w", err)
+	}
+	if err := os.Chmod(tokensDir, 0o755); err != nil {
+		return fmt.Errorf("failed to set tokens dir permissions: %w", err)
+	}
+	for _, ctx := range contexts {
+		token, err := resolveToken(ctx, kubeconfigPath, tokenDuration)
+		if err != nil {
+			return fmt.Errorf("failed to resolve token for context %q: %w", ctx.HostContext, err)
+		}
+		tokenPath := filepath.Join(tokensDir, TokenFileName(ctx.HostContext))
+		if err := writeFileAtomic(tokenPath, []byte(token), 0o644); err != nil {
+			return fmt.Errorf("failed to write token for context %q: %w", ctx.HostContext, err)
+		}
 	}
 	return nil
+}
+
+// TokenFileName returns a stable, filesystem-safe file name for a context's
+// token. Context names may contain characters that are invalid in file names
+// (EKS ARN contexts contain "/" and ":"), so unsafe runes are replaced and a
+// short hash keeps distinct contexts from colliding.
+func TokenFileName(hostContext string) string {
+	sum := sha256.Sum256([]byte(hostContext))
+	safe := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9',
+			r == '.', r == '_', r == '-':
+			return r
+		default:
+			return '-'
+		}
+	}, hostContext)
+	if len(safe) > 64 {
+		safe = safe[:64]
+	}
+	return fmt.Sprintf("%s-%x", safe, sum[:4])
+}
+
+// writeFileAtomic writes data via temp-file-plus-rename so concurrent
+// refreshers never produce a torn file and the container (which reads these
+// files through a bind mount of the parent directory) always sees a complete
+// one.
+func writeFileAtomic(filePath string, data []byte, perm os.FileMode) error {
+	tmp, err := os.CreateTemp(filepath.Dir(filePath), ".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, filePath)
 }
 
 // ListContexts reads a kubeconfig file and returns all context names.
@@ -149,14 +238,20 @@ func ListContexts(kubeconfigPath string) ([]string, error) {
 	return names, nil
 }
 
-// resolveToken calls `kubectl create token` to get a short-lived SA token.
-var resolveToken = func(ctx ContextConfig, kubeconfigPath string) (string, error) {
+// resolveToken calls `kubectl create token` to mint an SA token. The API
+// server caps the duration at its configured maximum (managed clusters
+// commonly cap at 24-48h), so longer requests degrade gracefully to the
+// cluster's cap rather than failing.
+var resolveToken = func(ctx ContextConfig, kubeconfigPath string, duration time.Duration) (string, error) {
 	args := []string{
 		"create", "token",
 		ctx.ServiceAccountName,
 		"-n", ctx.ServiceAccountNamespace,
 		"--context", ctx.HostContext,
 		"--kubeconfig", kubeconfigPath,
+	}
+	if duration > 0 {
+		args = append(args, "--duration", duration.String())
 	}
 	out, err := exec.Command("kubectl", args...).Output()
 	if err != nil {

--- a/internal/forge/kube/kubeconfig.go
+++ b/internal/forge/kube/kubeconfig.go
@@ -63,15 +63,30 @@ type userInfo struct {
 	TokenFile string `yaml:"tokenFile,omitempty"`
 }
 
+// TokenMintError signals that the kubeconfig was written successfully but one
+// or more contexts could not mint a token. It is non-fatal: the MCP server can
+// still start and serve every context whose token minted, and the periodic
+// refresher retries the rest. Callers should downgrade it to a warning rather
+// than aborting.
+type TokenMintError struct{ Err error }
+
+func (e *TokenMintError) Error() string { return e.Err.Error() }
+func (e *TokenMintError) Unwrap() error { return e.Err }
+
 // GenerateKubeconfig reads the user's kubeconfig, extracts the specified
-// contexts, mints SA tokens via kubectl, and writes a self-contained
-// kubeconfig plus per-context token files into outputDir, which is
-// bind-mounted into the k8s-mcp container at MCPServerKubeDir.
+// contexts, writes a self-contained kubeconfig, and mints per-context SA
+// tokens into outputDir, which is bind-mounted into the k8s-mcp container at
+// MCPServerKubeDir.
 //
 // The kubeconfig references each token via tokenFile rather than embedding
 // it: client-go re-reads tokenFile credentials on its own, so rewriting the
 // token files (see RefreshTokens) rotates credentials inside the running
 // container without a restart.
+//
+// The kubeconfig is written before tokens are minted and remains on disk even
+// when some contexts fail to mint; those failures are returned as a
+// *TokenMintError so a single unreachable cluster does not block the whole
+// MCP from starting for the healthy contexts sharing it.
 func GenerateKubeconfig(contexts []ContextConfig, kubeconfigPath, defaultContext, outputDir string, tokenDuration time.Duration) error {
 	if err := ensureDir(outputDir); err != nil {
 		return fmt.Errorf("failed to create kubeconfig dir: %w", err)
@@ -86,12 +101,12 @@ func GenerateKubeconfig(contexts []ContextConfig, kubeconfigPath, defaultContext
 		return err
 	}
 
-	if err := RefreshTokens(contexts, kubeconfigPath, outputDir, tokenDuration); err != nil {
-		return err
-	}
-
 	if err := writeFileAtomic(filepath.Join(outputDir, KubeconfigFileName), outData, 0o644); err != nil {
 		return fmt.Errorf("failed to write generated kubeconfig: %w", err)
+	}
+
+	if err := RefreshTokens(contexts, kubeconfigPath, outputDir, tokenDuration); err != nil {
+		return &TokenMintError{err}
 	}
 	return nil
 }
@@ -202,19 +217,40 @@ func RefreshTokens(contexts []ContextConfig, kubeconfigPath, outputDir string, t
 	if err != nil {
 		return err
 	}
+	keep := make(map[string]bool, len(contexts))
 	var errs []error
 	for _, ctx := range contexts {
+		name := TokenFileName(ctx.HostContext, salt)
+		keep[name] = true
 		token, err := resolveToken(ctx, kubeconfigPath, tokenDuration)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to resolve token for context %q: %w", ctx.HostContext, err))
 			continue
 		}
-		tokenPath := filepath.Join(tokensDir, TokenFileName(ctx.HostContext, salt))
-		if err := writeFileAtomic(tokenPath, []byte(token), 0o644); err != nil {
+		if err := writeFileAtomic(filepath.Join(tokensDir, name), []byte(token), 0o644); err != nil {
 			errs = append(errs, fmt.Errorf("failed to write token for context %q: %w", ctx.HostContext, err))
 		}
 	}
+	pruneStaleTokens(tokensDir, keep)
 	return errors.Join(errs...)
+}
+
+// pruneStaleTokens removes token files for contexts no longer configured, so a
+// removed context does not leave a live token lying around (same
+// no-stale-entries rule as UpdateMCPServers). Best-effort; transient temp
+// files from a concurrent writeFileAtomic are skipped.
+func pruneStaleTokens(tokensDir string, keep map[string]bool) {
+	entries, err := os.ReadDir(tokensDir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if keep[name] || strings.HasPrefix(name, ".tmp-") {
+			continue
+		}
+		_ = os.Remove(filepath.Join(tokensDir, name))
+	}
 }
 
 // TokenFileName returns a stable, filesystem-safe file name for a context's

--- a/internal/forge/kube/kubeconfig.go
+++ b/internal/forge/kube/kubeconfig.go
@@ -2,6 +2,7 @@ package kube
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"errors"
@@ -187,6 +188,11 @@ func buildKubeconfig(contexts []ContextConfig, kubeconfigPath, defaultContext, s
 // sessions can stay open for days, so this runs at every session start and
 // periodically while a session is attached. The old token stays valid until
 // its own expiry, so rotation never races in-flight requests.
+//
+// Each context is refreshed independently: one broken context (revoked RBAC,
+// unreachable cluster, stale kubeconfig entry) must not starve the healthy
+// contexts that share this MCP server, so failures are collected and joined
+// rather than aborting the loop.
 func RefreshTokens(contexts []ContextConfig, kubeconfigPath, outputDir string, tokenDuration time.Duration) error {
 	tokensDir := filepath.Join(outputDir, TokensDirName)
 	if err := ensureDir(tokensDir); err != nil {
@@ -196,17 +202,19 @@ func RefreshTokens(contexts []ContextConfig, kubeconfigPath, outputDir string, t
 	if err != nil {
 		return err
 	}
+	var errs []error
 	for _, ctx := range contexts {
 		token, err := resolveToken(ctx, kubeconfigPath, tokenDuration)
 		if err != nil {
-			return fmt.Errorf("failed to resolve token for context %q: %w", ctx.HostContext, err)
+			errs = append(errs, fmt.Errorf("failed to resolve token for context %q: %w", ctx.HostContext, err))
+			continue
 		}
 		tokenPath := filepath.Join(tokensDir, TokenFileName(ctx.HostContext, salt))
 		if err := writeFileAtomic(tokenPath, []byte(token), 0o644); err != nil {
-			return fmt.Errorf("failed to write token for context %q: %w", ctx.HostContext, err)
+			errs = append(errs, fmt.Errorf("failed to write token for context %q: %w", ctx.HostContext, err))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // TokenFileName returns a stable, filesystem-safe file name for a context's
@@ -338,6 +346,13 @@ func ListContexts(kubeconfigPath string) ([]string, error) {
 	return names, nil
 }
 
+// kubectlTokenTimeout bounds a single `kubectl create token` call. Minting is
+// normally sub-second, but this runs synchronously on the session-start path,
+// so a hung kubectl (unreachable cluster, VPN down, an interactive auth
+// prompt) must not block the session indefinitely. A var so tests can shorten
+// it.
+var kubectlTokenTimeout = 10 * time.Second
+
 // resolveToken calls `kubectl create token` to mint an SA token. Most API
 // servers cap the requested duration at their configured maximum (managed
 // clusters commonly cap at 24-48h); for servers that reject over-maximum
@@ -361,9 +376,9 @@ var resolveToken = func(ctx ContextConfig, kubeconfigPath string, duration time.
 		return token, nil
 	}
 	// Only a kubectl that ran and was refused (ExitError) can be a
-	// duration rejection; exec failures (kubectl missing) won't improve on
-	// retry. If the fallback fails too, report the original error — it
-	// names the real problem (auth, connectivity, RBAC).
+	// duration rejection; exec failures (kubectl missing) and timeouts won't
+	// improve on retry. If the fallback fails too, report the original error
+	// — it names the real problem (auth, connectivity, RBAC).
 	var exitErr *exec.ExitError
 	if !errors.As(err, &exitErr) {
 		return "", err
@@ -376,7 +391,14 @@ var resolveToken = func(ctx ContextConfig, kubeconfigPath string, duration time.
 }
 
 func kubectlCreateToken(args []string) (string, error) {
-	out, err := exec.Command("kubectl", args...).Output()
+	ctx, cancel := context.WithTimeout(context.Background(), kubectlTokenTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "kubectl", args...).Output()
+	// A timeout kills kubectl and surfaces as an ExitError; report it as a
+	// timeout (not a duration rejection) so the caller does not retry.
+	if ctx.Err() != nil {
+		return "", fmt.Errorf("kubectl create token timed out after %s: %w", kubectlTokenTimeout, ctx.Err())
+	}
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {

--- a/internal/forge/kube/kubeconfig.go
+++ b/internal/forge/kube/kubeconfig.go
@@ -1,7 +1,9 @@
 package kube
 
 import (
+	"bytes"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -69,14 +71,53 @@ type userInfo struct {
 // token files (see RefreshTokens) rotates credentials inside the running
 // container without a restart.
 func GenerateKubeconfig(contexts []ContextConfig, kubeconfigPath, defaultContext, outputDir string, tokenDuration time.Duration) error {
+	outData, err := buildKubeconfig(contexts, kubeconfigPath, defaultContext)
+	if err != nil {
+		return err
+	}
+
+	if err := ensureDir(outputDir); err != nil {
+		return fmt.Errorf("failed to create kubeconfig dir: %w", err)
+	}
+
+	if err := RefreshTokens(contexts, kubeconfigPath, outputDir, tokenDuration); err != nil {
+		return err
+	}
+
+	if err := writeFileAtomic(filepath.Join(outputDir, KubeconfigFileName), outData, 0o644); err != nil {
+		return fmt.Errorf("failed to write generated kubeconfig: %w", err)
+	}
+	return nil
+}
+
+// KubeconfigUpToDate reports whether the generated kubeconfig in outputDir
+// matches what the given contexts would generate. The k8s-mcp server only
+// reads its kubeconfig at startup, so a mismatch means the running container
+// must be recreated for context changes to take effect.
+func KubeconfigUpToDate(contexts []ContextConfig, kubeconfigPath, defaultContext, outputDir string) (bool, error) {
+	desired, err := buildKubeconfig(contexts, kubeconfigPath, defaultContext)
+	if err != nil {
+		return false, err
+	}
+	current, err := os.ReadFile(filepath.Join(outputDir, KubeconfigFileName))
+	if err != nil {
+		return false, err
+	}
+	return bytes.Equal(desired, current), nil
+}
+
+// buildKubeconfig renders the self-contained kubeconfig for the given
+// contexts without touching the filesystem beyond reading the source
+// kubeconfig. Marshalling is deterministic, so the output is byte-comparable.
+func buildKubeconfig(contexts []ContextConfig, kubeconfigPath, defaultContext string) ([]byte, error) {
 	data, err := os.ReadFile(kubeconfigPath)
 	if err != nil {
-		return fmt.Errorf("failed to read kubeconfig %s: %w", kubeconfigPath, err)
+		return nil, fmt.Errorf("failed to read kubeconfig %s: %w", kubeconfigPath, err)
 	}
 
 	var srcConfig kubeConfig
 	if err := yaml.Unmarshal(data, &srcConfig); err != nil {
-		return fmt.Errorf("failed to parse kubeconfig: %w", err)
+		return nil, fmt.Errorf("failed to parse kubeconfig: %w", err)
 	}
 
 	clusterByContext := make(map[string]namedCluster)
@@ -98,7 +139,7 @@ func GenerateKubeconfig(contexts []ContextConfig, kubeconfigPath, defaultContext
 	for _, ctx := range contexts {
 		cl, ok := clusterByContext[ctx.HostContext]
 		if !ok {
-			return fmt.Errorf("context %q not found in kubeconfig or its cluster is missing", ctx.HostContext)
+			return nil, fmt.Errorf("context %q not found in kubeconfig or its cluster is missing", ctx.HostContext)
 		}
 
 		userName := ctx.HostContext + "-sa"
@@ -124,28 +165,11 @@ func GenerateKubeconfig(contexts []ContextConfig, kubeconfigPath, defaultContext
 		})
 	}
 
-	// The directory (not just the kubeconfig) is bind-mounted, and the
-	// container's user is not necessarily the host user, so everything under
-	// it must be world-readable.
-	if err := os.MkdirAll(outputDir, 0o755); err != nil {
-		return fmt.Errorf("failed to create kubeconfig dir: %w", err)
-	}
-	if err := os.Chmod(outputDir, 0o755); err != nil {
-		return fmt.Errorf("failed to set kubeconfig dir permissions: %w", err)
-	}
-
-	if err := RefreshTokens(contexts, kubeconfigPath, outputDir, tokenDuration); err != nil {
-		return err
-	}
-
 	outData, err := yaml.Marshal(&out)
 	if err != nil {
-		return fmt.Errorf("failed to marshal generated kubeconfig: %w", err)
+		return nil, fmt.Errorf("failed to marshal generated kubeconfig: %w", err)
 	}
-	if err := writeFileAtomic(filepath.Join(outputDir, KubeconfigFileName), outData, 0o644); err != nil {
-		return fmt.Errorf("failed to write generated kubeconfig: %w", err)
-	}
-	return nil
+	return outData, nil
 }
 
 // RefreshTokens re-mints the SA tokens referenced by the generated kubeconfig
@@ -156,11 +180,8 @@ func GenerateKubeconfig(contexts []ContextConfig, kubeconfigPath, defaultContext
 // its own expiry, so rotation never races in-flight requests.
 func RefreshTokens(contexts []ContextConfig, kubeconfigPath, outputDir string, tokenDuration time.Duration) error {
 	tokensDir := filepath.Join(outputDir, TokensDirName)
-	if err := os.MkdirAll(tokensDir, 0o755); err != nil {
+	if err := ensureDir(tokensDir); err != nil {
 		return fmt.Errorf("failed to create tokens dir: %w", err)
-	}
-	if err := os.Chmod(tokensDir, 0o755); err != nil {
-		return fmt.Errorf("failed to set tokens dir permissions: %w", err)
 	}
 	for _, ctx := range contexts {
 		token, err := resolveToken(ctx, kubeconfigPath, tokenDuration)
@@ -178,7 +199,8 @@ func RefreshTokens(contexts []ContextConfig, kubeconfigPath, outputDir string, t
 // TokenFileName returns a stable, filesystem-safe file name for a context's
 // token. Context names may contain characters that are invalid in file names
 // (EKS ARN contexts contain "/" and ":"), so unsafe runes are replaced and a
-// short hash keeps distinct contexts from colliding.
+// hash of the full name keeps distinct contexts from colliding even when
+// their sanitized prefixes match.
 func TokenFileName(hostContext string) string {
 	sum := sha256.Sum256([]byte(hostContext))
 	safe := strings.Map(func(r rune) rune {
@@ -193,7 +215,19 @@ func TokenFileName(hostContext string) string {
 	if len(safe) > 64 {
 		safe = safe[:64]
 	}
-	return fmt.Sprintf("%s-%x", safe, sum[:4])
+	return fmt.Sprintf("%s-%x", safe, sum[:8])
+}
+
+// ensureDir creates dir if needed and forces 0711 permissions even on a
+// pre-existing directory (MkdirAll does not chmod those). The k8s-mcp
+// container runs as a non-host uid and opens only exact paths from the
+// kubeconfig, so it needs traversal (x) but not listing; withholding the
+// read bit keeps other host users from listing the minted token files.
+func ensureDir(dir string) error {
+	if err := os.MkdirAll(dir, 0o711); err != nil {
+		return err
+	}
+	return os.Chmod(dir, 0o711)
 }
 
 // writeFileAtomic writes data via temp-file-plus-rename so concurrent
@@ -238,10 +272,11 @@ func ListContexts(kubeconfigPath string) ([]string, error) {
 	return names, nil
 }
 
-// resolveToken calls `kubectl create token` to mint an SA token. The API
-// server caps the duration at its configured maximum (managed clusters
-// commonly cap at 24-48h), so longer requests degrade gracefully to the
-// cluster's cap rather than failing.
+// resolveToken calls `kubectl create token` to mint an SA token. Most API
+// servers cap the requested duration at their configured maximum (managed
+// clusters commonly cap at 24-48h); for servers that reject over-maximum
+// requests instead, it retries without --duration so a long token_duration
+// degrades to the server-default lifetime rather than disabling the MCP.
 var resolveToken = func(ctx ContextConfig, kubeconfigPath string, duration time.Duration) (string, error) {
 	args := []string{
 		"create", "token",
@@ -251,10 +286,21 @@ var resolveToken = func(ctx ContextConfig, kubeconfigPath string, duration time.
 		"--kubeconfig", kubeconfigPath,
 	}
 	if duration > 0 {
-		args = append(args, "--duration", duration.String())
+		token, err := kubectlCreateToken(append(args, "--duration", duration.String()))
+		if err == nil {
+			return token, nil
+		}
 	}
+	return kubectlCreateToken(args)
+}
+
+func kubectlCreateToken(args []string) (string, error) {
 	out, err := exec.Command("kubectl", args...).Output()
 	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+			return "", fmt.Errorf("kubectl create token failed: %w: %s", err, strings.TrimSpace(string(exitErr.Stderr)))
+		}
 		return "", fmt.Errorf("kubectl create token failed: %w", err)
 	}
 	return strings.TrimSpace(string(out)), nil

--- a/internal/forge/kube/kubeconfig.go
+++ b/internal/forge/kube/kubeconfig.go
@@ -2,6 +2,7 @@ package kube
 
 import (
 	"bytes"
+	"crypto/rand"
 	"crypto/sha256"
 	"errors"
 	"fmt"
@@ -71,13 +72,17 @@ type userInfo struct {
 // token files (see RefreshTokens) rotates credentials inside the running
 // container without a restart.
 func GenerateKubeconfig(contexts []ContextConfig, kubeconfigPath, defaultContext, outputDir string, tokenDuration time.Duration) error {
-	outData, err := buildKubeconfig(contexts, kubeconfigPath, defaultContext)
+	if err := ensureDir(outputDir); err != nil {
+		return fmt.Errorf("failed to create kubeconfig dir: %w", err)
+	}
+	salt, err := tokenSalt(outputDir)
 	if err != nil {
 		return err
 	}
 
-	if err := ensureDir(outputDir); err != nil {
-		return fmt.Errorf("failed to create kubeconfig dir: %w", err)
+	outData, err := buildKubeconfig(contexts, kubeconfigPath, defaultContext, salt)
+	if err != nil {
+		return err
 	}
 
 	if err := RefreshTokens(contexts, kubeconfigPath, outputDir, tokenDuration); err != nil {
@@ -95,7 +100,11 @@ func GenerateKubeconfig(contexts []ContextConfig, kubeconfigPath, defaultContext
 // reads its kubeconfig at startup, so a mismatch means the running container
 // must be recreated for context changes to take effect.
 func KubeconfigUpToDate(contexts []ContextConfig, kubeconfigPath, defaultContext, outputDir string) (bool, error) {
-	desired, err := buildKubeconfig(contexts, kubeconfigPath, defaultContext)
+	salt, err := tokenSalt(outputDir)
+	if err != nil {
+		return false, err
+	}
+	desired, err := buildKubeconfig(contexts, kubeconfigPath, defaultContext, salt)
 	if err != nil {
 		return false, err
 	}
@@ -109,7 +118,7 @@ func KubeconfigUpToDate(contexts []ContextConfig, kubeconfigPath, defaultContext
 // buildKubeconfig renders the self-contained kubeconfig for the given
 // contexts without touching the filesystem beyond reading the source
 // kubeconfig. Marshalling is deterministic, so the output is byte-comparable.
-func buildKubeconfig(contexts []ContextConfig, kubeconfigPath, defaultContext string) ([]byte, error) {
+func buildKubeconfig(contexts []ContextConfig, kubeconfigPath, defaultContext, salt string) ([]byte, error) {
 	data, err := os.ReadFile(kubeconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read kubeconfig %s: %w", kubeconfigPath, err)
@@ -161,7 +170,7 @@ func buildKubeconfig(contexts []ContextConfig, kubeconfigPath, defaultContext st
 		out.Users = append(out.Users, namedUser{
 			Name: userName,
 			// The container-side path of the token file written by RefreshTokens.
-			User: userInfo{TokenFile: path.Join(MCPServerKubeDir, TokensDirName, TokenFileName(ctx.HostContext))},
+			User: userInfo{TokenFile: path.Join(MCPServerKubeDir, TokensDirName, TokenFileName(ctx.HostContext, salt))},
 		})
 	}
 
@@ -183,12 +192,16 @@ func RefreshTokens(contexts []ContextConfig, kubeconfigPath, outputDir string, t
 	if err := ensureDir(tokensDir); err != nil {
 		return fmt.Errorf("failed to create tokens dir: %w", err)
 	}
+	salt, err := tokenSalt(outputDir)
+	if err != nil {
+		return err
+	}
 	for _, ctx := range contexts {
 		token, err := resolveToken(ctx, kubeconfigPath, tokenDuration)
 		if err != nil {
 			return fmt.Errorf("failed to resolve token for context %q: %w", ctx.HostContext, err)
 		}
-		tokenPath := filepath.Join(tokensDir, TokenFileName(ctx.HostContext))
+		tokenPath := filepath.Join(tokensDir, TokenFileName(ctx.HostContext, salt))
 		if err := writeFileAtomic(tokenPath, []byte(token), 0o644); err != nil {
 			return fmt.Errorf("failed to write token for context %q: %w", ctx.HostContext, err)
 		}
@@ -199,10 +212,15 @@ func RefreshTokens(contexts []ContextConfig, kubeconfigPath, outputDir string, t
 // TokenFileName returns a stable, filesystem-safe file name for a context's
 // token. Context names may contain characters that are invalid in file names
 // (EKS ARN contexts contain "/" and ":"), so unsafe runes are replaced and a
-// hash of the full name keeps distinct contexts from colliding even when
-// their sanitized prefixes match.
-func TokenFileName(hostContext string) string {
-	sum := sha256.Sum256([]byte(hostContext))
+// hash keeps distinct contexts from colliding even when their sanitized
+// prefixes match.
+//
+// The salt (see tokenSalt) makes the name underivable from public inputs:
+// context names are readable from config.yaml by any local user, and the
+// token dirs are 0711 (traversal allowed, listing blocked), so a guessable
+// name would let other users open live tokens by exact path.
+func TokenFileName(hostContext, salt string) string {
+	sum := sha256.Sum256([]byte(salt + "\x00" + hostContext))
 	safe := strings.Map(func(r rune) rune {
 		switch {
 		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9',
@@ -216,6 +234,54 @@ func TokenFileName(hostContext string) string {
 		safe = safe[:64]
 	}
 	return fmt.Sprintf("%s-%x", safe, sum[:8])
+}
+
+// saltFileName holds the random component of token file names, 0600 inside
+// the generated-kubeconfig dir: the container never reads it (the kubeconfig
+// carries full token paths) and other host users cannot.
+const saltFileName = ".token-salt"
+
+// tokenSalt returns the per-install salt, creating it on first use. Creation
+// is write-temp-then-link so concurrent first sessions agree on one salt: the
+// hard link fails on an existing path, and the linked file is always fully
+// written.
+func tokenSalt(outputDir string) (string, error) {
+	saltPath := filepath.Join(outputDir, saltFileName)
+	if data, err := os.ReadFile(saltPath); err == nil && len(data) > 0 {
+		return strings.TrimSpace(string(data)), nil
+	}
+
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", fmt.Errorf("failed to generate token salt: %w", err)
+	}
+	salt := fmt.Sprintf("%x", buf)
+
+	tmp, err := os.CreateTemp(outputDir, ".tmp-salt-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create token salt: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.WriteString(salt); err != nil {
+		tmp.Close()
+		return "", fmt.Errorf("failed to write token salt: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return "", fmt.Errorf("failed to write token salt: %w", err)
+	}
+	if err := os.Link(tmpPath, saltPath); err != nil {
+		if os.IsExist(err) {
+			// Another session created the salt first; use theirs.
+			data, readErr := os.ReadFile(saltPath)
+			if readErr != nil || len(data) == 0 {
+				return "", fmt.Errorf("failed to read token salt: %w", readErr)
+			}
+			return strings.TrimSpace(string(data)), nil
+		}
+		return "", fmt.Errorf("failed to store token salt: %w", err)
+	}
+	return salt, nil
 }
 
 // ensureDir creates dir if needed and forces 0711 permissions even on a
@@ -275,8 +341,9 @@ func ListContexts(kubeconfigPath string) ([]string, error) {
 // resolveToken calls `kubectl create token` to mint an SA token. Most API
 // servers cap the requested duration at their configured maximum (managed
 // clusters commonly cap at 24-48h); for servers that reject over-maximum
-// requests instead, it retries without --duration so a long token_duration
-// degrades to the server-default lifetime rather than disabling the MCP.
+// requests instead, it retries once without --duration so a long
+// token_duration degrades to the server-default lifetime rather than
+// disabling the MCP.
 var resolveToken = func(ctx ContextConfig, kubeconfigPath string, duration time.Duration) (string, error) {
 	args := []string{
 		"create", "token",
@@ -285,13 +352,27 @@ var resolveToken = func(ctx ContextConfig, kubeconfigPath string, duration time.
 		"--context", ctx.HostContext,
 		"--kubeconfig", kubeconfigPath,
 	}
-	if duration > 0 {
-		token, err := kubectlCreateToken(append(args, "--duration", duration.String()))
-		if err == nil {
-			return token, nil
-		}
+	if duration <= 0 {
+		return kubectlCreateToken(args)
 	}
-	return kubectlCreateToken(args)
+
+	token, err := kubectlCreateToken(append(args, "--duration", duration.String()))
+	if err == nil {
+		return token, nil
+	}
+	// Only a kubectl that ran and was refused (ExitError) can be a
+	// duration rejection; exec failures (kubectl missing) won't improve on
+	// retry. If the fallback fails too, report the original error — it
+	// names the real problem (auth, connectivity, RBAC).
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return "", err
+	}
+	token, fallbackErr := kubectlCreateToken(args)
+	if fallbackErr != nil {
+		return "", err
+	}
+	return token, nil
 }
 
 func kubectlCreateToken(args []string) (string, error) {

--- a/internal/forge/kube/kubeconfig_test.go
+++ b/internal/forge/kube/kubeconfig_test.go
@@ -434,6 +434,64 @@ func TestResolveToken_KubectlFailure(t *testing.T) {
 	assert.Contains(t, err.Error(), "kubectl create token failed")
 }
 
+// fakeKubectl puts a kubectl shell script on PATH for the test. The script
+// body sees the kubectl arguments as "$@".
+func fakeKubectl(t *testing.T, script string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kubectl")
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\n"+script), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestResolveToken_DurationRejectedFallsBack(t *testing.T) {
+	// A server that rejects over-maximum --duration requests: the fallback
+	// without --duration must return its token, not the rejection error.
+	fakeKubectl(t, `for arg in "$@"; do
+  if [ "$arg" = "--duration" ]; then echo "duration rejected" >&2; exit 1; fi
+done
+echo fallback-token`)
+
+	token, err := resolveToken(ContextConfig{
+		HostContext:             "ctx",
+		ServiceAccountName:      "sa",
+		ServiceAccountNamespace: "ns",
+	}, "unused", time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, "fallback-token", token)
+}
+
+func TestResolveToken_FallbackFailureReportsOriginalError(t *testing.T) {
+	// When both attempts fail server-side, the first error names the real
+	// problem and must be the one reported.
+	fakeKubectl(t, `for arg in "$@"; do
+  if [ "$arg" = "--duration" ]; then echo "original failure detail" >&2; exit 1; fi
+done
+echo "second failure" >&2; exit 1`)
+
+	_, err := resolveToken(ContextConfig{
+		HostContext:             "ctx",
+		ServiceAccountName:      "sa",
+		ServiceAccountNamespace: "ns",
+	}, "unused", time.Hour)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "original failure detail")
+	assert.NotContains(t, err.Error(), "second failure")
+}
+
+func TestResolveToken_NoDurationSkipsFallback(t *testing.T) {
+	// Without a requested duration there is exactly one attempt.
+	fakeKubectl(t, `echo plain-token`)
+
+	token, err := resolveToken(ContextConfig{
+		HostContext:             "ctx",
+		ServiceAccountName:      "sa",
+		ServiceAccountNamespace: "ns",
+	}, "unused", 0)
+	require.NoError(t, err)
+	assert.Equal(t, "plain-token", token)
+}
+
 func TestListContexts(t *testing.T) {
 	t.Run("returns context names", func(t *testing.T) {
 		tmpDir := t.TempDir()

--- a/internal/forge/kube/kubeconfig_test.go
+++ b/internal/forge/kube/kubeconfig_test.go
@@ -101,16 +101,17 @@ func TestGenerateKubeconfig_Success(t *testing.T) {
 	assert.Equal(t, "ctx-b-sa", out.Contexts[1].Context.User)
 
 	// Users reference container-side token files instead of embedding tokens.
+	salt := readSalt(t, outDir)
 	require.Len(t, out.Users, 2)
 	assert.Equal(t, "ctx-a-sa", out.Users[0].Name)
-	assert.Equal(t, MCPServerKubeDir+"/"+TokensDirName+"/"+TokenFileName("ctx-a"), out.Users[0].User.TokenFile)
+	assert.Equal(t, MCPServerKubeDir+"/"+TokensDirName+"/"+TokenFileName("ctx-a", salt), out.Users[0].User.TokenFile)
 	assert.Equal(t, "ctx-b-sa", out.Users[1].Name)
-	assert.Equal(t, MCPServerKubeDir+"/"+TokensDirName+"/"+TokenFileName("ctx-b"), out.Users[1].User.TokenFile)
+	assert.Equal(t, MCPServerKubeDir+"/"+TokensDirName+"/"+TokenFileName("ctx-b", salt), out.Users[1].User.TokenFile)
 	assert.NotContains(t, string(data), "sa-token-", "tokens must not be embedded in the kubeconfig")
 
 	// Token files hold the minted tokens.
 	for _, name := range []string{"ctx-a", "ctx-b"} {
-		tokenPath := filepath.Join(outDir, TokensDirName, TokenFileName(name))
+		tokenPath := filepath.Join(outDir, TokensDirName, TokenFileName(name, salt))
 		token, err := os.ReadFile(tokenPath)
 		require.NoError(t, err)
 		assert.Equal(t, "sa-token-"+name, string(token))
@@ -272,7 +273,7 @@ func TestRefreshTokens_RewritesTokenFiles(t *testing.T) {
 	}
 	require.NoError(t, GenerateKubeconfig(contexts, srcPath, "ctx-a", outDir, time.Hour))
 
-	tokenPath := filepath.Join(outDir, TokensDirName, TokenFileName("ctx-a"))
+	tokenPath := filepath.Join(outDir, TokensDirName, TokenFileName("ctx-a", readSalt(t, outDir)))
 	data, err := os.ReadFile(tokenPath)
 	require.NoError(t, err)
 	assert.Equal(t, "first", string(data))
@@ -309,24 +310,77 @@ func TestRefreshTokens_ResolveTokenError(t *testing.T) {
 }
 
 func TestTokenFileName(t *testing.T) {
+	const salt = "test-salt"
+
 	// Unsafe runes (EKS ARN-style contexts) are replaced.
-	name := TokenFileName("arn:aws:eks:us-east-1:123:cluster/prod")
+	name := TokenFileName("arn:aws:eks:us-east-1:123:cluster/prod", salt)
 	assert.NotContains(t, name, "/")
 	assert.NotContains(t, name, ":")
 
 	// Distinct contexts that sanitize identically still get distinct names.
-	assert.NotEqual(t, TokenFileName("ctx/a"), TokenFileName("ctx:a"))
+	assert.NotEqual(t, TokenFileName("ctx/a", salt), TokenFileName("ctx:a", salt))
 
-	// Stable across calls.
-	assert.Equal(t, TokenFileName("ctx-a"), TokenFileName("ctx-a"))
+	// Stable across calls with the same salt, underivable without it.
+	assert.Equal(t, TokenFileName("ctx-a", salt), TokenFileName("ctx-a", salt))
+	assert.NotEqual(t, TokenFileName("ctx-a", salt), TokenFileName("ctx-a", "other-salt"))
 
 	// Very long context names are truncated but stay unique via the hash.
 	long := ""
 	for range 20 {
 		long += "0123456789"
 	}
-	assert.LessOrEqual(t, len(TokenFileName(long)), 64+1+16)
-	assert.NotEqual(t, TokenFileName(long), TokenFileName(long+"x"))
+	assert.LessOrEqual(t, len(TokenFileName(long, salt)), 64+1+16)
+	assert.NotEqual(t, TokenFileName(long, salt), TokenFileName(long+"x", salt))
+}
+
+// readSalt returns the token salt GenerateKubeconfig/RefreshTokens created in
+// outDir.
+func readSalt(t *testing.T, outDir string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(outDir, saltFileName))
+	require.NoError(t, err)
+	return string(data)
+}
+
+func TestTokenSalt(t *testing.T) {
+	dir := t.TempDir()
+
+	salt, err := tokenSalt(dir)
+	require.NoError(t, err)
+	assert.NotEmpty(t, salt)
+
+	// Stable across calls: token file names must not change between the
+	// process that generated the kubeconfig and later refreshers.
+	again, err := tokenSalt(dir)
+	require.NoError(t, err)
+	assert.Equal(t, salt, again)
+
+	// Different installs get different salts.
+	other, err := tokenSalt(t.TempDir())
+	require.NoError(t, err)
+	assert.NotEqual(t, salt, other)
+
+	// Owner-only: other host users must not be able to read the salt, or
+	// they could derive token file paths through the 0711 dirs.
+	info, err := os.Stat(filepath.Join(dir, saltFileName))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+
+	t.Run("errors when the dir does not exist", func(t *testing.T) {
+		_, err := tokenSalt(filepath.Join(t.TempDir(), "missing"))
+		assert.Error(t, err)
+	})
+
+	t.Run("errors on an empty salt file instead of using it", func(t *testing.T) {
+		dir := t.TempDir()
+		// An empty file skips the fast-path read (a zero-length salt would
+		// silently weaken every token file name) and makes the exclusive
+		// link fail, exercising the lost-the-race branch.
+		require.NoError(t, os.WriteFile(filepath.Join(dir, saltFileName), nil, 0o600))
+		_, err := tokenSalt(dir)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "token salt")
+	})
 }
 
 func TestKubeconfigUpToDate(t *testing.T) {

--- a/internal/forge/kube/kubeconfig_test.go
+++ b/internal/forge/kube/kubeconfig_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,16 +45,24 @@ users:
 `
 }
 
+// stubResolveToken replaces resolveToken for the duration of the test.
+func stubResolveToken(t *testing.T, fn func(ctx ContextConfig, kubeconfigPath string, duration time.Duration) (string, error)) {
+	t.Helper()
+	orig := resolveToken
+	resolveToken = fn
+	t.Cleanup(func() { resolveToken = orig })
+}
+
+func staticToken(ctx ContextConfig, kubeconfigPath string, duration time.Duration) (string, error) {
+	return "sa-token-" + ctx.HostContext, nil
+}
+
 func TestGenerateKubeconfig_Success(t *testing.T) {
-	origResolveToken := resolveToken
-	resolveToken = func(ctx ContextConfig, kubeconfigPath string) (string, error) {
-		return "sa-token-" + ctx.HostContext, nil
-	}
-	t.Cleanup(func() { resolveToken = origResolveToken })
+	stubResolveToken(t, staticToken)
 
 	tmpDir := t.TempDir()
 	srcPath := filepath.Join(tmpDir, "kubeconfig")
-	outPath := filepath.Join(tmpDir, "kubeconfig-out")
+	outDir := filepath.Join(tmpDir, "out")
 	require.NoError(t, os.WriteFile(srcPath, []byte(sampleKubeconfig()), 0o600))
 
 	contexts := []ContextConfig{
@@ -61,10 +70,10 @@ func TestGenerateKubeconfig_Success(t *testing.T) {
 		{HostContext: "ctx-b", ServiceAccountName: "sa-b", ServiceAccountNamespace: "ns-b"},
 	}
 
-	err := GenerateKubeconfig(contexts, srcPath, "ctx-a", outPath)
+	err := GenerateKubeconfig(contexts, srcPath, "ctx-a", outDir, time.Hour)
 	require.NoError(t, err)
 
-	data, err := os.ReadFile(outPath)
+	data, err := os.ReadFile(filepath.Join(outDir, KubeconfigFileName))
 	require.NoError(t, err)
 
 	var out kubeConfig
@@ -91,120 +100,121 @@ func TestGenerateKubeconfig_Success(t *testing.T) {
 	assert.Equal(t, "ctx-b", out.Contexts[1].Context.Cluster)
 	assert.Equal(t, "ctx-b-sa", out.Contexts[1].Context.User)
 
-	// Users
+	// Users reference container-side token files instead of embedding tokens.
 	require.Len(t, out.Users, 2)
 	assert.Equal(t, "ctx-a-sa", out.Users[0].Name)
-	assert.Equal(t, "sa-token-ctx-a", out.Users[0].User.Token)
+	assert.Equal(t, MCPServerKubeDir+"/"+TokensDirName+"/"+TokenFileName("ctx-a"), out.Users[0].User.TokenFile)
 	assert.Equal(t, "ctx-b-sa", out.Users[1].Name)
-	assert.Equal(t, "sa-token-ctx-b", out.Users[1].User.Token)
+	assert.Equal(t, MCPServerKubeDir+"/"+TokensDirName+"/"+TokenFileName("ctx-b"), out.Users[1].User.TokenFile)
+	assert.NotContains(t, string(data), "sa-token-", "tokens must not be embedded in the kubeconfig")
 
-	// Verify file permissions
-	info, err := os.Stat(outPath)
+	// Token files hold the minted tokens.
+	for _, name := range []string{"ctx-a", "ctx-b"} {
+		tokenPath := filepath.Join(outDir, TokensDirName, TokenFileName(name))
+		token, err := os.ReadFile(tokenPath)
+		require.NoError(t, err)
+		assert.Equal(t, "sa-token-"+name, string(token))
+
+		info, err := os.Stat(tokenPath)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+	}
+
+	// The container user is not necessarily the host user: the mounted
+	// directory tree must be world-readable.
+	for _, p := range []string{outDir, filepath.Join(outDir, TokensDirName)} {
+		info, err := os.Stat(p)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o755), info.Mode().Perm(), p)
+	}
+	info, err := os.Stat(filepath.Join(outDir, KubeconfigFileName))
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
 }
 
 func TestGenerateKubeconfig_OverwritesRestrictivePermissions(t *testing.T) {
-	origResolveToken := resolveToken
-	resolveToken = func(ctx ContextConfig, kubeconfigPath string) (string, error) {
-		return "sa-token-" + ctx.HostContext, nil
-	}
-	t.Cleanup(func() { resolveToken = origResolveToken })
+	stubResolveToken(t, staticToken)
 
 	tmpDir := t.TempDir()
 	srcPath := filepath.Join(tmpDir, "kubeconfig")
-	outPath := filepath.Join(tmpDir, "kubeconfig-out")
+	outDir := filepath.Join(tmpDir, "out")
 	require.NoError(t, os.WriteFile(srcPath, []byte(sampleKubeconfig()), 0o600))
 
-	// Pre-create the output file with restrictive 0600 permissions, simulating
-	// a file left over from a prior run.
-	require.NoError(t, os.WriteFile(outPath, []byte("old-content"), 0o600))
-	info, err := os.Stat(outPath)
-	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "precondition: file should start with 0600")
+	// Pre-create the output dir with restrictive 0700 permissions, simulating
+	// a directory left over from a prior version.
+	require.NoError(t, os.MkdirAll(outDir, 0o700))
 
 	contexts := []ContextConfig{
 		{HostContext: "ctx-a", ServiceAccountName: "sa-a", ServiceAccountNamespace: "ns-a"},
 	}
 
-	err = GenerateKubeconfig(contexts, srcPath, "ctx-a", outPath)
+	err := GenerateKubeconfig(contexts, srcPath, "ctx-a", outDir, time.Hour)
 	require.NoError(t, err)
 
-	// Verify permissions were updated to 0644 despite the pre-existing 0600 file.
-	info, err = os.Stat(outPath)
+	info, err := os.Stat(outDir)
 	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm(), "permissions should be 0644 after regeneration")
+	assert.Equal(t, os.FileMode(0o755), info.Mode().Perm(), "dir permissions should be widened to 0755")
+
+	info, err = os.Stat(filepath.Join(outDir, KubeconfigFileName))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
 }
 
 func TestGenerateKubeconfig_KubeconfigNotFound(t *testing.T) {
-	origResolveToken := resolveToken
-	resolveToken = func(ctx ContextConfig, kubeconfigPath string) (string, error) {
-		return "unused", nil
-	}
-	t.Cleanup(func() { resolveToken = origResolveToken })
+	stubResolveToken(t, staticToken)
 
 	tmpDir := t.TempDir()
 	missingPath := filepath.Join(tmpDir, "does-not-exist")
-	outPath := filepath.Join(tmpDir, "kubeconfig-out")
+	outDir := filepath.Join(tmpDir, "out")
 
-	err := GenerateKubeconfig([]ContextConfig{{HostContext: "ctx-a"}}, missingPath, "ctx-a", outPath)
+	err := GenerateKubeconfig([]ContextConfig{{HostContext: "ctx-a"}}, missingPath, "ctx-a", outDir, time.Hour)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to read kubeconfig")
 }
 
 func TestGenerateKubeconfig_ContextNotFound(t *testing.T) {
-	origResolveToken := resolveToken
-	resolveToken = func(ctx ContextConfig, kubeconfigPath string) (string, error) {
-		return "token", nil
-	}
-	t.Cleanup(func() { resolveToken = origResolveToken })
+	stubResolveToken(t, staticToken)
 
 	tmpDir := t.TempDir()
 	srcPath := filepath.Join(tmpDir, "kubeconfig")
-	outPath := filepath.Join(tmpDir, "kubeconfig-out")
+	outDir := filepath.Join(tmpDir, "out")
 	require.NoError(t, os.WriteFile(srcPath, []byte(sampleKubeconfig()), 0o600))
 
 	contexts := []ContextConfig{
 		{HostContext: "ctx-nonexistent", ServiceAccountName: "sa", ServiceAccountNamespace: "ns"},
 	}
 
-	err := GenerateKubeconfig(contexts, srcPath, "ctx-nonexistent", outPath)
+	err := GenerateKubeconfig(contexts, srcPath, "ctx-nonexistent", outDir, time.Hour)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "context \"ctx-nonexistent\" not found in kubeconfig")
 }
 
 func TestGenerateKubeconfig_ResolveTokenError(t *testing.T) {
-	origResolveToken := resolveToken
-	resolveToken = func(ctx ContextConfig, kubeconfigPath string) (string, error) {
+	stubResolveToken(t, func(ctx ContextConfig, kubeconfigPath string, duration time.Duration) (string, error) {
 		return "", fmt.Errorf("kubectl not available")
-	}
-	t.Cleanup(func() { resolveToken = origResolveToken })
+	})
 
 	tmpDir := t.TempDir()
 	srcPath := filepath.Join(tmpDir, "kubeconfig")
-	outPath := filepath.Join(tmpDir, "kubeconfig-out")
+	outDir := filepath.Join(tmpDir, "out")
 	require.NoError(t, os.WriteFile(srcPath, []byte(sampleKubeconfig()), 0o600))
 
 	contexts := []ContextConfig{
 		{HostContext: "ctx-a", ServiceAccountName: "sa-a", ServiceAccountNamespace: "ns-a"},
 	}
 
-	err := GenerateKubeconfig(contexts, srcPath, "ctx-a", outPath)
+	err := GenerateKubeconfig(contexts, srcPath, "ctx-a", outDir, time.Hour)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to resolve token for context \"ctx-a\"")
 	assert.Contains(t, err.Error(), "kubectl not available")
 }
 
 func TestGenerateKubeconfig_CurrentContext(t *testing.T) {
-	origResolveToken := resolveToken
-	resolveToken = func(ctx ContextConfig, kubeconfigPath string) (string, error) {
-		return "token", nil
-	}
-	t.Cleanup(func() { resolveToken = origResolveToken })
+	stubResolveToken(t, staticToken)
 
 	tmpDir := t.TempDir()
 	srcPath := filepath.Join(tmpDir, "kubeconfig")
-	outPath := filepath.Join(tmpDir, "kubeconfig-out")
+	outDir := filepath.Join(tmpDir, "out")
 	require.NoError(t, os.WriteFile(srcPath, []byte(sampleKubeconfig()), 0o600))
 
 	contexts := []ContextConfig{
@@ -213,16 +223,109 @@ func TestGenerateKubeconfig_CurrentContext(t *testing.T) {
 	}
 
 	// Set defaultContext to ctx-b (not ctx-a which is current in source)
-	err := GenerateKubeconfig(contexts, srcPath, "ctx-b", outPath)
+	err := GenerateKubeconfig(contexts, srcPath, "ctx-b", outDir, time.Hour)
 	require.NoError(t, err)
 
-	data, err := os.ReadFile(outPath)
+	data, err := os.ReadFile(filepath.Join(outDir, KubeconfigFileName))
 	require.NoError(t, err)
 
 	var out kubeConfig
 	require.NoError(t, yaml.Unmarshal(data, &out))
 
 	assert.Equal(t, "ctx-b", out.CurrentContext)
+}
+
+func TestGenerateKubeconfig_PassesTokenDuration(t *testing.T) {
+	var gotDuration time.Duration
+	stubResolveToken(t, func(ctx ContextConfig, kubeconfigPath string, duration time.Duration) (string, error) {
+		gotDuration = duration
+		return "token", nil
+	})
+
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "kubeconfig")
+	outDir := filepath.Join(tmpDir, "out")
+	require.NoError(t, os.WriteFile(srcPath, []byte(sampleKubeconfig()), 0o600))
+
+	contexts := []ContextConfig{
+		{HostContext: "ctx-a", ServiceAccountName: "sa-a", ServiceAccountNamespace: "ns-a"},
+	}
+
+	require.NoError(t, GenerateKubeconfig(contexts, srcPath, "ctx-a", outDir, 24*time.Hour))
+	assert.Equal(t, 24*time.Hour, gotDuration)
+}
+
+func TestRefreshTokens_RewritesTokenFiles(t *testing.T) {
+	token := "first"
+	stubResolveToken(t, func(ctx ContextConfig, kubeconfigPath string, duration time.Duration) (string, error) {
+		return token, nil
+	})
+
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "kubeconfig")
+	outDir := filepath.Join(tmpDir, "out")
+	require.NoError(t, os.WriteFile(srcPath, []byte(sampleKubeconfig()), 0o600))
+
+	contexts := []ContextConfig{
+		{HostContext: "ctx-a", ServiceAccountName: "sa-a", ServiceAccountNamespace: "ns-a"},
+	}
+	require.NoError(t, GenerateKubeconfig(contexts, srcPath, "ctx-a", outDir, time.Hour))
+
+	tokenPath := filepath.Join(outDir, TokensDirName, TokenFileName("ctx-a"))
+	data, err := os.ReadFile(tokenPath)
+	require.NoError(t, err)
+	assert.Equal(t, "first", string(data))
+
+	kubeconfigBefore, err := os.ReadFile(filepath.Join(outDir, KubeconfigFileName))
+	require.NoError(t, err)
+
+	token = "second"
+	require.NoError(t, RefreshTokens(contexts, srcPath, outDir, time.Hour))
+
+	data, err = os.ReadFile(tokenPath)
+	require.NoError(t, err)
+	assert.Equal(t, "second", string(data))
+
+	// Refresh only rotates token files; the kubeconfig stays untouched.
+	kubeconfigAfter, err := os.ReadFile(filepath.Join(outDir, KubeconfigFileName))
+	require.NoError(t, err)
+	assert.Equal(t, string(kubeconfigBefore), string(kubeconfigAfter))
+}
+
+func TestRefreshTokens_ResolveTokenError(t *testing.T) {
+	stubResolveToken(t, func(ctx ContextConfig, kubeconfigPath string, duration time.Duration) (string, error) {
+		return "", fmt.Errorf("boom")
+	})
+
+	outDir := filepath.Join(t.TempDir(), "out")
+	contexts := []ContextConfig{
+		{HostContext: "ctx-a", ServiceAccountName: "sa-a", ServiceAccountNamespace: "ns-a"},
+	}
+
+	err := RefreshTokens(contexts, "unused", outDir, time.Hour)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve token for context \"ctx-a\"")
+}
+
+func TestTokenFileName(t *testing.T) {
+	// Unsafe runes (EKS ARN-style contexts) are replaced.
+	name := TokenFileName("arn:aws:eks:us-east-1:123:cluster/prod")
+	assert.NotContains(t, name, "/")
+	assert.NotContains(t, name, ":")
+
+	// Distinct contexts that sanitize identically still get distinct names.
+	assert.NotEqual(t, TokenFileName("ctx/a"), TokenFileName("ctx:a"))
+
+	// Stable across calls.
+	assert.Equal(t, TokenFileName("ctx-a"), TokenFileName("ctx-a"))
+
+	// Very long context names are truncated but stay unique via the hash.
+	long := ""
+	for range 20 {
+		long += "0123456789"
+	}
+	assert.LessOrEqual(t, len(TokenFileName(long)), 64+1+8)
+	assert.NotEqual(t, TokenFileName(long), TokenFileName(long+"x"))
 }
 
 func TestListContexts(t *testing.T) {

--- a/internal/forge/kube/kubeconfig_test.go
+++ b/internal/forge/kube/kubeconfig_test.go
@@ -344,6 +344,70 @@ func TestRefreshTokens_ContinuesPastFailingContext(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
+func TestGenerateKubeconfig_WritesKubeconfigDespiteTokenFailure(t *testing.T) {
+	// A token mint failure must not prevent the kubeconfig from being written:
+	// healthy contexts still work and the refresher retries the rest.
+	stubResolveToken(t, func(ctx ContextConfig, kubeconfigPath string, duration time.Duration) (string, error) {
+		if ctx.HostContext == "ctx-b" {
+			return "", fmt.Errorf("cluster unreachable")
+		}
+		return "token-" + ctx.HostContext, nil
+	})
+
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "kubeconfig")
+	outDir := filepath.Join(tmpDir, "out")
+	require.NoError(t, os.WriteFile(srcPath, []byte(sampleKubeconfig()), 0o600))
+
+	contexts := []ContextConfig{
+		{HostContext: "ctx-a", ServiceAccountName: "sa-a", ServiceAccountNamespace: "ns-a"},
+		{HostContext: "ctx-b", ServiceAccountName: "sa-b", ServiceAccountNamespace: "ns-b"},
+	}
+
+	err := GenerateKubeconfig(contexts, srcPath, "ctx-a", outDir, time.Hour)
+
+	// The error is a TokenMintError (non-fatal), not a hard failure.
+	require.Error(t, err)
+	var mintErr *TokenMintError
+	require.ErrorAs(t, err, &mintErr)
+	assert.Contains(t, err.Error(), "ctx-b")
+
+	// The kubeconfig was still written, and the healthy context has a token.
+	_, statErr := os.Stat(filepath.Join(outDir, KubeconfigFileName))
+	require.NoError(t, statErr)
+	salt := readSalt(t, outDir)
+	data, readErr := os.ReadFile(filepath.Join(outDir, TokensDirName, TokenFileName("ctx-a", salt)))
+	require.NoError(t, readErr)
+	assert.Equal(t, "token-ctx-a", string(data))
+}
+
+func TestRefreshTokens_PrunesRemovedContexts(t *testing.T) {
+	stubResolveToken(t, staticToken)
+
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "kubeconfig")
+	outDir := filepath.Join(tmpDir, "out")
+	require.NoError(t, os.WriteFile(srcPath, []byte(sampleKubeconfig()), 0o600))
+
+	both := []ContextConfig{
+		{HostContext: "ctx-a", ServiceAccountName: "sa-a", ServiceAccountNamespace: "ns-a"},
+		{HostContext: "ctx-b", ServiceAccountName: "sa-b", ServiceAccountNamespace: "ns-b"},
+	}
+	require.NoError(t, GenerateKubeconfig(both, srcPath, "ctx-a", outDir, time.Hour))
+	salt := readSalt(t, outDir)
+	bTokenPath := filepath.Join(outDir, TokensDirName, TokenFileName("ctx-b", salt))
+	_, err := os.Stat(bTokenPath)
+	require.NoError(t, err, "precondition: ctx-b token exists")
+
+	// Refresh with ctx-b removed: its token file must be pruned.
+	require.NoError(t, RefreshTokens(both[:1], srcPath, outDir, time.Hour))
+
+	_, err = os.Stat(bTokenPath)
+	assert.True(t, os.IsNotExist(err), "removed context's token file should be pruned")
+	_, err = os.Stat(filepath.Join(outDir, TokensDirName, TokenFileName("ctx-a", salt)))
+	assert.NoError(t, err, "remaining context's token file is kept")
+}
+
 func TestKubectlCreateToken_Timeout(t *testing.T) {
 	// A kubectl that hangs must not block indefinitely; the bounded timeout
 	// turns it into an error rather than a stuck session start. `exec` so the

--- a/internal/forge/kube/kubeconfig_test.go
+++ b/internal/forge/kube/kubeconfig_test.go
@@ -120,12 +120,13 @@ func TestGenerateKubeconfig_Success(t *testing.T) {
 		assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
 	}
 
-	// The container user is not necessarily the host user: the mounted
-	// directory tree must be world-readable.
+	// The container user is not necessarily the host user: it needs traversal
+	// into the mounted directories (x), but other host users must not be able
+	// to list the token files (no r).
 	for _, p := range []string{outDir, filepath.Join(outDir, TokensDirName)} {
 		info, err := os.Stat(p)
 		require.NoError(t, err)
-		assert.Equal(t, os.FileMode(0o755), info.Mode().Perm(), p)
+		assert.Equal(t, os.FileMode(0o711), info.Mode().Perm(), p)
 	}
 	info, err := os.Stat(filepath.Join(outDir, KubeconfigFileName))
 	require.NoError(t, err)
@@ -153,7 +154,7 @@ func TestGenerateKubeconfig_OverwritesRestrictivePermissions(t *testing.T) {
 
 	info, err := os.Stat(outDir)
 	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o755), info.Mode().Perm(), "dir permissions should be widened to 0755")
+	assert.Equal(t, os.FileMode(0o711), info.Mode().Perm(), "dir permissions should be widened to 0711 for container traversal")
 
 	info, err = os.Stat(filepath.Join(outDir, KubeconfigFileName))
 	require.NoError(t, err)
@@ -324,8 +325,59 @@ func TestTokenFileName(t *testing.T) {
 	for range 20 {
 		long += "0123456789"
 	}
-	assert.LessOrEqual(t, len(TokenFileName(long)), 64+1+8)
+	assert.LessOrEqual(t, len(TokenFileName(long)), 64+1+16)
 	assert.NotEqual(t, TokenFileName(long), TokenFileName(long+"x"))
+}
+
+func TestKubeconfigUpToDate(t *testing.T) {
+	stubResolveToken(t, staticToken)
+
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "kubeconfig")
+	outDir := filepath.Join(tmpDir, "out")
+	require.NoError(t, os.WriteFile(srcPath, []byte(sampleKubeconfig()), 0o600))
+
+	contexts := []ContextConfig{
+		{HostContext: "ctx-a", ServiceAccountName: "sa-a", ServiceAccountNamespace: "ns-a"},
+	}
+	require.NoError(t, GenerateKubeconfig(contexts, srcPath, "ctx-a", outDir, time.Hour))
+
+	t.Run("true when nothing changed", func(t *testing.T) {
+		upToDate, err := KubeconfigUpToDate(contexts, srcPath, "ctx-a", outDir)
+		require.NoError(t, err)
+		assert.True(t, upToDate)
+	})
+
+	t.Run("false when contexts changed", func(t *testing.T) {
+		changed := append(contexts, ContextConfig{HostContext: "ctx-b", ServiceAccountName: "sa-b", ServiceAccountNamespace: "ns-b"})
+		upToDate, err := KubeconfigUpToDate(changed, srcPath, "ctx-a", outDir)
+		require.NoError(t, err)
+		assert.False(t, upToDate)
+	})
+
+	t.Run("false when default context changed", func(t *testing.T) {
+		upToDate, err := KubeconfigUpToDate(contexts, srcPath, "ctx-b", outDir)
+		require.NoError(t, err)
+		assert.False(t, upToDate)
+	})
+
+	t.Run("error when no generated kubeconfig exists", func(t *testing.T) {
+		_, err := KubeconfigUpToDate(contexts, srcPath, "ctx-a", filepath.Join(tmpDir, "missing"))
+		assert.Error(t, err)
+	})
+}
+
+func TestResolveToken_KubectlFailure(t *testing.T) {
+	// Exercise the real resolveToken: with no cluster (and possibly no
+	// kubectl), both the --duration attempt and the fallback must fail with a
+	// wrapped error rather than returning a bogus token.
+	_, err := resolveToken(ContextConfig{
+		HostContext:             "nope",
+		ServiceAccountName:      "sa",
+		ServiceAccountNamespace: "ns",
+	}, filepath.Join(t.TempDir(), "missing-kubeconfig"), time.Hour)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "kubectl create token failed")
 }
 
 func TestListContexts(t *testing.T) {

--- a/internal/forge/kube/kubeconfig_test.go
+++ b/internal/forge/kube/kubeconfig_test.go
@@ -309,6 +309,59 @@ func TestRefreshTokens_ResolveTokenError(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to resolve token for context \"ctx-a\"")
 }
 
+func TestRefreshTokens_ContinuesPastFailingContext(t *testing.T) {
+	// One broken context must not starve refresh for the healthy contexts
+	// that share the MCP server.
+	stubResolveToken(t, func(ctx ContextConfig, kubeconfigPath string, duration time.Duration) (string, error) {
+		if ctx.HostContext == "broken" {
+			return "", fmt.Errorf("cluster unreachable")
+		}
+		return "token-" + ctx.HostContext, nil
+	})
+
+	outDir := filepath.Join(t.TempDir(), "out")
+	require.NoError(t, ensureDir(outDir))
+	contexts := []ContextConfig{
+		{HostContext: "broken", ServiceAccountName: "sa", ServiceAccountNamespace: "ns"},
+		{HostContext: "healthy-a", ServiceAccountName: "sa", ServiceAccountNamespace: "ns"},
+		{HostContext: "healthy-b", ServiceAccountName: "sa", ServiceAccountNamespace: "ns"},
+	}
+
+	err := RefreshTokens(contexts, "unused", outDir, time.Hour)
+	// The broken context is reported...
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve token for context \"broken\"")
+
+	// ...but the healthy contexts were still refreshed.
+	salt := readSalt(t, outDir)
+	for _, name := range []string{"healthy-a", "healthy-b"} {
+		data, err := os.ReadFile(filepath.Join(outDir, TokensDirName, TokenFileName(name, salt)))
+		require.NoError(t, err, "healthy context %q must be refreshed despite a broken sibling", name)
+		assert.Equal(t, "token-"+name, string(data))
+	}
+	// The broken context has no token file.
+	_, err = os.Stat(filepath.Join(outDir, TokensDirName, TokenFileName("broken", salt)))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestKubectlCreateToken_Timeout(t *testing.T) {
+	// A kubectl that hangs must not block indefinitely; the bounded timeout
+	// turns it into an error rather than a stuck session start. `exec` so the
+	// sleep replaces the shell and the context kill terminates it directly
+	// (as it would the real kubectl), instead of leaving a child holding the
+	// stdout pipe open.
+	fakeKubectl(t, `exec sleep 5`)
+	orig := kubectlTokenTimeout
+	kubectlTokenTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { kubectlTokenTimeout = orig })
+
+	start := time.Now()
+	_, err := kubectlCreateToken([]string{"create", "token", "sa"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out")
+	assert.Less(t, time.Since(start), 3*time.Second, "should return promptly on timeout, not wait for kubectl")
+}
+
 func TestTokenFileName(t *testing.T) {
 	const salt = "test-salt"
 

--- a/internal/forge/kube/mcp.go
+++ b/internal/forge/kube/mcp.go
@@ -1,8 +1,19 @@
 package kube
 
 const (
-	MCPServerPort           = "8090"
-	MCPServerKubeconfigPath = "/home/user/.kube/config"
+	MCPServerPort = "8090"
+
+	// MCPServerKubeDir is where the generated kubeconfig directory is
+	// bind-mounted inside the k8s-mcp container. The whole directory is
+	// mounted (not just the kubeconfig) so token files rewritten on the host
+	// appear in the container.
+	MCPServerKubeDir        = "/home/user/.kube"
+	MCPServerKubeconfigPath = MCPServerKubeDir + "/" + KubeconfigFileName
+
+	// KubeconfigFileName and TokensDirName define the layout inside the
+	// mounted directory, identical on the host and in the container.
+	KubeconfigFileName = "config"
+	TokensDirName      = "tokens"
 )
 
 func MCPServerArgs() []string {

--- a/internal/forge/kube/refresh.go
+++ b/internal/forge/kube/refresh.go
@@ -1,0 +1,47 @@
+package kube
+
+import (
+	"context"
+	"time"
+)
+
+// DefaultTokenRefreshInterval is how often a running session re-mints SA
+// tokens. It must stay comfortably below the smallest token lifetime an API
+// server will grant (1h on most clusters) so a single missed refresh never
+// leaves the MCP server with expired credentials.
+const DefaultTokenRefreshInterval = 15 * time.Minute
+
+// TokenRefresher periodically re-mints the SA tokens used by the shared
+// Kubernetes MCP server. Tokens expire after ~1h on most clusters while
+// sessions can stay open for days, so the CLI keeps refreshing them for as
+// long as it is attached to a session.
+type TokenRefresher struct {
+	Contexts       []ContextConfig
+	KubeconfigPath string        // host kubeconfig used to mint tokens
+	OutputDir      string        // generated-kubeconfig dir mounted into the container
+	TokenDuration  time.Duration // lifetime requested for each minted token
+	Interval       time.Duration // defaults to DefaultTokenRefreshInterval
+	Log            func(format string, args ...any)
+}
+
+// Run blocks, refreshing tokens every Interval until ctx is cancelled.
+// Failures are logged and retried on the next tick: a transient kubectl or
+// network error must not end refreshes for a session that runs for days.
+func (r *TokenRefresher) Run(ctx context.Context) {
+	interval := r.Interval
+	if interval <= 0 {
+		interval = DefaultTokenRefreshInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := RefreshTokens(r.Contexts, r.KubeconfigPath, r.OutputDir, r.TokenDuration); err != nil && r.Log != nil {
+				r.Log("Warning: failed to refresh Kubernetes MCP tokens: %v", err)
+			}
+		}
+	}
+}

--- a/internal/forge/kube/refresh.go
+++ b/internal/forge/kube/refresh.go
@@ -6,9 +6,9 @@ import (
 )
 
 // DefaultTokenRefreshInterval is how often a running session re-mints SA
-// tokens. It must stay comfortably below the smallest token lifetime an API
-// server will grant (1h on most clusters) so a single missed refresh never
-// leaves the MCP server with expired credentials.
+// tokens. Run caps the effective interval at half the requested token
+// lifetime, so even a token_duration near the 10m TokenRequest minimum is
+// refreshed before it can expire.
 const DefaultTokenRefreshInterval = 15 * time.Minute
 
 // TokenRefresher periodically re-mints the SA tokens used by the shared
@@ -31,6 +31,9 @@ func (r *TokenRefresher) Run(ctx context.Context) {
 	interval := r.Interval
 	if interval <= 0 {
 		interval = DefaultTokenRefreshInterval
+	}
+	if r.TokenDuration > 0 && r.TokenDuration/2 < interval {
+		interval = r.TokenDuration / 2
 	}
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()

--- a/internal/forge/kube/refresh_test.go
+++ b/internal/forge/kube/refresh_test.go
@@ -1,0 +1,83 @@
+package kube
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenRefresher_RefreshesUntilCancelled(t *testing.T) {
+	var calls atomic.Int32
+	stubResolveToken(t, func(ctx ContextConfig, kubeconfigPath string, duration time.Duration) (string, error) {
+		calls.Add(1)
+		return fmt.Sprintf("token-%d", calls.Load()), nil
+	})
+
+	outDir := filepath.Join(t.TempDir(), "out")
+	contexts := []ContextConfig{
+		{HostContext: "ctx-a", ServiceAccountName: "sa-a", ServiceAccountNamespace: "ns-a"},
+	}
+
+	r := &TokenRefresher{
+		Contexts:       contexts,
+		KubeconfigPath: "unused",
+		OutputDir:      outDir,
+		TokenDuration:  time.Hour,
+		Interval:       time.Millisecond,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		r.Run(ctx)
+		close(done)
+	}()
+
+	require.Eventually(t, func() bool { return calls.Load() >= 2 }, 5*time.Second, time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("refresher did not stop after cancellation")
+	}
+
+	data, err := os.ReadFile(filepath.Join(outDir, TokensDirName, TokenFileName("ctx-a")))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "token-")
+}
+
+func TestTokenRefresher_LogsAndKeepsGoingOnError(t *testing.T) {
+	var calls atomic.Int32
+	stubResolveToken(t, func(ctx ContextConfig, kubeconfigPath string, duration time.Duration) (string, error) {
+		calls.Add(1)
+		return "", fmt.Errorf("transient failure")
+	})
+
+	var logged atomic.Int32
+	r := &TokenRefresher{
+		Contexts: []ContextConfig{
+			{HostContext: "ctx-a", ServiceAccountName: "sa-a", ServiceAccountNamespace: "ns-a"},
+		},
+		KubeconfigPath: "unused",
+		OutputDir:      filepath.Join(t.TempDir(), "out"),
+		Interval:       time.Millisecond,
+		Log: func(format string, args ...any) {
+			logged.Add(1)
+			assert.Contains(t, fmt.Sprintf(format, args...), "transient failure")
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	// Multiple failing ticks: the loop must survive errors and keep retrying.
+	require.Eventually(t, func() bool { return calls.Load() >= 2 && logged.Load() >= 2 }, 5*time.Second, time.Millisecond)
+}

--- a/internal/forge/kube/refresh_test.go
+++ b/internal/forge/kube/refresh_test.go
@@ -48,7 +48,7 @@ func TestTokenRefresher_RefreshesUntilCancelled(t *testing.T) {
 		t.Fatal("refresher did not stop after cancellation")
 	}
 
-	data, err := os.ReadFile(filepath.Join(outDir, TokensDirName, TokenFileName("ctx-a")))
+	data, err := os.ReadFile(filepath.Join(outDir, TokensDirName, TokenFileName("ctx-a", readSalt(t, outDir))))
 	require.NoError(t, err)
 	assert.Contains(t, string(data), "token-")
 }

--- a/internal/forge/kube/refresh_test.go
+++ b/internal/forge/kube/refresh_test.go
@@ -53,6 +53,32 @@ func TestTokenRefresher_RefreshesUntilCancelled(t *testing.T) {
 	assert.Contains(t, string(data), "token-")
 }
 
+func TestTokenRefresher_IntervalCappedByTokenDuration(t *testing.T) {
+	var calls atomic.Int32
+	stubResolveToken(t, func(ctx ContextConfig, kubeconfigPath string, duration time.Duration) (string, error) {
+		calls.Add(1)
+		return "token", nil
+	})
+
+	// A long explicit Interval must be capped to half the token lifetime —
+	// otherwise a short-lived token would expire between ticks.
+	r := &TokenRefresher{
+		Contexts: []ContextConfig{
+			{HostContext: "ctx-a", ServiceAccountName: "sa-a", ServiceAccountNamespace: "ns-a"},
+		},
+		KubeconfigPath: "unused",
+		OutputDir:      filepath.Join(t.TempDir(), "out"),
+		TokenDuration:  10 * time.Millisecond,
+		Interval:       time.Hour,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	require.Eventually(t, func() bool { return calls.Load() >= 2 }, 5*time.Second, time.Millisecond)
+}
+
 func TestTokenRefresher_LogsAndKeepsGoingOnError(t *testing.T) {
 	var calls atomic.Int32
 	stubResolveToken(t, func(ctx ContextConfig, kubeconfigPath string, duration time.Duration) (string, error) {

--- a/internal/forge/orchestrator.go
+++ b/internal/forge/orchestrator.go
@@ -4,6 +4,7 @@ package forge
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -912,37 +913,36 @@ func (o *Orchestrator) startKubernetesMCP(ctx context.Context, cfg *config.Confi
 		return err
 	}
 
+	// Decide whether the running container can be reused as-is, WITHOUT tearing
+	// it down yet — the shared server backs every session on the host, so a
+	// failed regeneration must leave it in place rather than take it down for
+	// everyone.
+	reuse := running
+	recreateReason := ""
 	// A container created before the tokenFile layout existed bind-mounts a
 	// single kubeconfig with an inline (long-expired) token; refreshing token
 	// files can't reach it, so it must be recreated.
-	if running && !hasTokenFileLayout(kubeconfigDir) {
-		o.Log("Recreating Kubernetes MCP: kubeconfig layout changed")
-		_ = o.Containers.StopContainer(ctx, k8sMCPName)
-		_ = o.Containers.RemoveContainer(ctx, k8sMCPName)
-		running = false
+	if reuse && !hasTokenFileLayout(kubeconfigDir) {
+		reuse, recreateReason = false, "kubeconfig layout changed"
 	}
-
 	// The server reads its kubeconfig only at startup, so context changes in
-	// config.yaml require a recreate: the old kubeconfig would keep
-	// referencing token files that are no longer refreshed.
-	if running {
+	// config.yaml require a recreate: the old kubeconfig would keep referencing
+	// token files that are no longer refreshed.
+	if reuse {
 		upToDate, err := kube.KubeconfigUpToDate(contexts, homeKubeconfig, defaultCtx, kubeconfigDir)
 		switch {
 		case err != nil:
 			o.Log("Warning: could not compare Kubernetes MCP kubeconfig: %v", err)
 		case !upToDate:
-			o.Log("Recreating Kubernetes MCP: context configuration changed")
-			_ = o.Containers.StopContainer(ctx, k8sMCPName)
-			_ = o.Containers.RemoveContainer(ctx, k8sMCPName)
-			running = false
+			reuse, recreateReason = false, "context configuration changed"
 		}
 	}
 
-	if running {
+	if reuse {
 		// Non-fatal: the running server's current tokens may still be valid,
 		// and the in-session refresher will retry.
 		if err := kube.RefreshTokens(contexts, homeKubeconfig, kubeconfigDir, tokenDuration); err != nil {
-			o.Log("Warning: Kubernetes MCP is running but token refresh failed: %v", err)
+			o.Log("Warning: some Kubernetes contexts could not refresh tokens: %v", err)
 		} else {
 			o.Log("Kubernetes MCP already running; refreshed ServiceAccount tokens")
 		}
@@ -950,21 +950,30 @@ func (o *Orchestrator) startKubernetesMCP(ctx context.Context, cfg *config.Confi
 		return nil
 	}
 
-	// Remove stale container if it exists but isn't running (e.g. crashed/exited)
-	// so we can create a fresh one with the same name.
-	_ = o.Containers.RemoveContainer(ctx, k8sMCPName)
-
-	// The container is down, so rebuild the tokens dir from scratch: contexts
-	// removed from the config would otherwise leave their token files behind
-	// forever (same no-stale-entries rule as UpdateMCPServers).
-	_ = os.RemoveAll(filepath.Join(kubeconfigDir, kube.TokensDirName))
-
+	// (Re)create. Build the new kubeconfig and mint tokens BEFORE stopping any
+	// running container: a hard failure (e.g. an unknown context) then leaves
+	// the shared server serving other sessions instead of taking it down.
+	// Token-mint failures are non-fatal — the kubeconfig is written, healthy
+	// contexts work, and the refresher retries the rest.
 	if err := kube.GenerateKubeconfig(contexts, homeKubeconfig, defaultCtx, kubeconfigDir, tokenDuration); err != nil {
-		return fmt.Errorf("failed to generate kubeconfig: %w", err)
+		var mintErr *kube.TokenMintError
+		if !errors.As(err, &mintErr) {
+			return fmt.Errorf("failed to generate kubeconfig: %w", err)
+		}
+		o.Log("Warning: some Kubernetes contexts could not mint tokens (the refresher will retry): %v", err)
 	}
 	// Drop the pre-tokenFile-layout kubeconfig so the mounted directory only
 	// carries current credentials.
 	_ = os.Remove(filepath.Join(kubeconfigDir, legacyKubeconfigFile))
+
+	// The replacement is ready; now it is safe to swap the container.
+	if running {
+		o.Log("Recreating Kubernetes MCP: %s", recreateReason)
+		_ = o.Containers.StopContainer(ctx, k8sMCPName)
+	}
+	// Remove the existing container (stopped above, or a stale crashed one) so
+	// we can create a fresh one with the same name.
+	_ = o.Containers.RemoveContainer(ctx, k8sMCPName)
 
 	cmd := kube.MCPServerArgs()
 
@@ -1032,9 +1041,11 @@ func (o *Orchestrator) setKubeRefresher(contexts []kube.ContextConfig, kubeconfi
 // the CLI keeps them fresh for as long as it is attached. No-op when the
 // Kubernetes MCP was not started by this process.
 //
-// quiet suppresses failure warnings: during an interactive session stdout
-// belongs to the attached Claude Code TUI, and a background printf would
-// corrupt it. Failed refreshes are retried on the next tick either way.
+// quiet routes failure warnings to stderr instead of the orchestrator's
+// stdout logger: during an interactive session `docker attach` owns
+// stdin/stdout for the Claude Code TUI, so a background printf there would
+// corrupt the screen — but stderr is safe, and dropping the warnings entirely
+// would hide a cluster going unreachable until a tool call fails hours later.
 func (o *Orchestrator) RunKubeTokenRefresher(ctx context.Context, quiet bool) {
 	if o.kubeRefresher == nil {
 		return
@@ -1042,7 +1053,9 @@ func (o *Orchestrator) RunKubeTokenRefresher(ctx context.Context, quiet bool) {
 	r := o.kubeRefresher
 	if quiet {
 		rc := *r
-		rc.Log = nil
+		rc.Log = func(format string, args ...any) {
+			fmt.Fprintf(os.Stderr, format+"\n", args...)
+		}
 		r = &rc
 	}
 	r.Run(ctx)

--- a/internal/forge/orchestrator.go
+++ b/internal/forge/orchestrator.go
@@ -954,6 +954,11 @@ func (o *Orchestrator) startKubernetesMCP(ctx context.Context, cfg *config.Confi
 	// so we can create a fresh one with the same name.
 	_ = o.Containers.RemoveContainer(ctx, k8sMCPName)
 
+	// The container is down, so rebuild the tokens dir from scratch: contexts
+	// removed from the config would otherwise leave their token files behind
+	// forever (same no-stale-entries rule as UpdateMCPServers).
+	_ = os.RemoveAll(filepath.Join(kubeconfigDir, kube.TokensDirName))
+
 	if err := kube.GenerateKubeconfig(contexts, homeKubeconfig, defaultCtx, kubeconfigDir, tokenDuration); err != nil {
 		return fmt.Errorf("failed to generate kubeconfig: %w", err)
 	}

--- a/internal/forge/orchestrator.go
+++ b/internal/forge/orchestrator.go
@@ -29,6 +29,10 @@ type Orchestrator struct {
 	ConfigDir  string
 	ClaudeDir  string
 	Log        func(format string, args ...any)
+
+	// kubeRefresher is set by startKubernetesMCP so RunKubeTokenRefresher can
+	// keep the shared MCP server's SA tokens fresh while a session runs.
+	kubeRefresher *kube.TokenRefresher
 }
 
 // NewOrchestrator creates an Orchestrator with default paths derived from homeDir.
@@ -865,7 +869,11 @@ func (o *Orchestrator) warnUnauthenticatedMCP(cfg *config.Config) {
 	}
 }
 
-// startKubernetesMCP ensures the shared Kubernetes MCP service is running.
+// startKubernetesMCP ensures the shared Kubernetes MCP service is running and
+// that the SA tokens it uses are fresh. The generated-kubeconfig directory is
+// bind-mounted into the container, and the kubeconfig references tokens via
+// tokenFile, so rewriting the token files rotates credentials inside the
+// running container without a restart.
 func (o *Orchestrator) startKubernetesMCP(ctx context.Context, cfg *config.Config) error {
 	// Ensure shared network exists
 	if _, err := o.Containers.EnsureSharedNetwork(ctx, "forge-shared"); err != nil {
@@ -877,21 +885,8 @@ func (o *Orchestrator) startKubernetesMCP(ctx context.Context, cfg *config.Confi
 	if err != nil {
 		return fmt.Errorf("failed to check k8s-mcp status: %w", err)
 	}
-	if running {
-		o.Log("Kubernetes MCP already running")
-		return nil
-	}
 
-	// Remove stale container if it exists but isn't running (e.g. crashed/exited)
-	// so we can create a fresh one with the same name.
-	_ = o.Containers.RemoveContainer(ctx, k8sMCPName)
-
-	// Generate kubeconfig with SA tokens
 	kubeconfigDir := filepath.Join(o.ConfigDir, "k8s-mcp")
-	if err := os.MkdirAll(kubeconfigDir, 0o700); err != nil {
-		return fmt.Errorf("failed to create k8s-mcp config dir: %w", err)
-	}
-	kubeconfigOutput := filepath.Join(kubeconfigDir, "kubeconfig")
 
 	homeKubeconfig := filepath.Join(o.HomeDir, ".kube", "config")
 	if kc := os.Getenv("KUBECONFIG"); kc != "" {
@@ -912,9 +907,43 @@ func (o *Orchestrator) startKubernetesMCP(ctx context.Context, cfg *config.Confi
 		defaultCtx = cfg.Kubernetes.Contexts[0].HostContext
 	}
 
-	if err := kube.GenerateKubeconfig(contexts, homeKubeconfig, defaultCtx, kubeconfigOutput); err != nil {
+	tokenDuration, err := cfg.Kubernetes.TokenDurationValue()
+	if err != nil {
+		return err
+	}
+
+	// A container created before the tokenFile layout existed bind-mounts a
+	// single kubeconfig with an inline (long-expired) token; refreshing token
+	// files can't reach it, so it must be recreated.
+	if running && !hasTokenFileLayout(kubeconfigDir) {
+		o.Log("Recreating Kubernetes MCP: kubeconfig layout changed")
+		_ = o.Containers.StopContainer(ctx, k8sMCPName)
+		_ = o.Containers.RemoveContainer(ctx, k8sMCPName)
+		running = false
+	}
+
+	if running {
+		// Non-fatal: the running server's current tokens may still be valid,
+		// and the in-session refresher will retry.
+		if err := kube.RefreshTokens(contexts, homeKubeconfig, kubeconfigDir, tokenDuration); err != nil {
+			o.Log("Warning: Kubernetes MCP is running but token refresh failed: %v", err)
+		} else {
+			o.Log("Kubernetes MCP already running; refreshed ServiceAccount tokens")
+		}
+		o.setKubeRefresher(contexts, homeKubeconfig, kubeconfigDir, tokenDuration)
+		return nil
+	}
+
+	// Remove stale container if it exists but isn't running (e.g. crashed/exited)
+	// so we can create a fresh one with the same name.
+	_ = o.Containers.RemoveContainer(ctx, k8sMCPName)
+
+	if err := kube.GenerateKubeconfig(contexts, homeKubeconfig, defaultCtx, kubeconfigDir, tokenDuration); err != nil {
 		return fmt.Errorf("failed to generate kubeconfig: %w", err)
 	}
+	// Drop the pre-tokenFile-layout kubeconfig so the mounted directory only
+	// carries current credentials.
+	_ = os.Remove(filepath.Join(kubeconfigDir, "kubeconfig"))
 
 	cmd := kube.MCPServerArgs()
 
@@ -928,8 +957,8 @@ func (o *Orchestrator) startKubernetesMCP(ctx context.Context, cfg *config.Confi
 		Mounts: []mount.Mount{
 			{
 				Type:     mount.TypeBind,
-				Source:   kubeconfigOutput,
-				Target:   kube.MCPServerKubeconfigPath,
+				Source:   kubeconfigDir,
+				Target:   kube.MCPServerKubeDir,
 				ReadOnly: true,
 			},
 		},
@@ -942,7 +971,38 @@ func (o *Orchestrator) startKubernetesMCP(ctx context.Context, cfg *config.Confi
 		return fmt.Errorf("k8s-mcp failed to start: %w", err)
 	}
 
+	o.setKubeRefresher(contexts, homeKubeconfig, kubeconfigDir, tokenDuration)
 	return nil
+}
+
+// hasTokenFileLayout reports whether the generated-kubeconfig directory uses
+// the tokenFile-based layout the container's directory mount expects, as
+// opposed to the legacy single-file layout with an inline token.
+func hasTokenFileLayout(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, kube.KubeconfigFileName))
+	return err == nil
+}
+
+func (o *Orchestrator) setKubeRefresher(contexts []kube.ContextConfig, kubeconfigPath, outputDir string, tokenDuration time.Duration) {
+	o.kubeRefresher = &kube.TokenRefresher{
+		Contexts:       contexts,
+		KubeconfigPath: kubeconfigPath,
+		OutputDir:      outputDir,
+		TokenDuration:  tokenDuration,
+		Log:            o.Log,
+	}
+}
+
+// RunKubeTokenRefresher blocks until ctx is cancelled, periodically
+// re-minting the SA tokens the shared Kubernetes MCP server uses. Tokens
+// expire after ~1h on most clusters while sessions can stay open for days, so
+// the CLI keeps them fresh for as long as it is attached. No-op when the
+// Kubernetes MCP was not started by this process.
+func (o *Orchestrator) RunKubeTokenRefresher(ctx context.Context) {
+	if o.kubeRefresher == nil {
+		return
+	}
+	o.kubeRefresher.Run(ctx)
 }
 
 // RestartSharedMCP stops all shared MCP containers and starts them again.

--- a/internal/forge/orchestrator.go
+++ b/internal/forge/orchestrator.go
@@ -922,6 +922,22 @@ func (o *Orchestrator) startKubernetesMCP(ctx context.Context, cfg *config.Confi
 		running = false
 	}
 
+	// The server reads its kubeconfig only at startup, so context changes in
+	// config.yaml require a recreate: the old kubeconfig would keep
+	// referencing token files that are no longer refreshed.
+	if running {
+		upToDate, err := kube.KubeconfigUpToDate(contexts, homeKubeconfig, defaultCtx, kubeconfigDir)
+		switch {
+		case err != nil:
+			o.Log("Warning: could not compare Kubernetes MCP kubeconfig: %v", err)
+		case !upToDate:
+			o.Log("Recreating Kubernetes MCP: context configuration changed")
+			_ = o.Containers.StopContainer(ctx, k8sMCPName)
+			_ = o.Containers.RemoveContainer(ctx, k8sMCPName)
+			running = false
+		}
+	}
+
 	if running {
 		// Non-fatal: the running server's current tokens may still be valid,
 		// and the in-session refresher will retry.
@@ -943,7 +959,7 @@ func (o *Orchestrator) startKubernetesMCP(ctx context.Context, cfg *config.Confi
 	}
 	// Drop the pre-tokenFile-layout kubeconfig so the mounted directory only
 	// carries current credentials.
-	_ = os.Remove(filepath.Join(kubeconfigDir, "kubeconfig"))
+	_ = os.Remove(filepath.Join(kubeconfigDir, legacyKubeconfigFile))
 
 	cmd := kube.MCPServerArgs()
 
@@ -975,12 +991,24 @@ func (o *Orchestrator) startKubernetesMCP(ctx context.Context, cfg *config.Confi
 	return nil
 }
 
-// hasTokenFileLayout reports whether the generated-kubeconfig directory uses
-// the tokenFile-based layout the container's directory mount expects, as
-// opposed to the legacy single-file layout with an inline token.
+// legacyKubeconfigFile is the single-file kubeconfig (inline token) written
+// by binaries that predate the tokenFile layout.
+const legacyKubeconfigFile = "kubeconfig"
+
+// hasTokenFileLayout reports whether the running container was created with
+// the tokenFile-based directory mount, as opposed to the legacy single-file
+// mount with an inline token. Legacy binaries rewrite their single-file
+// kubeconfig whenever they create the container (and this binary removes it
+// after every create), so its presence means an old binary created the
+// running container even if the new layout also exists on disk.
 func hasTokenFileLayout(dir string) bool {
-	_, err := os.Stat(filepath.Join(dir, kube.KubeconfigFileName))
-	return err == nil
+	if _, err := os.Stat(filepath.Join(dir, kube.KubeconfigFileName)); err != nil {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(dir, legacyKubeconfigFile)); err == nil {
+		return false
+	}
+	return true
 }
 
 func (o *Orchestrator) setKubeRefresher(contexts []kube.ContextConfig, kubeconfigPath, outputDir string, tokenDuration time.Duration) {
@@ -998,11 +1026,21 @@ func (o *Orchestrator) setKubeRefresher(contexts []kube.ContextConfig, kubeconfi
 // expire after ~1h on most clusters while sessions can stay open for days, so
 // the CLI keeps them fresh for as long as it is attached. No-op when the
 // Kubernetes MCP was not started by this process.
-func (o *Orchestrator) RunKubeTokenRefresher(ctx context.Context) {
+//
+// quiet suppresses failure warnings: during an interactive session stdout
+// belongs to the attached Claude Code TUI, and a background printf would
+// corrupt it. Failed refreshes are retried on the next tick either way.
+func (o *Orchestrator) RunKubeTokenRefresher(ctx context.Context, quiet bool) {
 	if o.kubeRefresher == nil {
 		return
 	}
-	o.kubeRefresher.Run(ctx)
+	r := o.kubeRefresher
+	if quiet {
+		rc := *r
+		rc.Log = nil
+		r = &rc
+	}
+	r.Run(ctx)
 }
 
 // RestartSharedMCP stops all shared MCP containers and starts them again.

--- a/internal/forge/orchestrator_test.go
+++ b/internal/forge/orchestrator_test.go
@@ -53,6 +53,47 @@ func setupOrchestrator(t *testing.T, mock *MockContainerManager) (*Orchestrator,
 	return orch, homeDir
 }
 
+// stubFailingKubectl puts a kubectl on PATH that always exits non-zero, so
+// token minting fails fast and deterministically. Minting failures are
+// non-fatal (the container still starts and the refresher retries), so this
+// lets tests exercise the start/recreate paths past token minting without
+// depending on whether a real kubectl or cluster is reachable.
+func stubFailingKubectl(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "kubectl"),
+		[]byte("#!/bin/sh\necho 'no cluster' >&2\nexit 1\n"), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// hostKubeconfigYAML is a minimal host kubeconfig containing a single
+// "my-cluster" context, enough for GenerateKubeconfig to build a valid output.
+const hostKubeconfigYAML = `apiVersion: v1
+kind: Config
+clusters:
+- name: my-cluster
+  cluster:
+    server: https://k8s.example.com:6443
+contexts:
+- name: my-cluster
+  context:
+    cluster: my-cluster
+    user: admin
+users:
+- name: admin
+  user:
+    token: admin-token
+current-context: my-cluster
+`
+
+// writeHostKubeconfig writes hostKubeconfigYAML to homeDir/.kube/config.
+func writeHostKubeconfig(t *testing.T, homeDir string) {
+	t.Helper()
+	kubeDir := filepath.Join(homeDir, ".kube")
+	require.NoError(t, os.MkdirAll(kubeDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(kubeDir, "config"), []byte(hostKubeconfigYAML), 0o644))
+}
+
 func TestStart_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
@@ -1093,11 +1134,12 @@ kubernetes:
 	mockCM.EXPECT().WaitForReady(gomock.Any(), "gw-id", gomock.Any()).Return(nil)
 	mockCM.EXPECT().StartGitHubMCP(gomock.Any(), gomock.Any()).Return("mcp-id", nil)
 	mockCM.EXPECT().WaitForReady(gomock.Any(), "mcp-id", gomock.Any()).Return(nil)
-	// startKubernetesMCP will be called but will fail at GenerateKubeconfig (no kubeconfig file)
-	// Start logs a warning and continues without adding kubernetes to settings.json
+	// startKubernetesMCP is called but fails at GenerateKubeconfig (no host
+	// kubeconfig), which now happens before any container teardown, so no
+	// RemoveContainer call. Start logs a warning and continues without adding
+	// kubernetes to settings.json.
 	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("shared-net-id", nil)
 	mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-k8s-mcp").Return(false, nil)
-	mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-k8s-mcp").Return(nil)
 	mockCM.EXPECT().StartAgent(gomock.Any(), gomock.Any()).Return("agent-id", nil)
 	// ExtraNetworks is NOT set because startKubernetesMCP failed
 
@@ -1140,11 +1182,11 @@ kubernetes:
 	mockCM.EXPECT().WaitForReady(gomock.Any(), "gw-id", gomock.Any()).Return(nil)
 	mockCM.EXPECT().StartGitHubMCP(gomock.Any(), gomock.Any()).Return("mcp-id", nil)
 	mockCM.EXPECT().WaitForReady(gomock.Any(), "mcp-id", gomock.Any()).Return(nil)
-	// startKubernetesMCP fails (no kubeconfig) — Start continues without
-	// kubernetes in settings.json
+	// startKubernetesMCP fails at GenerateKubeconfig (no host kubeconfig),
+	// before any teardown, so no RemoveContainer. Start continues without
+	// kubernetes in settings.json.
 	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("shared-net-id", nil)
 	mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-k8s-mcp").Return(false, nil)
-	mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-k8s-mcp").Return(nil)
 	mockCM.EXPECT().StartAgent(gomock.Any(), gomock.Any()).Return("agent-id", nil)
 
 	sess, err := orch.Start(context.Background(), StartOptions{
@@ -1262,16 +1304,20 @@ current-context: my-cluster
 		},
 	}
 
+	// Token minting fails (fake failing kubectl), but that is non-fatal: the
+	// kubeconfig is still written and the container starts, serving healthy
+	// contexts while the refresher retries the rest.
+	stubFailingKubectl(t)
+
 	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net-id", nil)
 	mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-k8s-mcp").Return(false, nil)
 	mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-k8s-mcp").Return(nil)
-	// GenerateKubeconfig will fail because kubectl isn't available,
-	// but this test verifies the code path up to that point
+	mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).Return("k8s-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "k8s-id", gomock.Any()).Return(nil)
 
 	err := orch.startKubernetesMCP(context.Background(), cfg)
-	// Will fail at GenerateKubeconfig (no kubectl), but exercises the setup code
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to generate kubeconfig")
+	require.NoError(t, err)
+	assert.NotNil(t, orch.kubeRefresher)
 }
 
 func TestStartKubernetesMCP_KUBECONFIGEnvVar(t *testing.T) {
@@ -1293,9 +1339,10 @@ func TestStartKubernetesMCP_KUBECONFIGEnvVar(t *testing.T) {
 		},
 	}
 
+	// No host kubeconfig: GenerateKubeconfig hard-fails before any teardown,
+	// so RemoveContainer is not reached.
 	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net-id", nil)
 	mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-k8s-mcp").Return(false, nil)
-	mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-k8s-mcp").Return(nil)
 
 	err := orch.startKubernetesMCP(context.Background(), cfg)
 	require.Error(t, err)
@@ -1319,9 +1366,9 @@ func TestStartKubernetesMCP_DefaultContextFallback(t *testing.T) {
 		},
 	}
 
+	// No host kubeconfig: GenerateKubeconfig hard-fails before any teardown.
 	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net-id", nil)
 	mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-k8s-mcp").Return(false, nil)
-	mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-k8s-mcp").Return(nil)
 
 	err := orch.startKubernetesMCP(context.Background(), cfg)
 	// Will fail at GenerateKubeconfig, but exercises the DefaultContext path
@@ -1385,28 +1432,8 @@ func TestStartKubernetesMCP_AlreadyRunning_ContextChangeRecreates(t *testing.T) 
 
 	mockCM := NewMockContainerManager(ctrl)
 	orch, homeDir := setupOrchestrator(t, mockCM)
-
-	// Host kubeconfig with two contexts.
-	kubeDir := filepath.Join(homeDir, ".kube")
-	require.NoError(t, os.MkdirAll(kubeDir, 0o755))
-	hostKubeconfig := `apiVersion: v1
-kind: Config
-clusters:
-- name: my-cluster
-  cluster:
-    server: https://k8s.example.com:6443
-contexts:
-- name: my-cluster
-  context:
-    cluster: my-cluster
-    user: admin
-users:
-- name: admin
-  user:
-    token: admin-token
-current-context: my-cluster
-`
-	require.NoError(t, os.WriteFile(filepath.Join(kubeDir, "config"), []byte(hostKubeconfig), 0o644))
+	writeHostKubeconfig(t, homeDir)
+	stubFailingKubectl(t)
 
 	// The generated kubeconfig on disk does not match the current contexts.
 	kubeconfigDir := filepath.Join(orch.ConfigDir, "k8s-mcp")
@@ -1425,27 +1452,71 @@ current-context: my-cluster
 
 	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net-id", nil)
 	mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-k8s-mcp").Return(true, nil)
-	// Context change: the running container is recreated, then the create
-	// path removes any stale container again.
+	// Context drift: the new kubeconfig is generated first, then the running
+	// container is stopped, removed, and replaced.
 	mockCM.EXPECT().StopContainer(gomock.Any(), "forge-k8s-mcp").Return(nil)
-	mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-k8s-mcp").Return(nil).Times(2)
+	mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-k8s-mcp").Return(nil)
+	mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).Return("k8s-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "k8s-id", gomock.Any()).Return(nil)
 
-	// Recreation reaches GenerateKubeconfig, which fails minting (no kubectl)
-	// — the recreate-on-context-change path was exercised.
 	err := orch.startKubernetesMCP(context.Background(), cfg)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to generate kubeconfig")
+	require.NoError(t, err)
+	assert.NotNil(t, orch.kubeRefresher)
 }
 
 func TestStartKubernetesMCP_AlreadyRunning_LegacyFilePresentRecreates(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockCM := NewMockContainerManager(ctrl)
-	orch, _ := setupOrchestrator(t, mockCM)
+	orch, homeDir := setupOrchestrator(t, mockCM)
+	writeHostKubeconfig(t, homeDir)
+	stubFailingKubectl(t)
 
 	// Both layouts on disk: a legacy binary ran after the new layout was
 	// written (downgrade/upgrade), so the running container mounts the legacy
 	// single file and must be recreated.
+	kubeconfigDir := filepath.Join(orch.ConfigDir, "k8s-mcp")
+	require.NoError(t, os.MkdirAll(kubeconfigDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(kubeconfigDir, kube.KubeconfigFileName), []byte("apiVersion: v1\nkind: Config\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(kubeconfigDir, "kubeconfig"), []byte("legacy"), 0o644))
+
+	cfg := &config.Config{
+		Kubernetes: config.KubernetesConfig{
+			Enabled: true,
+			Image:   "k8s-mcp:latest",
+			Contexts: []config.KubeContextEntry{
+				{HostContext: "my-cluster", ServiceAccountName: "sa", ServiceAccountNamespace: "ns"},
+			},
+		},
+	}
+
+	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net-id", nil)
+	mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-k8s-mcp").Return(true, nil)
+	mockCM.EXPECT().StopContainer(gomock.Any(), "forge-k8s-mcp").Return(nil)
+	mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-k8s-mcp").Return(nil)
+	mockCM.EXPECT().StartSharedService(gomock.Any(), gomock.Any()).Return("k8s-id", nil)
+	mockCM.EXPECT().WaitForReady(gomock.Any(), "k8s-id", gomock.Any()).Return(nil)
+
+	err := orch.startKubernetesMCP(context.Background(), cfg)
+	require.NoError(t, err)
+
+	// The legacy single-file kubeconfig is dropped from the mounted dir.
+	_, statErr := os.Stat(filepath.Join(kubeconfigDir, "kubeconfig"))
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+// TestStartKubernetesMCP_GenerateFailureLeavesRunningContainer verifies the
+// shared server is not torn down when regenerating its kubeconfig fails: the
+// container backs every session on the host, so a bad regeneration must leave
+// the working server in place rather than take it down for everyone.
+func TestStartKubernetesMCP_GenerateFailureLeavesRunningContainer(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, _ := setupOrchestrator(t, mockCM)
+
+	// Legacy layout forces a recreate, but there is no host kubeconfig, so
+	// GenerateKubeconfig hard-fails.
 	kubeconfigDir := filepath.Join(orch.ConfigDir, "k8s-mcp")
 	require.NoError(t, os.MkdirAll(kubeconfigDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(kubeconfigDir, kube.KubeconfigFileName), []byte("apiVersion: v1\nkind: Config\n"), 0o644))
@@ -1461,42 +1532,13 @@ func TestStartKubernetesMCP_AlreadyRunning_LegacyFilePresentRecreates(t *testing
 		},
 	}
 
+	// Only network + running checks are expected: no StopContainer /
+	// RemoveContainer, because the regeneration fails before any teardown. If
+	// the code tore the container down first, the strict mock would fail on
+	// the unexpected Stop/Remove call.
 	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net-id", nil)
 	mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-k8s-mcp").Return(true, nil)
-	mockCM.EXPECT().StopContainer(gomock.Any(), "forge-k8s-mcp").Return(nil)
-	mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-k8s-mcp").Return(nil).Times(2)
 
-	err := orch.startKubernetesMCP(context.Background(), cfg)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to generate kubeconfig")
-}
-
-func TestStartKubernetesMCP_AlreadyRunning_LegacyLayoutRecreates(t *testing.T) {
-	ctrl := gomock.NewController(t)
-
-	mockCM := NewMockContainerManager(ctrl)
-	orch, _ := setupOrchestrator(t, mockCM)
-
-	// No tokenFile-layout kubeconfig on disk: the running container still
-	// bind-mounts the legacy single-file kubeconfig with an inline token, so
-	// it must be recreated.
-	cfg := &config.Config{
-		Kubernetes: config.KubernetesConfig{
-			Enabled: true,
-			Image:   "k8s-mcp:latest",
-			Contexts: []config.KubeContextEntry{
-				{HostContext: "ctx-1", ServiceAccountName: "sa", ServiceAccountNamespace: "ns"},
-			},
-		},
-	}
-
-	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net-id", nil)
-	mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-k8s-mcp").Return(true, nil)
-	mockCM.EXPECT().StopContainer(gomock.Any(), "forge-k8s-mcp").Return(nil)
-	mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-k8s-mcp").Return(nil).Times(2)
-
-	// Recreation proceeds to GenerateKubeconfig, which fails without a host
-	// kubeconfig — the recreate path was exercised.
 	err := orch.startKubernetesMCP(context.Background(), cfg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to generate kubeconfig")
@@ -1610,17 +1652,17 @@ kubernetes:
 `
 	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configContent), 0o644))
 
-	// Container is currently running
+	// RestartSharedMCP stops+removes the container itself, then calls
+	// startKubernetesMCP, which hard-fails at GenerateKubeconfig (no host
+	// kubeconfig) before reaching the create-path RemoveContainer.
 	mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-k8s-mcp").Return(true, nil)
 	mockCM.EXPECT().StopContainer(gomock.Any(), "forge-k8s-mcp").Return(nil)
 	mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-k8s-mcp").Return(nil)
-	// startKubernetesMCP is called to restart
 	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net-id", nil)
 	mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-k8s-mcp").Return(false, nil)
-	mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-k8s-mcp").Return(nil)
 
 	err := orch.RestartSharedMCP(context.Background())
-	// Will fail at GenerateKubeconfig (no real kubectl), but exercises stop+start path
+	// Will fail at GenerateKubeconfig (no host kubeconfig), but exercises stop+start path
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to restart Kubernetes MCP")
 }
@@ -1646,11 +1688,12 @@ kubernetes:
 `
 	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configContent), 0o644))
 
-	// Container is NOT running — skip stop, go straight to start
+	// Container is NOT running — skip stop, go straight to start, which
+	// hard-fails at GenerateKubeconfig (no host kubeconfig) before the
+	// create-path RemoveContainer.
 	mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-k8s-mcp").Return(false, nil)
 	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net-id", nil)
 	mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-k8s-mcp").Return(false, nil)
-	mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-k8s-mcp").Return(nil)
 
 	err := orch.RestartSharedMCP(context.Background())
 	require.Error(t, err)

--- a/internal/forge/orchestrator_test.go
+++ b/internal/forge/orchestrator_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/michael-freling/claude-forge/internal/forge/claudecode"
 	"github.com/michael-freling/claude-forge/internal/forge/config"
 	"github.com/michael-freling/claude-forge/internal/forge/container"
+	"github.com/michael-freling/claude-forge/internal/forge/kube"
 	"github.com/michael-freling/claude-forge/internal/forge/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1327,11 +1328,17 @@ func TestStartKubernetesMCP_DefaultContextFallback(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestStartKubernetesMCP_AlreadyRunning(t *testing.T) {
+func TestStartKubernetesMCP_AlreadyRunning_RefreshesTokens(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockCM := NewMockContainerManager(ctrl)
 	orch, _ := setupOrchestrator(t, mockCM)
+
+	// A generated kubeconfig with the tokenFile layout already exists, so the
+	// running container is kept and only the tokens are refreshed.
+	kubeconfigDir := filepath.Join(orch.ConfigDir, "k8s-mcp")
+	require.NoError(t, os.MkdirAll(kubeconfigDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(kubeconfigDir, kube.KubeconfigFileName), []byte("apiVersion: v1\nkind: Config\n"), 0o644))
 
 	cfg := &config.Config{
 		Kubernetes: config.KubernetesConfig{
@@ -1346,8 +1353,98 @@ func TestStartKubernetesMCP_AlreadyRunning(t *testing.T) {
 	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net-id", nil)
 	mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-k8s-mcp").Return(true, nil)
 
+	// Token refresh fails (no kubectl in the test environment) but that is
+	// non-fatal for an already-running server.
 	err := orch.startKubernetesMCP(context.Background(), cfg)
 	require.NoError(t, err)
+
+	// The refresher is armed so the session keeps tokens fresh while attached.
+	require.NotNil(t, orch.kubeRefresher)
+
+	// With the refresher armed, RunKubeTokenRefresher runs until cancelled.
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	done := make(chan struct{})
+	go func() {
+		orch.RunKubeTokenRefresher(cancelled)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunKubeTokenRefresher did not honor context cancellation")
+	}
+}
+
+func TestStartKubernetesMCP_AlreadyRunning_LegacyLayoutRecreates(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, _ := setupOrchestrator(t, mockCM)
+
+	// No tokenFile-layout kubeconfig on disk: the running container still
+	// bind-mounts the legacy single-file kubeconfig with an inline token, so
+	// it must be recreated.
+	cfg := &config.Config{
+		Kubernetes: config.KubernetesConfig{
+			Enabled: true,
+			Image:   "k8s-mcp:latest",
+			Contexts: []config.KubeContextEntry{
+				{HostContext: "ctx-1", ServiceAccountName: "sa", ServiceAccountNamespace: "ns"},
+			},
+		},
+	}
+
+	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net-id", nil)
+	mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-k8s-mcp").Return(true, nil)
+	mockCM.EXPECT().StopContainer(gomock.Any(), "forge-k8s-mcp").Return(nil)
+	mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-k8s-mcp").Return(nil).Times(2)
+
+	// Recreation proceeds to GenerateKubeconfig, which fails without a host
+	// kubeconfig — the recreate path was exercised.
+	err := orch.startKubernetesMCP(context.Background(), cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to generate kubeconfig")
+}
+
+func TestStartKubernetesMCP_InvalidTokenDuration(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, _ := setupOrchestrator(t, mockCM)
+
+	cfg := &config.Config{
+		Kubernetes: config.KubernetesConfig{
+			Enabled:       true,
+			Image:         "k8s-mcp:latest",
+			TokenDuration: "not-a-duration",
+			Contexts: []config.KubeContextEntry{
+				{HostContext: "ctx-1", ServiceAccountName: "sa", ServiceAccountNamespace: "ns"},
+			},
+		},
+	}
+
+	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net-id", nil)
+	mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-k8s-mcp").Return(false, nil)
+
+	err := orch.startKubernetesMCP(context.Background(), cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token_duration")
+}
+
+func TestRunKubeTokenRefresher_NoopWithoutKubernetesMCP(t *testing.T) {
+	orch := &Orchestrator{}
+	// Must return immediately when no Kubernetes MCP was started.
+	done := make(chan struct{})
+	go func() {
+		orch.RunKubeTokenRefresher(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunKubeTokenRefresher did not return for a nil refresher")
+	}
 }
 
 func TestStartKubernetesMCP_EnsureNetworkFails(t *testing.T) {

--- a/internal/forge/orchestrator_test.go
+++ b/internal/forge/orchestrator_test.go
@@ -1361,19 +1361,114 @@ func TestStartKubernetesMCP_AlreadyRunning_RefreshesTokens(t *testing.T) {
 	// The refresher is armed so the session keeps tokens fresh while attached.
 	require.NotNil(t, orch.kubeRefresher)
 
-	// With the refresher armed, RunKubeTokenRefresher runs until cancelled.
-	cancelled, cancel := context.WithCancel(context.Background())
-	cancel()
-	done := make(chan struct{})
-	go func() {
-		orch.RunKubeTokenRefresher(cancelled)
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("RunKubeTokenRefresher did not honor context cancellation")
+	// With the refresher armed, RunKubeTokenRefresher runs until cancelled —
+	// including in quiet mode, which must not mutate the stored refresher.
+	for _, quiet := range []bool{false, true} {
+		cancelled, cancel := context.WithCancel(context.Background())
+		cancel()
+		done := make(chan struct{})
+		go func() {
+			orch.RunKubeTokenRefresher(cancelled, quiet)
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("RunKubeTokenRefresher did not honor context cancellation")
+		}
 	}
+	assert.NotNil(t, orch.kubeRefresher.Log, "quiet mode must not clear the stored refresher's logger")
+}
+
+func TestStartKubernetesMCP_AlreadyRunning_ContextChangeRecreates(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, homeDir := setupOrchestrator(t, mockCM)
+
+	// Host kubeconfig with two contexts.
+	kubeDir := filepath.Join(homeDir, ".kube")
+	require.NoError(t, os.MkdirAll(kubeDir, 0o755))
+	hostKubeconfig := `apiVersion: v1
+kind: Config
+clusters:
+- name: my-cluster
+  cluster:
+    server: https://k8s.example.com:6443
+contexts:
+- name: my-cluster
+  context:
+    cluster: my-cluster
+    user: admin
+users:
+- name: admin
+  user:
+    token: admin-token
+current-context: my-cluster
+`
+	require.NoError(t, os.WriteFile(filepath.Join(kubeDir, "config"), []byte(hostKubeconfig), 0o644))
+
+	// The generated kubeconfig on disk does not match the current contexts.
+	kubeconfigDir := filepath.Join(orch.ConfigDir, "k8s-mcp")
+	require.NoError(t, os.MkdirAll(kubeconfigDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(kubeconfigDir, kube.KubeconfigFileName), []byte("apiVersion: v1\nkind: Config\ncurrent-context: old-ctx\n"), 0o644))
+
+	cfg := &config.Config{
+		Kubernetes: config.KubernetesConfig{
+			Enabled: true,
+			Image:   "k8s-mcp:latest",
+			Contexts: []config.KubeContextEntry{
+				{HostContext: "my-cluster", ServiceAccountName: "sa", ServiceAccountNamespace: "ns"},
+			},
+		},
+	}
+
+	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net-id", nil)
+	mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-k8s-mcp").Return(true, nil)
+	// Context change: the running container is recreated, then the create
+	// path removes any stale container again.
+	mockCM.EXPECT().StopContainer(gomock.Any(), "forge-k8s-mcp").Return(nil)
+	mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-k8s-mcp").Return(nil).Times(2)
+
+	// Recreation reaches GenerateKubeconfig, which fails minting (no kubectl)
+	// — the recreate-on-context-change path was exercised.
+	err := orch.startKubernetesMCP(context.Background(), cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to generate kubeconfig")
+}
+
+func TestStartKubernetesMCP_AlreadyRunning_LegacyFilePresentRecreates(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockCM := NewMockContainerManager(ctrl)
+	orch, _ := setupOrchestrator(t, mockCM)
+
+	// Both layouts on disk: a legacy binary ran after the new layout was
+	// written (downgrade/upgrade), so the running container mounts the legacy
+	// single file and must be recreated.
+	kubeconfigDir := filepath.Join(orch.ConfigDir, "k8s-mcp")
+	require.NoError(t, os.MkdirAll(kubeconfigDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(kubeconfigDir, kube.KubeconfigFileName), []byte("apiVersion: v1\nkind: Config\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(kubeconfigDir, "kubeconfig"), []byte("legacy"), 0o644))
+
+	cfg := &config.Config{
+		Kubernetes: config.KubernetesConfig{
+			Enabled: true,
+			Image:   "k8s-mcp:latest",
+			Contexts: []config.KubeContextEntry{
+				{HostContext: "ctx-1", ServiceAccountName: "sa", ServiceAccountNamespace: "ns"},
+			},
+		},
+	}
+
+	mockCM.EXPECT().EnsureSharedNetwork(gomock.Any(), "forge-shared").Return("net-id", nil)
+	mockCM.EXPECT().IsContainerRunning(gomock.Any(), "forge-k8s-mcp").Return(true, nil)
+	mockCM.EXPECT().StopContainer(gomock.Any(), "forge-k8s-mcp").Return(nil)
+	mockCM.EXPECT().RemoveContainer(gomock.Any(), "forge-k8s-mcp").Return(nil).Times(2)
+
+	err := orch.startKubernetesMCP(context.Background(), cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to generate kubeconfig")
 }
 
 func TestStartKubernetesMCP_AlreadyRunning_LegacyLayoutRecreates(t *testing.T) {
@@ -1437,7 +1532,7 @@ func TestRunKubeTokenRefresher_NoopWithoutKubernetesMCP(t *testing.T) {
 	// Must return immediately when no Kubernetes MCP was started.
 	done := make(chan struct{})
 	go func() {
-		orch.RunKubeTokenRefresher(context.Background())
+		orch.RunKubeTokenRefresher(context.Background(), false)
 		close(done)
 	}()
 	select {

--- a/test/e2e/forge/e2e_test.go
+++ b/test/e2e/forge/e2e_test.go
@@ -415,7 +415,7 @@ func writeKubeDirLayout(t *testing.T, token string) (kubeDir, tokenPath string) 
 	require.NoError(t, os.MkdirAll(tokensDir, 0o711))
 	require.NoError(t, os.Chmod(kubeDir, 0o711))
 
-	tokenFile := kube.TokenFileName("dummy")
+	tokenFile := kube.TokenFileName("dummy", "e2e-salt")
 	kubeconfig := `apiVersion: v1
 kind: Config
 clusters:

--- a/test/e2e/forge/e2e_test.go
+++ b/test/e2e/forge/e2e_test.go
@@ -357,10 +357,63 @@ func TestKubernetesMCPServer_Starts(t *testing.T) {
 	out, err := pullCmd.CombinedOutput()
 	require.NoError(t, err, "failed to pull k8s-mcp image: %s", out)
 
-	// Create a minimal kubeconfig (no real cluster needed — the server starts
-	// regardless and serves MCP tooling; k8s calls would fail but startup won't)
-	tmpDir := t.TempDir()
-	kubeconfigPath := filepath.Join(tmpDir, "kubeconfig")
+	// Create a minimal kubeconfig directory in the layout the orchestrator
+	// generates: a kubeconfig referencing per-context token files, all mounted
+	// as one directory (no real cluster needed — the server starts regardless
+	// and serves MCP tooling; k8s calls would fail but startup won't).
+	kubeDir, tokenPath := writeKubeDirLayout(t, "dummy-token")
+
+	containerName := "forge-e2e-k8s-mcp-test"
+
+	// Clean up any previous run
+	_ = exec.Command("docker", "rm", "-f", containerName).Run()
+	t.Cleanup(func() {
+		_ = exec.Command("docker", "rm", "-f", containerName).Run()
+	})
+
+	runArgs := []string{
+		"run", "-d",
+		"--name", containerName,
+		"-v", kubeDir + ":" + kube.MCPServerKubeDir + ":ro",
+		image,
+	}
+	runArgs = append(runArgs, kube.MCPServerArgs()...)
+	runCmd := exec.CommandContext(ctx, "docker", runArgs...)
+	out, err = runCmd.CombinedOutput()
+	require.NoError(t, err, "failed to start k8s-mcp container: %s", out)
+
+	// Wait for the container to be running (not immediately exited).
+	// waitForRunning includes a 1s stabilization delay to catch immediate crashes.
+	waitForRunning(t, ctx, containerName, 15*time.Second)
+
+	// Rotate the token host-side the way RefreshTokens does (atomic rename)
+	// and verify the running container sees the new content through the
+	// read-only directory mount — the mechanism that keeps long sessions
+	// authenticated without restarting the server.
+	tmpToken := filepath.Join(filepath.Dir(tokenPath), ".tmp-rotate")
+	require.NoError(t, os.WriteFile(tmpToken, []byte("rotated-token"), 0o644))
+	require.NoError(t, os.Rename(tmpToken, tokenPath))
+
+	containerTokenPath := kube.MCPServerKubeDir + "/" + kube.TokensDirName + "/" + filepath.Base(tokenPath)
+	catCmd := exec.CommandContext(ctx, "docker", "exec", containerName, "/bin/cat", containerTokenPath)
+	catOut, err := catCmd.CombinedOutput()
+	require.NoError(t, err, "failed to read token inside container: %s", catOut)
+	require.Equal(t, "rotated-token", strings.TrimSpace(string(catOut)),
+		"container must see host-side token rotation without a restart")
+}
+
+// writeKubeDirLayout writes the generated-kubeconfig directory layout the
+// orchestrator mounts into the k8s-mcp container (config + tokens/<file>),
+// with the world-readable permissions the non-root container user needs.
+// Returns the directory and the host path of the token file.
+func writeKubeDirLayout(t *testing.T, token string) (kubeDir, tokenPath string) {
+	t.Helper()
+
+	kubeDir = filepath.Join(t.TempDir(), "k8s-mcp")
+	tokensDir := filepath.Join(kubeDir, kube.TokensDirName)
+	require.NoError(t, os.MkdirAll(tokensDir, 0o755))
+
+	tokenFile := kube.TokenFileName("dummy")
 	kubeconfig := `apiVersion: v1
 kind: Config
 clusters:
@@ -375,33 +428,14 @@ contexts:
 users:
   - name: dummy
     user:
-      token: dummy-token
+      tokenFile: ` + kube.MCPServerKubeDir + "/" + kube.TokensDirName + "/" + tokenFile + `
 current-context: dummy
 `
-	require.NoError(t, os.WriteFile(kubeconfigPath, []byte(kubeconfig), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(kubeDir, kube.KubeconfigFileName), []byte(kubeconfig), 0o644))
 
-	containerName := "forge-e2e-k8s-mcp-test"
-
-	// Clean up any previous run
-	_ = exec.Command("docker", "rm", "-f", containerName).Run()
-	t.Cleanup(func() {
-		_ = exec.Command("docker", "rm", "-f", containerName).Run()
-	})
-
-	runArgs := []string{
-		"run", "-d",
-		"--name", containerName,
-		"-v", kubeconfigPath + ":" + kube.MCPServerKubeconfigPath + ":ro",
-		image,
-	}
-	runArgs = append(runArgs, kube.MCPServerArgs()...)
-	runCmd := exec.CommandContext(ctx, "docker", runArgs...)
-	out, err = runCmd.CombinedOutput()
-	require.NoError(t, err, "failed to start k8s-mcp container: %s", out)
-
-	// Wait for the container to be running (not immediately exited).
-	// waitForRunning includes a 1s stabilization delay to catch immediate crashes.
-	waitForRunning(t, ctx, containerName, 15*time.Second)
+	tokenPath = filepath.Join(tokensDir, tokenFile)
+	require.NoError(t, os.WriteFile(tokenPath, []byte(token), 0o644))
+	return kubeDir, tokenPath
 }
 
 // TestAgentDockerInDocker verifies the agent image's Docker-in-Docker support:
@@ -525,27 +559,9 @@ func TestKubernetesMCPServer_AgentConnectivity(t *testing.T) {
 		_ = exec.Command("docker", "network", "rm", sessionNet).Run()
 	})
 
-	// Create kubeconfig with 0644 (testing the permission fix)
-	tmpDir := t.TempDir()
-	kubeconfigPath := filepath.Join(tmpDir, "kubeconfig")
-	kubeconfig := `apiVersion: v1
-kind: Config
-clusters:
-  - name: dummy
-    cluster:
-      server: https://localhost:6443
-contexts:
-  - name: dummy
-    context:
-      cluster: dummy
-      user: dummy
-users:
-  - name: dummy
-    user:
-      token: dummy-token
-current-context: dummy
-`
-	require.NoError(t, os.WriteFile(kubeconfigPath, []byte(kubeconfig), 0o644))
+	// Create the kubeconfig directory layout with world-readable permissions
+	// (the container runs as a non-root user that differs from the host user)
+	kubeDir, _ := writeKubeDirLayout(t, "dummy-token")
 
 	// Start k8s MCP on the shared network with alias "k8s-mcp"
 	k8sName := "forge-e2e-k8s-mcp-conn"
@@ -559,7 +575,7 @@ current-context: dummy
 		"--name", k8sName,
 		"--network", sharedNet,
 		"--network-alias", "k8s-mcp",
-		"-v", kubeconfigPath + ":" + kube.MCPServerKubeconfigPath + ":ro",
+		"-v", kubeDir + ":" + kube.MCPServerKubeDir + ":ro",
 		k8sImage,
 	}
 	k8sArgs = append(k8sArgs, kube.MCPServerArgs()...)

--- a/test/e2e/forge/e2e_test.go
+++ b/test/e2e/forge/e2e_test.go
@@ -403,15 +403,17 @@ func TestKubernetesMCPServer_Starts(t *testing.T) {
 }
 
 // writeKubeDirLayout writes the generated-kubeconfig directory layout the
-// orchestrator mounts into the k8s-mcp container (config + tokens/<file>),
-// with the world-readable permissions the non-root container user needs.
+// orchestrator mounts into the k8s-mcp container (config + tokens/<file>):
+// execute-only 0711 directories (the non-root container user opens exact
+// paths, other host users cannot list the tokens) and 0644 files.
 // Returns the directory and the host path of the token file.
 func writeKubeDirLayout(t *testing.T, token string) (kubeDir, tokenPath string) {
 	t.Helper()
 
 	kubeDir = filepath.Join(t.TempDir(), "k8s-mcp")
 	tokensDir := filepath.Join(kubeDir, kube.TokensDirName)
-	require.NoError(t, os.MkdirAll(tokensDir, 0o755))
+	require.NoError(t, os.MkdirAll(tokensDir, 0o711))
+	require.NoError(t, os.Chmod(kubeDir, 0o711))
 
 	tokenFile := kube.TokenFileName("dummy")
 	kubeconfig := `apiVersion: v1


### PR DESCRIPTION
## Summary

The shared Kubernetes MCP container was started once with a kubeconfig that embedded a ServiceAccount token minted at container-creation time (`kubectl create token` default ≈1h). Claude Code sessions stay open for days and the container is reused across sessions, so every cluster call started failing with 401 about an hour after the container first started. This PR makes the tokens self-refreshing, lets users request longer-lived tokens, and hardens the surrounding lifecycle so a single bad cluster can't take the shared server down.

## Core mechanism

- **`tokenFile` instead of an inline token.** The generated kubeconfig references each context's token via `tokenFile` from a directory (not a single file) bind-mounted into the container. kubernetes-mcp-server builds its clients through standard `clientcmd`, and client-go's bearer-auth transport re-reads a `tokenFile` on its own — so rewriting the token files on the host rotates credentials inside the running container **without a restart**. Writes are atomic (temp-file + rename).
- **Refreshed at start and on a timer.** Tokens are re-minted at every `start`/`resume` (even when the shared container is already up), then refreshed by a background loop while the CLI is attached — every 15 min, or every half token-lifetime if that is shorter.
- **Configurable lifetime.** New `kubernetes.token_duration` (default `24h`, min `10m`), passed as `kubectl create token --duration`. API servers that cap over-max requests degrade gracefully; for servers that *reject* them, minting retries once without `--duration`. Validation is scoped to `kubernetes.enabled: true` so a stray value can't break unrelated commands.

## Resilience & security

- **Per-context independence.** One broken context (revoked RBAC, unreachable cluster, stale kubeconfig entry) no longer starves refresh for the healthy contexts sharing the server — failures are collected with `errors.Join` and healthy contexts keep refreshing.
- **Generate-before-teardown.** Cold-start and recreate paths write the new kubeconfig and mint tokens *before* stopping the running container; a hard failure leaves the shared server serving every other session instead of taking it down. Token-mint failures are non-fatal (`TokenMintError` → warning) so the MCP still starts for healthy contexts.
- **Bounded `kubectl`.** Token minting runs under a 10s timeout, so a hung kubectl / unreachable cluster can't block session start indefinitely.
- **Unguessable token paths.** Token filenames are salted with a per-install `.token-salt` (0600); the mounted dirs are `0711` (traversal for the container's non-host uid, no listing for other users) and token files `0644` — restoring the old "no other-user access" property.
- **Migration & hygiene.** A container still using the legacy single-file mount is detected and recreated once; token files for contexts removed from the config are pruned; refresh warnings route to stderr in interactive mode (safe alongside the `docker attach` TTY) instead of being suppressed.

## Testing

- Unit tests for kubeconfig generation, refresh loop (interval capping, cancellation, error resilience), per-context degradation, salt, `--duration` fallback, kubectl timeout, config validation, and the orchestrator start/recreate/generate-failure paths. `go test -race ./...` green; coverage ≈91% vs the 90% gate; `golangci-lint` clean.
- E2E (`-tags=forge_e2e`) run against the real `ghcr.io/containers/kubernetes-mcp-server:latest`, including a host-side atomic token rotation observed inside the running container and the `0711`/`0644` permission layout.

## Docs

- `docs/content/docs/mcp-servers/kubernetes.md`: token lifetime, refresh behavior, and the shared-host confidentiality trade-off.
- `docs/content/docs/configuration.md` + `claude-forge init` template: `token_duration`.
- `docs/content/docs/how-it-works.md`, `CLAUDE.md`: refresh behavior and the rotate-token-files-never-restart invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)