### PR TITLE
fix: recover from Docker address-pool exhaustion on network create

### DIFF
--- a/internal/forge/container/client.go
+++ b/internal/forge/container/client.go
@@ -152,16 +152,103 @@ func (c *Client) Close() error {
 	return c.docker.Close()
 }
 
-// CreateNetwork creates a Docker network with the given name.
+const (
+	// forgeNetworkPrefix is the name prefix of a per-session network
+	// (forge_net_<project>_<session>).
+	forgeNetworkPrefix = "forge_net_"
+
+	// danglingNetworkMinAge is how old an empty forge network must be before it
+	// is eligible for pruning. It protects a concurrently-created network that
+	// is briefly empty in the window between CreateNetwork and its containers
+	// attaching.
+	danglingNetworkMinAge = time.Minute
+)
+
+// CreateNetwork creates a bridge Docker network with the given name.
+//
+// If Docker's address pool is exhausted — which happens when sessions that
+// crashed or were killed before Cleanup leave their per-session networks
+// behind, each holding a subnet — it prunes orphaned (container-less) forge
+// networks and retries once, then returns an actionable error if that still
+// fails.
 func (c *Client) CreateNetwork(ctx context.Context, name string) (string, error) {
-	resp, err := c.docker.NetworkCreate(ctx, name, network.CreateOptions{
-		Driver: "bridge",
-	})
-	if err != nil {
+	id, err := c.createBridgeNetwork(ctx, name)
+	if err == nil {
+		return id, nil
+	}
+	if !isAddressPoolExhaustedErr(err) {
 		return "", fmt.Errorf("failed to create network %s: %w", name, err)
 	}
 
+	// Reclaim subnets held by orphaned forge networks and try once more.
+	pruned := c.pruneDanglingForgeNetworks(ctx)
+	if pruned > 0 {
+		id, retryErr := c.createBridgeNetwork(ctx, name)
+		if retryErr == nil {
+			return id, nil
+		}
+		err = retryErr
+	}
+	return "", fmt.Errorf("failed to create network %s: %w; Docker's address pool is exhausted "+
+		"(pruned %d orphaned forge network(s), still no free subnet). Free more with `docker network prune`, "+
+		"or widen Docker's default-address-pools in the daemon configuration", name, err, pruned)
+}
+
+// createBridgeNetwork creates a bridge network and returns its ID.
+func (c *Client) createBridgeNetwork(ctx context.Context, name string) (string, error) {
+	resp, err := c.docker.NetworkCreate(ctx, name, network.CreateOptions{Driver: "bridge"})
+	if err != nil {
+		return "", err
+	}
 	return resp.ID, nil
+}
+
+// isAddressPoolExhaustedErr reports whether err is Docker's "no subnet
+// available" failure, emitted when every subnet in the configured
+// default-address-pools is already allocated to a network.
+func isAddressPoolExhaustedErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "predefined address pools have been fully subnetted") ||
+		strings.Contains(msg, "non-overlapping IPv4 address pool")
+}
+
+// pruneDanglingForgeNetworks removes per-session forge networks that have no
+// containers attached (orphaned by a session that never ran Cleanup) and
+// returns how many were removed.
+//
+// It is deliberately conservative:
+//   - only networks named forge_net_* are considered (never forge-shared or a
+//     user's own networks);
+//   - networks younger than danglingNetworkMinAge are skipped, so a concurrent
+//     session's just-created (still empty) network is not reclaimed;
+//   - Docker refuses to remove a network with active endpoints, which is a
+//     final backstop against removing a live session's network even if the
+//     dangling filter is not honored by an old daemon.
+func (c *Client) pruneDanglingForgeNetworks(ctx context.Context) int {
+	filterArgs := filters.NewArgs()
+	filterArgs.Add("dangling", "true")
+	filterArgs.Add("name", forgeNetworkPrefix)
+	networks, err := c.docker.NetworkList(ctx, network.ListOptions{Filters: filterArgs})
+	if err != nil {
+		return 0
+	}
+
+	removed := 0
+	for _, n := range networks {
+		if !strings.HasPrefix(n.Name, forgeNetworkPrefix) {
+			continue
+		}
+		if !n.Created.IsZero() && time.Since(n.Created) < danglingNetworkMinAge {
+			continue
+		}
+		if err := c.docker.NetworkRemove(ctx, n.ID); err == nil {
+			removed++
+		}
+	}
+	return removed
 }
 
 // RemoveNetwork removes a Docker network by name.

--- a/internal/forge/container/client_test.go
+++ b/internal/forge/container/client_test.go
@@ -77,6 +77,112 @@ func TestCreateNetwork(t *testing.T) {
 	}
 }
 
