### PR TITLE
feat(kube): scope ArgoCD access in kube render — read-all, patch ApplicationSets

### DIFF
--- a/internal/forge/kube/carveouts.go
+++ b/internal/forge/kube/carveouts.go
@@ -43,6 +43,46 @@ func GrantedSubresources() []string {
 	}
 }
 
+// ScopedWriteGroup narrows write access for a non-core API group: the agent
+// gets read-only access to every resource in the group, but write verbs are
+// limited to an explicit set of resources. It is only applied when the group
+// is actually discovered in the target cluster (i.e. its CRDs are installed),
+// so no rule is emitted for groups the cluster does not have.
+type ScopedWriteGroup struct {
+	APIGroup          string
+	WritableResources []string
+	WriteVerbs        []string
+}
+
+// ScopedWriteGroups returns non-core API groups whose write access is narrowed
+// to specific resources. These override the default "namespaced group → full
+// verbs on all resources" behaviour for the listed groups.
+func ScopedWriteGroups() []ScopedWriteGroup {
+	return []ScopedWriteGroup{
+		{
+			// ArgoCD: broad read for inspecting Applications/AppProjects, but
+			// writes limited to ApplicationSets (e.g. patching target
+			// revisions). Only rendered when the argoproj.io CRDs are
+			// installed; the ClusterRole is cluster-wide, so this covers
+			// ApplicationSets in every namespace.
+			APIGroup:          "argoproj.io",
+			WritableResources: []string{"applicationsets"},
+			WriteVerbs:        []string{"update", "patch"},
+		},
+	}
+}
+
+// IsScopedWriteGroup reports whether a non-core API group has narrowed write
+// access and must be excluded from the default wildcard grouping.
+func IsScopedWriteGroup(group string) bool {
+	for _, sg := range ScopedWriteGroups() {
+		if group == sg.APIGroup {
+			return true
+		}
+	}
+	return false
+}
+
 // DeniedVerbs returns verbs that are filtered from all rules.
 func DeniedVerbs() []string {
 	return []string{

--- a/internal/forge/kube/carveouts_test.go
+++ b/internal/forge/kube/carveouts_test.go
@@ -35,6 +35,30 @@ func TestGrantedSubresources(t *testing.T) {
 	}
 }
 
+func TestScopedWriteGroups_ArgoApplicationSets(t *testing.T) {
+	var argo *ScopedWriteGroup
+	for i, sg := range ScopedWriteGroups() {
+		if sg.APIGroup == "argoproj.io" {
+			argo = &ScopedWriteGroups()[i]
+			break
+		}
+	}
+
+	if assert.NotNil(t, argo, "expected a scoped-write group for argoproj.io") {
+		assert.Equal(t, []string{"applicationsets"}, argo.WritableResources,
+			"writes must be limited to applicationsets")
+		assert.Contains(t, argo.WriteVerbs, "patch", "must allow patching target revisions")
+		assert.NotContains(t, argo.WriteVerbs, "delete")
+		assert.NotContains(t, argo.WriteVerbs, "create")
+	}
+}
+
+func TestIsScopedWriteGroup(t *testing.T) {
+	assert.True(t, IsScopedWriteGroup("argoproj.io"))
+	assert.False(t, IsScopedWriteGroup("apps"))
+	assert.False(t, IsScopedWriteGroup(""))
+}
+
 func TestFilterVerbs(t *testing.T) {
 	result := FilterVerbs([]string{"get", "list", "impersonate", "watch"})
 	assert.Equal(t, []string{"get", "list", "watch"}, result)

--- a/internal/forge/kube/render.go
+++ b/internal/forge/kube/render.go
@@ -67,6 +67,9 @@ func buildRules(resources []APIResource) []PolicyRule {
 	groups := make(map[string]*groupScope)
 	coreNamespaced := make(map[string]bool)
 	coreClustered := make(map[string]bool)
+	// Discovered resources per scoped-write group (e.g. argoproj.io), used to
+	// emit narrowed rules only when the group's CRDs are installed.
+	scopedResources := make(map[string]map[string]bool)
 
 	for _, r := range resources {
 		if IsAPIGroupDenied(r.APIGroup) {
@@ -84,6 +87,19 @@ func buildRules(resources []APIResource) []PolicyRule {
 			} else {
 				coreClustered[r.Resource] = true
 			}
+			continue
+		}
+
+		// Scoped-write groups are handled separately: read-only across the
+		// group, write only on specific resources. Keep them out of the
+		// default wildcard grouping below.
+		if IsScopedWriteGroup(r.APIGroup) {
+			seen, ok := scopedResources[r.APIGroup]
+			if !ok {
+				seen = make(map[string]bool)
+				scopedResources[r.APIGroup] = seen
+			}
+			seen[r.Resource] = true
 			continue
 		}
 
@@ -195,6 +211,37 @@ func buildRules(resources []APIResource) []PolicyRule {
 			Resources: []string{"*"},
 			Verbs:     fullVerbs,
 		})
+	}
+
+	// Scoped-write groups (e.g. argoproj.io): only emitted when discovered in
+	// the cluster. Broad read across the group, with write verbs limited to
+	// the configured resources (which are themselves also read via the
+	// wildcard rule).
+	for _, sg := range ScopedWriteGroups() {
+		seen, ok := scopedResources[sg.APIGroup]
+		if !ok {
+			continue // group's CRDs are not installed in this cluster
+		}
+		rules = append(rules, PolicyRule{
+			APIGroups: []string{sg.APIGroup},
+			Resources: []string{"*"},
+			Verbs:     ReadOnlyVerbs(),
+		})
+
+		var writable []string
+		for _, res := range sg.WritableResources {
+			if seen[res] {
+				writable = append(writable, res)
+			}
+		}
+		sort.Strings(writable)
+		if len(writable) > 0 {
+			rules = append(rules, PolicyRule{
+				APIGroups: []string{sg.APIGroup},
+				Resources: writable,
+				Verbs:     FilterVerbs(sg.WriteVerbs),
+			})
+		}
 	}
 
 	return rules

--- a/internal/forge/kube/render_test.go
+++ b/internal/forge/kube/render_test.go
@@ -248,6 +248,101 @@ func TestRenderFromResources_GeneratesValidYAML(t *testing.T) {
 	assert.Len(t, docs, 3)
 }
 
+func TestBuildRules_ArgoScopedWhenDiscovered(t *testing.T) {
+	// When argoproj.io CRDs are installed, Argo gets read-only across the
+	// whole group plus write (update/patch) limited to applicationsets — never
+	// the default full-verb wildcard.
+	resources := []APIResource{
+		{APIGroup: "apps", Resource: "deployments", Namespaced: true, Verbs: []string{"*"}},
+		{APIGroup: "argoproj.io", Resource: "applications", Namespaced: true, Verbs: []string{"*"}},
+		{APIGroup: "argoproj.io", Resource: "applicationsets", Namespaced: true, Verbs: []string{"*"}},
+		{APIGroup: "argoproj.io", Resource: "appprojects", Namespaced: true, Verbs: []string{"*"}},
+	}
+
+	rules := buildRules(resources)
+
+	var argoRead, argoWrite *PolicyRule
+	for i, r := range rules {
+		if !contains(r.APIGroups, "argoproj.io") {
+			// argoproj.io must never be merged into another group's rule.
+			continue
+		}
+		switch {
+		case contains(r.Resources, "*"):
+			argoRead = &rules[i]
+		case contains(r.Resources, "applicationsets"):
+			argoWrite = &rules[i]
+		}
+	}
+
+	require.NotNil(t, argoRead, "expected a read-only wildcard rule for argoproj.io")
+	assert.Equal(t, []string{"argoproj.io"}, argoRead.APIGroups)
+	assert.Equal(t, ReadOnlyVerbs(), argoRead.Verbs)
+
+	require.NotNil(t, argoWrite, "expected an applicationsets write rule")
+	assert.Equal(t, []string{"applicationsets"}, argoWrite.Resources)
+	assert.Equal(t, []string{"update", "patch"}, argoWrite.Verbs)
+
+	// argoproj.io must not appear in any full-verb wildcard rule.
+	for _, r := range rules {
+		if contains(r.APIGroups, "argoproj.io") && contains(r.Resources, "*") {
+			assert.Equal(t, ReadOnlyVerbs(), r.Verbs,
+				"argoproj.io wildcard must be read-only, never full verbs")
+		}
+	}
+}
+
+func TestBuildRules_NoArgoRuleWhenAbsent(t *testing.T) {
+	resources := []APIResource{
+		{APIGroup: "", Resource: "pods", Namespaced: true, Verbs: []string{"*"}},
+		{APIGroup: "apps", Resource: "deployments", Namespaced: true, Verbs: []string{"*"}},
+	}
+
+	rules := buildRules(resources)
+
+	for _, r := range rules {
+		assert.NotContains(t, r.APIGroups, "argoproj.io",
+			"no argoproj.io rule should be emitted when Argo is not discovered")
+	}
+}
+
+func TestBuildRules_ArgoWriteOnlyWhenApplicationSetDiscovered(t *testing.T) {
+	// Argo group present but the ApplicationSet CRD is not installed: read-only
+	// on the group, but no phantom write rule for a resource that doesn't exist.
+	resources := []APIResource{
+		{APIGroup: "argoproj.io", Resource: "applications", Namespaced: true, Verbs: []string{"*"}},
+	}
+
+	rules := buildRules(resources)
+
+	var sawArgo bool
+	for _, r := range rules {
+		if contains(r.APIGroups, "argoproj.io") {
+			sawArgo = true
+			assert.NotContains(t, r.Resources, "applicationsets")
+			assert.Equal(t, ReadOnlyVerbs(), r.Verbs)
+		}
+	}
+	assert.True(t, sawArgo, "expected a read-only argoproj.io rule")
+}
+
+func TestRenderFromResources_ArgoApplicationSetGrant(t *testing.T) {
+	resources := []APIResource{
+		{APIGroup: "", Resource: "pods", Namespaced: true, Verbs: []string{"*"}},
+		{APIGroup: "argoproj.io", Resource: "applicationsets", Namespaced: true, Verbs: []string{"*"}},
+	}
+
+	output := RenderFromResources(RenderOptions{
+		ClusterRoleName:         "claude-forge-agent",
+		ServiceAccountName:      "claude-forge-agent",
+		ServiceAccountNamespace: "claude-forge",
+	}, resources)
+
+	assert.Contains(t, output, "argoproj.io")
+	assert.Contains(t, output, "applicationsets")
+	assert.Contains(t, output, "patch")
+}
+
 func TestParseAPIResources(t *testing.T) {
 	input := `bindings                                    v1                                     true         Binding                          [create]
 configmaps                       cm          v1                                     true         ConfigMap                        [create delete deletecollection get list patch update watch]


### PR DESCRIPTION
## Summary

`claude-forge kube render` derives its ClusterRole rules from live API discovery (`kubectl api-resources`). Today a discovered namespaced CRD group like `argoproj.io` falls into the generic "namespaced group → `resources: ["*"]`, `verbs: ["*"]`" path, granting the agent **full** create/update/patch/delete on all Argo resources (Applications, ApplicationSets, AppProjects).

This PR narrows Argo access to what's actually needed — patching ApplicationSet target revisions — while keeping broad read for inspection, and only when Argo is present in the cluster.

## Behavior

**When `argoproj.io` CRDs are discovered:**
```yaml
- apiGroups: [argoproj.io]
  resources: ["*"]
  verbs: [get, list, watch]        # read-all: still inspect Applications/AppProjects
- apiGroups: [argoproj.io]
  resources: [applicationsets]
  verbs: [update, patch]           # write scoped to ApplicationSets (target revisions)
```
No `create`/`delete` anywhere in the group; no write on Applications/AppProjects.

**When Argo is not installed:** no `argoproj.io` rule is emitted at all.

The ClusterRole is cluster-wide, so ApplicationSet patch is covered in **every namespace**.

## What changed

- **`kube.ScopedWriteGroup`** (new, `carveouts.go`) — a data-driven carveout describing a non-core group that gets read-only across all resources plus write on an explicit resource set. Seeded with `argoproj.io` → writable `applicationsets`, write verbs `update`/`patch`.
- **`buildRules`** diverts scoped-write groups out of the default wildcard grouping and, only when the group is discovered, emits the read-only rule plus a write rule for the discovered writable resources (no phantom rule if e.g. the ApplicationSet CRD isn't installed).

## Testing

- `TestScopedWriteGroups_ArgoApplicationSets` / `TestIsScopedWriteGroup` — carveout data + membership.
- `TestBuildRules_ArgoScopedWhenDiscovered` — Argo present → read-only wildcard + `applicationsets` `update`/`patch`; asserts argoproj.io never gets a full-verb wildcard and is never merged into another group's rule.
- `TestBuildRules_NoArgoRuleWhenAbsent` — Argo absent → no argoproj.io rule.
- `TestBuildRules_ArgoWriteOnlyWhenApplicationSetDiscovered` — group present but ApplicationSet CRD absent → read-only only, no phantom write rule.
- `TestRenderFromResources_ArgoApplicationSetGrant` — end-to-end rendered YAML.
- Full `go build ./...`, `go vet`, `gofmt`, `go test ./...` pass; existing discovery unit tests unchanged; kube package coverage 89.1%.

> Note: this is a scope-**down** — clusters relying on the previous broad Argo grant will lose create/delete on Argo resources and update/patch on Applications/AppProjects. That's intentional per the requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)