+// errPoolExhausted mimics the daemon error when every subnet in Docker's
+// default-address-pools is already allocated.
+var errPoolExhausted = fmt.Errorf("all predefined address pools have been fully subnetted")
+
+func bridgeOpts() network.CreateOptions { return network.CreateOptions{Driver: "bridge"} }
+
+func TestIsAddressPoolExhaustedErr(t *testing.T) {
+	assert.True(t, isAddressPoolExhaustedErr(errPoolExhausted))
+	assert.True(t, isAddressPoolExhaustedErr(fmt.Errorf(
+		"could not find an available, non-overlapping IPv4 address pool among the defaults to assign to the network")))
+	assert.False(t, isAddressPoolExhaustedErr(fmt.Errorf("network already exists")))
+	assert.False(t, isAddressPoolExhaustedErr(nil))
+}
+
+func TestCreateNetwork_PoolExhausted_PrunesAndRetries(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	m := NewMockDockerAPI(ctrl)
+
+	old := time.Now().Add(-time.Hour)
+	gomock.InOrder(
+		m.EXPECT().NetworkCreate(gomock.Any(), "forge_net_x", bridgeOpts()).
+			Return(network.CreateResponse{}, errPoolExhausted),
+		m.EXPECT().NetworkList(gomock.Any(), gomock.Any()).Return([]network.Inspect{
+			{Name: "forge_net_dead1", ID: "n1", Created: old},
+			{Name: "forge_net_dead2", ID: "n2", Created: old},
+		}, nil),
+		m.EXPECT().NetworkRemove(gomock.Any(), "n1").Return(nil),
+		m.EXPECT().NetworkRemove(gomock.Any(), "n2").Return(nil),
+		m.EXPECT().NetworkCreate(gomock.Any(), "forge_net_x", bridgeOpts()).
+			Return(network.CreateResponse{ID: "new-net"}, nil),
+	)
+
+	id, err := newClientWithAPI(m).CreateNetwork(context.Background(), "forge_net_x")
+	require.NoError(t, err)
+	assert.Equal(t, "new-net", id)
+}
+
+func TestCreateNetwork_PoolExhausted_RetryStillFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	m := NewMockDockerAPI(ctrl)
+
+	old := time.Now().Add(-time.Hour)
+	gomock.InOrder(
+		m.EXPECT().NetworkCreate(gomock.Any(), "forge_net_x", bridgeOpts()).
+			Return(network.CreateResponse{}, errPoolExhausted),
+		m.EXPECT().NetworkList(gomock.Any(), gomock.Any()).Return([]network.Inspect{
+			{Name: "forge_net_dead", ID: "n1", Created: old},
+		}, nil),
+		m.EXPECT().NetworkRemove(gomock.Any(), "n1").Return(nil),
+		m.EXPECT().NetworkCreate(gomock.Any(), "forge_net_x", bridgeOpts()).
+			Return(network.CreateResponse{}, errPoolExhausted),
+	)
+
+	_, err := newClientWithAPI(m).CreateNetwork(context.Background(), "forge_net_x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "address pool is exhausted")
+	assert.Contains(t, err.Error(), "pruned 1")
+	assert.Contains(t, err.Error(), "docker network prune")
+}
+
+func TestCreateNetwork_PoolExhausted_NothingToPrune(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	m := NewMockDockerAPI(ctrl)
+
+	// Empty list => nothing pruned => no retry NetworkCreate.
+	gomock.InOrder(
+		m.EXPECT().NetworkCreate(gomock.Any(), "forge_net_x", bridgeOpts()).
+			Return(network.CreateResponse{}, errPoolExhausted),
+		m.EXPECT().NetworkList(gomock.Any(), gomock.Any()).Return(nil, nil),
+	)
+
+	_, err := newClientWithAPI(m).CreateNetwork(context.Background(), "forge_net_x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pruned 0")
+}
+
+func TestPruneDanglingForgeNetworks_SkipsRecentAndNonForge(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	m := NewMockDockerAPI(ctrl)
+
+	m.EXPECT().NetworkList(gomock.Any(), gomock.Any()).Return([]network.Inspect{
+		{Name: "forge_net_recent", ID: "recent", Created: time.Now()},               // too new — skip
+		{Name: "not-a-forge-net", ID: "other", Created: time.Now().Add(-time.Hour)}, // wrong prefix — skip
+		{Name: "forge_net_old", ID: "old", Created: time.Now().Add(-time.Hour)},     // eligible
+	}, nil)
+	// Only the old forge network is removed.
+	m.EXPECT().NetworkRemove(gomock.Any(), "old").Return(nil)
+
+	removed := newClientWithAPI(m).pruneDanglingForgeNetworks(context.Background())
+	assert.Equal(t, 1, removed)
+}
+
+func TestPruneDanglingForgeNetworks_ListError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	m := NewMockDockerAPI(ctrl)
+
+	m.EXPECT().NetworkList(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("boom"))
+	removed := newClientWithAPI(m).pruneDanglingForgeNetworks(context.Background())
+	assert.Equal(t, 0, removed)
+}
+
 func TestRemoveNetwork(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Problem

`claude-forge start` fails once enough per-session networks have leaked:

```
Creating network: forge_net_…_5aeee308
Error: failed to create network …: Error response from daemon:
all predefined address pools have been fully subnetted
```

Each session creates a `forge_net_<project>_<session>` bridge network that holds one subnet from Docker's `default-address-pools`. A session that **crashes or is killed before `Cleanup`** leaves its network behind; over time the accumulated orphans exhaust the pool, and no new network can be created — so *every* subsequent `start` fails until the user manually runs `docker network prune`.

## Fix

`CreateNetwork` now detects the pool-exhaustion error, reclaims subnets held by orphaned forge networks, and retries once. Pruning is deliberately conservative:

- **Only `forge_net_*` networks** are touched — never `forge-shared` or the user's own networks.
- **Networks younger than one minute are skipped**, so a concurrently-starting session's just-created (still empty) network isn't reclaimed out from under it.
- Relies on Docker **refusing to remove a network with active endpoints** as a final backstop — a live session's network can't be removed even if the `dangling` filter isn't honored by an old daemon.

If the pool is still exhausted after pruning, the error now names the cause and the remedy instead of the opaque daemon message:

```
failed to create network …: … ; Docker's address pool is exhausted
(pruned N orphaned forge network(s), still no free subnet). Free more with
`docker network prune`, or widen Docker's default-address-pools in the daemon configuration
```

## Tests

New unit tests via the mocked Docker API cover: prune-and-retry success, retry-still-fails (actionable error), nothing-to-prune, the age/name guards, and list-error handling. `isAddressPoolExhaustedErr` matches both daemon phrasings. The three new helpers are at **100%** coverage; container package **96.8%**, aggregate **91.2%** (gate 90%). `golangci-lint` + `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)