### PR TITLE
feat: k8s-mcp serves every kubeconfig context, not just current-context

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - Runs Claude Code in Docker with `--dangerously-skip-permissions` by default
 - Gateway proxy mediates all GitHub traffic (git + API) with per-repo write restrictions
 - Per-session **GitHub MCP** sidecar scoped to the current repository
-- A first-party **Kubernetes MCP** server (`mcp/k8s-mcp/`, added as a custom container server) with your own kubeconfig and policy-enforced carveouts — no secrets, no exec, no RBAC
+- A first-party **Kubernetes MCP** server (`mcp/k8s-mcp/`, added as a custom container server) serving every context in your own kubeconfig, with policy-enforced carveouts — no secrets, no exec, no RBAC
 - Custom **MCP servers** (remote http/sse or stdio) configurable per install
 - A ready-made read-only, multi-project **Google Cloud MCP** server (added as a custom container server)
 - Optional **Docker-in-Docker**: sessions get their own isolated Docker daemon, unable to see or touch host or other sessions' containers

--- a/docs/content/docs/mcp-servers/kubernetes.md
+++ b/docs/content/docs/mcp-servers/kubernetes.md
@@ -43,26 +43,62 @@ mcp_servers:
       - "~/.config/gcloud:/home/user/.config/gcloud:ro" # ADC, for GKE contexts
 ```
 
+## Contexts
+
+**Every context in the mounted kubeconfig is served.** One server reaches all
+of your clusters; each tool call picks one with an optional `context`
+parameter, and the `list_contexts` tool reports what is available (with each
+cluster's API endpoint) plus which context is used when a call names none —
+the kubeconfig's `current-context`.
+
+Clients are built on first use, not at startup, so a context you never call
+costs nothing and an unreachable cluster (laptop off-VPN, local cluster
+stopped) neither blocks startup nor affects the contexts that do work. A
+context that starts failing is retried on the next call, so recovery needs no
+restart.
+
+Pass `--context` to narrow the served set — repeatable, or comma-separated:
+
+```yaml
+    # Serve only these two; every other context in the file is ignored.
+    args: ["--addr=:8080", "--kubeconfig=/home/user/.kube/config",
+           "--context=microk8s", "--context=gke_myproject_us-central1-a_prod"]
+```
+
+A name that isn't in the kubeconfig fails at startup rather than at first use.
+Narrowing is worth doing deliberately: mounting `~/.kube` hands the sidecar
+credentials for **every** cluster in the file, production included, and the
+policy below is the only thing standing between the agent and all of them.
+
 ## Authentication
 
 Credentials are taken straight from the mounted kubeconfig (bearer token or
 embedded client certificate) — with one exception: **GKE kubeconfigs work**.
-When the selected context uses the `gke-gcloud-auth-plugin` exec plugin (or
-`--gcp-auth` forces it), the server authenticates with a Bearer token minted
-in-process from Google Application Default Credentials and auto-refreshes it,
-so the plugin binary is never needed. That path requires
+Whenever a context uses the `gke-gcloud-auth-plugin` exec plugin (or
+`--gcp-auth` forces it for all of them), that context authenticates with a
+Bearer token minted in-process from Google Application Default Credentials and
+auto-refreshes it, so the plugin binary is never needed. That path requires
 `gcloud auth application-default login` on the host and the read-only
-`~/.config/gcloud` mount shown above.
+`~/.config/gcloud` mount shown above. Detection is per context, so a GKE
+context and a token- or certificate-based one coexist in the same server.
 
 ## Limitations
 
-Other exec plugins (EKS `aws`, OIDC helpers) remain unsupported. A cluster
-served at `localhost` is not reachable from the container network, and a
-private GKE endpoint still needs a route (bastion/tunnel; `--network host`
-when running standalone). Because the credential is your own (unrestricted)
-one, the MCP policy is the *only* safety layer — if you need
-defense-in-depth, point the kubeconfig at a user or ServiceAccount you have
-scoped down with RBAC yourself.
+Other exec plugins (EKS `aws`, OIDC helpers) remain unsupported.
+
+Reachability is separate from auth, and is judged from the **sidecar's**
+network, not your host's. A cluster served at `localhost` in the kubeconfig is
+not reachable, because loopback inside the sidecar is the sidecar itself; a
+local cluster has to be addressed by an IP the container network can route to,
+and that IP must appear in the API server's certificate SANs (or the context
+must set `insecure-skip-tls-verify`). A private GKE endpoint still needs a
+route — bastion or tunnel, or `--network host` when running the image
+standalone.
+
+Because the credential is your own (unrestricted) one, the MCP policy is the
+*only* safety layer — if you need defense-in-depth, point the kubeconfig at a
+user or ServiceAccount you have scoped down with RBAC yourself, or use
+`--context` to keep sensitive clusters out of the served set entirely.
 
 ## Migration from the built-in integration
 

--- a/mcp/k8s-mcp/README.md
+++ b/mcp/k8s-mcp/README.md
@@ -34,26 +34,47 @@ The server never offers an exec/attach tool at all.
 | `delete_resource` | Delete a resource | write |
 | `get_logs` | Pod logs (capped) | read |
 | `list_api_resources` | Discover served apiVersion/kind | read |
+| `list_contexts` | Show the targetable contexts and their endpoints | read |
+
+Every tool except `list_contexts` takes an optional `context` argument.
 
 ## Usage
 
 ```
-k8s-mcp [--addr :8080] [--kubeconfig <path>] [--context <name>] [--gcp-auth]
+k8s-mcp [--addr :8080] [--kubeconfig <path>] [--context <name>]... [--gcp-auth]
 ```
 
-`--kubeconfig` defaults to `$KUBECONFIG`, then `~/.kube/config`. Auth is taken
-straight from the kubeconfig (bearer token or embedded client certificate) —
-with one exception: **GKE kubeconfigs work**. When the selected context
+`--kubeconfig` defaults to `$KUBECONFIG`, then `~/.kube/config`.
+
+### Contexts
+
+**All contexts in the kubeconfig are served by default.** A call selects one
+via its `context` argument; without it, the kubeconfig's `current-context` is
+used. `--context` narrows the served set and is repeatable (or
+comma-separated); an unknown name fails at startup rather than at first use.
+
+Clients are constructed lazily per context and cached, so an unreachable
+cluster in the kubeconfig neither blocks startup nor affects the contexts that
+work, and a build failure is not cached — a context that recovers works again
+on the next call without a restart.
+
+### Authentication
+
+Auth is taken straight from the kubeconfig (bearer token or embedded client
+certificate) — with one exception: **GKE kubeconfigs work**. When a context
 authenticates via the `gke-gcloud-auth-plugin` exec plugin (or `--gcp-auth`
-forces it), the server replaces that auth with a Bearer token minted in-process
-from Google Application Default Credentials, and auto-refreshes it — the plugin
-binary is never needed. This requires running
+forces it for every context), the server replaces that auth with a Bearer token
+minted in-process from Google Application Default Credentials, and
+auto-refreshes it — the plugin binary is never needed. This requires running
 `gcloud auth application-default login` on the host and mounting
-`~/.config/gcloud` read-only into the container.
+`~/.config/gcloud` read-only into the container. Detection is per context, so
+GKE and non-GKE clusters coexist in one server.
 
 Other exec plugins (EKS `aws`, OIDC helpers) remain unsupported. Network
-reachability is separate from auth: a cluster served at `localhost` is not
-reachable from the container network, and a private GKE endpoint still needs a
+reachability is separate from auth, and is judged from inside the container: a
+cluster served at `localhost` is not reachable (loopback is the container
+itself), a local cluster must be addressed by a container-routable IP that the
+API server's certificate SANs cover, and a private GKE endpoint still needs a
 route (bastion/tunnel; `--network host` when running standalone).
 
 ## As a claude-forge MCP server

--- a/mcp/k8s-mcp/clientset.go
+++ b/mcp/k8s-mcp/clientset.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync"
 
-	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 // ContextInfo describes one kubeconfig context the server can target. It is the
@@ -21,9 +21,10 @@ type ContextInfo struct {
 	Default bool   `json:"default,omitempty"`
 }
 
-// clientFactory builds a Client for a single context. It is a field on ClientSet
-// so tests can substitute a fake without a reachable cluster.
-type clientFactory func(kubeconfigPath, kubeContext string, gcpAuth bool) (*Client, error)
+// clientFactory builds a Client for a single context of an already-parsed
+// kubeconfig. It is a field on ClientSet so tests can substitute a fake without
+// a reachable cluster.
+type clientFactory func(cfg *clientcmdapi.Config, kubeContext string, gcpAuth bool) (*Client, error)
 
 // ClientSet serves one Client per kubeconfig context. Every context in the
 // kubeconfig is served unless an explicit allowlist narrows the set.
@@ -34,8 +35,12 @@ type clientFactory func(kubeconfigPath, kubeContext string, gcpAuth bool) (*Clie
 // the server's startup nor the working contexts may depend on the broken ones.
 // A build failure is reported to the caller and deliberately not cached, so a
 // context that recovers starts working without restarting the server.
+// The kubeconfig is parsed exactly once, at construction, and that one parsed
+// config backs both the enumerated context set and every client built from it —
+// so a file edited underneath a running server cannot make Get disagree with
+// what list_contexts reported.
 type ClientSet struct {
-	kubeconfigPath string
+	cfg            *clientcmdapi.Config
 	gcpAuth        bool
 	defaultContext string
 	infos          []ContextInfo
@@ -50,9 +55,9 @@ type ClientSet struct {
 // must exist in the kubeconfig, so a typo fails loudly at startup rather than
 // silently serving fewer clusters than intended.
 func NewClientSet(kubeconfigPath string, allow []string, gcpAuth bool) (*ClientSet, error) {
-	cfg, err := clientcmd.LoadFromFile(kubeconfigPath)
+	cfg, err := loadKubeconfig(kubeconfigPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load kubeconfig %s: %w", kubeconfigPath, err)
+		return nil, err
 	}
 
 	all := make([]string, 0, len(cfg.Contexts))
@@ -106,11 +111,11 @@ func NewClientSet(kubeconfigPath string, allow []string, gcpAuth bool) (*ClientS
 	}
 
 	return &ClientSet{
-		kubeconfigPath: kubeconfigPath,
+		cfg:            cfg,
 		gcpAuth:        gcpAuth,
 		defaultContext: def,
 		infos:          infos,
-		newClient:      NewClient,
+		newClient:      newClientForContext,
 		clients:        map[string]*Client{},
 	}, nil
 }
@@ -158,7 +163,7 @@ func (cs *ClientSet) Get(name string) (*Client, error) {
 	// minting or a dead endpoint, and one bad context must not stall calls to the
 	// others. A concurrent duplicate build is harmless — one wins the map and
 	// both callers get that one.
-	built, err := cs.newClient(cs.kubeconfigPath, name, cs.gcpAuth)
+	built, err := cs.newClient(cs.cfg, name, cs.gcpAuth)
 	if err != nil {
 		return nil, fmt.Errorf("context %q: %w", name, err)
 	}

--- a/mcp/k8s-mcp/clientset.go
+++ b/mcp/k8s-mcp/clientset.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// ContextInfo describes one kubeconfig context the server can target. It is the
+// payload of the list_contexts tool, and it carries the cluster endpoint on
+// purpose: "which cluster am I actually talking to" and "why is that one
+// unreachable" are the two questions this server gets asked, and neither is
+// answerable from a context name alone.
+type ContextInfo struct {
+	Name    string `json:"name"`
+	Cluster string `json:"cluster,omitempty"`
+	Server  string `json:"server,omitempty"`
+	Default bool   `json:"default,omitempty"`
+}
+
+// clientFactory builds a Client for a single context. It is a field on ClientSet
+// so tests can substitute a fake without a reachable cluster.
+type clientFactory func(kubeconfigPath, kubeContext string, gcpAuth bool) (*Client, error)
+
+// ClientSet serves one Client per kubeconfig context. Every context in the
+// kubeconfig is served unless an explicit allowlist narrows the set.
+//
+// Clients are built lazily on first use and then cached, which matters for more
+// than latency: a kubeconfig routinely mixes reachable and unreachable clusters
+// (a laptop that is off-VPN, a local cluster that is not running), and neither
+// the server's startup nor the working contexts may depend on the broken ones.
+// A build failure is reported to the caller and deliberately not cached, so a
+// context that recovers starts working without restarting the server.
+type ClientSet struct {
+	kubeconfigPath string
+	gcpAuth        bool
+	defaultContext string
+	infos          []ContextInfo
+	newClient      clientFactory
+
+	mu      sync.Mutex
+	clients map[string]*Client
+}
+
+// NewClientSet enumerates the kubeconfig's contexts and prepares to serve them.
+// When allow is non-empty it narrows the served set to those names; every entry
+// must exist in the kubeconfig, so a typo fails loudly at startup rather than
+// silently serving fewer clusters than intended.
+func NewClientSet(kubeconfigPath string, allow []string, gcpAuth bool) (*ClientSet, error) {
+	cfg, err := clientcmd.LoadFromFile(kubeconfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load kubeconfig %s: %w", kubeconfigPath, err)
+	}
+
+	all := make([]string, 0, len(cfg.Contexts))
+	for name := range cfg.Contexts {
+		all = append(all, name)
+	}
+	slices.Sort(all)
+
+	names := all
+	if len(allow) > 0 {
+		var missing []string
+		for _, want := range allow {
+			if _, ok := cfg.Contexts[want]; !ok {
+				missing = append(missing, want)
+			}
+		}
+		if len(missing) > 0 {
+			return nil, fmt.Errorf("kubeconfig %s has no context named %s (available: %s)",
+				kubeconfigPath, strings.Join(missing, ", "), strings.Join(all, ", "))
+		}
+		names = slices.DeleteFunc(slices.Clone(all), func(n string) bool {
+			return !slices.Contains(allow, n)
+		})
+	}
+	if len(names) == 0 {
+		return nil, fmt.Errorf("kubeconfig %s defines no contexts", kubeconfigPath)
+	}
+
+	// The default is the kubeconfig's current-context whenever it is served. If
+	// an allowlist excluded it, a single served context is unambiguous enough to
+	// stand in; with several, callers must name one rather than have the server
+	// guess which cluster they meant.
+	def := cfg.CurrentContext
+	if !slices.Contains(names, def) {
+		def = ""
+		if len(names) == 1 {
+			def = names[0]
+		}
+	}
+
+	infos := make([]ContextInfo, 0, len(names))
+	for _, name := range names {
+		info := ContextInfo{Name: name, Default: name == def}
+		if kctx := cfg.Contexts[name]; kctx != nil {
+			info.Cluster = kctx.Cluster
+			if cluster := cfg.Clusters[kctx.Cluster]; cluster != nil {
+				info.Server = cluster.Server
+			}
+		}
+		infos = append(infos, info)
+	}
+
+	return &ClientSet{
+		kubeconfigPath: kubeconfigPath,
+		gcpAuth:        gcpAuth,
+		defaultContext: def,
+		infos:          infos,
+		newClient:      NewClient,
+		clients:        map[string]*Client{},
+	}, nil
+}
+
+// Contexts returns the served contexts, sorted by name.
+func (cs *ClientSet) Contexts() []ContextInfo {
+	return slices.Clone(cs.infos)
+}
+
+// Names returns the served context names, sorted.
+func (cs *ClientSet) Names() []string {
+	names := make([]string, 0, len(cs.infos))
+	for _, info := range cs.infos {
+		names = append(names, info.Name)
+	}
+	return names
+}
+
+// DefaultContext returns the context used when a call names none. It is empty
+// when the set is ambiguous, in which case Get requires an explicit name.
+func (cs *ClientSet) DefaultContext() string { return cs.defaultContext }
+
+// Get returns the Client for a context, building it on first use. An empty name
+// selects the default context.
+func (cs *ClientSet) Get(name string) (*Client, error) {
+	if name == "" {
+		if cs.defaultContext == "" {
+			return nil, fmt.Errorf("no default context; pass \"context\" explicitly (available: %s)",
+				strings.Join(cs.Names(), ", "))
+		}
+		name = cs.defaultContext
+	}
+	if !slices.Contains(cs.Names(), name) {
+		return nil, fmt.Errorf("unknown context %q (available: %s)", name, strings.Join(cs.Names(), ", "))
+	}
+
+	cs.mu.Lock()
+	cached, ok := cs.clients[name]
+	cs.mu.Unlock()
+	if ok {
+		return cached, nil
+	}
+
+	// Built outside the lock: constructing a client can block on credential
+	// minting or a dead endpoint, and one bad context must not stall calls to the
+	// others. A concurrent duplicate build is harmless — one wins the map and
+	// both callers get that one.
+	built, err := cs.newClient(cs.kubeconfigPath, name, cs.gcpAuth)
+	if err != nil {
+		return nil, fmt.Errorf("context %q: %w", name, err)
+	}
+
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	if existing, ok := cs.clients[name]; ok {
+		return existing, nil
+	}
+	cs.clients[name] = built
+	return built, nil
+}

--- a/mcp/k8s-mcp/clientset_test.go
+++ b/mcp/k8s-mcp/clientset_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -193,6 +194,38 @@ func TestClientSet_Get_BuildErrorIsNotCached(t *testing.T) {
 	c, err := cs.Get("prod")
 	require.NoError(t, err)
 	assert.NotNil(t, c)
+}
+
+// Get claims a concurrent duplicate build is harmless because one wins the map
+// and both callers get that one. Pin it: goroutines racing on an uncached
+// context must all succeed and observe the identical *Client, and a later call
+// must be served from that same entry.
+func TestClientSet_Get_Concurrent(t *testing.T) {
+	cs, err := NewClientSet(writeKubeconfig(t, multiContextKubeconfig), nil, false)
+	require.NoError(t, err)
+	cs.newClient = func(_, _ string, _ bool) (*Client, error) { return newTestClient(), nil }
+
+	const n = 16
+	clients := make([]*Client, n)
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			clients[i], errs[i] = cs.Get("local")
+		}()
+	}
+	wg.Wait()
+
+	for i := range n {
+		require.NoErrorf(t, errs[i], "goroutine %d", i)
+		assert.Samef(t, clients[0], clients[i], "goroutine %d got a different client", i)
+	}
+
+	cached, err := cs.Get("local")
+	require.NoError(t, err)
+	assert.Same(t, clients[0], cached)
 }
 
 func TestClientSet_ContextsIsACopy(t *testing.T) {

--- a/mcp/k8s-mcp/clientset_test.go
+++ b/mcp/k8s-mcp/clientset_test.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// multiContextKubeconfig has three contexts with current-context set to "prod",
+// so tests can exercise both the default path and an allowlist that excludes the
+// current context.
+const multiContextKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- name: prod
+  cluster:
+    server: https://prod.example:6443
+- name: local
+  cluster:
+    server: https://127.0.0.1:16443
+- name: staging
+  cluster:
+    server: https://staging.example:6443
+contexts:
+- name: prod
+  context:
+    cluster: prod
+    user: prod
+- name: local
+  context:
+    cluster: local
+    user: local
+- name: staging
+  context:
+    cluster: staging
+    user: prod
+current-context: prod
+users:
+- name: prod
+  user:
+    token: abc
+- name: local
+  user:
+    token: def
+`
+
+// countingFactory records how many times a client was built per context.
+func countingFactory(calls map[string]int, err error) clientFactory {
+	return func(_, kubeContext string, _ bool) (*Client, error) {
+		calls[kubeContext]++
+		if err != nil {
+			return nil, err
+		}
+		return newTestClient(), nil
+	}
+}
+
+// --- NewClientSet ---
+
+func TestNewClientSet_ServesEveryContextByDefault(t *testing.T) {
+	cs, err := NewClientSet(writeKubeconfig(t, multiContextKubeconfig), nil, false)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"local", "prod", "staging"}, cs.Names())
+	assert.Equal(t, "prod", cs.DefaultContext())
+
+	infos := cs.Contexts()
+	require.Len(t, infos, 3)
+	assert.Equal(t, ContextInfo{Name: "local", Cluster: "local", Server: "https://127.0.0.1:16443"}, infos[0])
+	assert.Equal(t, ContextInfo{Name: "prod", Cluster: "prod", Server: "https://prod.example:6443", Default: true}, infos[1])
+	assert.False(t, infos[2].Default)
+}
+
+func TestNewClientSet_AllowlistNarrows(t *testing.T) {
+	cs, err := NewClientSet(writeKubeconfig(t, multiContextKubeconfig), []string{"local"}, false)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"local"}, cs.Names())
+	// current-context is excluded, but a lone served context is unambiguous.
+	assert.Equal(t, "local", cs.DefaultContext())
+	assert.True(t, cs.Contexts()[0].Default)
+}
+
+func TestNewClientSet_AllowlistWithoutCurrentContextHasNoDefault(t *testing.T) {
+	cs, err := NewClientSet(writeKubeconfig(t, multiContextKubeconfig), []string{"staging", "local"}, false)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"local", "staging"}, cs.Names(), "served set stays sorted")
+	assert.Empty(t, cs.DefaultContext())
+	for _, info := range cs.Contexts() {
+		assert.False(t, info.Default)
+	}
+
+	// With no default, a call must name a context.
+	_, err = cs.Get("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no default context")
+	assert.Contains(t, err.Error(), "local, staging")
+}
+
+func TestNewClientSet_UnknownContextInAllowlist(t *testing.T) {
+	_, err := NewClientSet(writeKubeconfig(t, multiContextKubeconfig), []string{"local", "nope"}, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no context named nope")
+	assert.Contains(t, err.Error(), "available: local, prod, staging")
+}
+
+func TestNewClientSet_NoContexts(t *testing.T) {
+	_, err := NewClientSet(writeKubeconfig(t, "apiVersion: v1\nkind: Config\n"), nil, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "defines no contexts")
+}
+
+func TestNewClientSet_LoadError(t *testing.T) {
+	_, err := NewClientSet(filepath.Join(t.TempDir(), "missing"), nil, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load kubeconfig")
+}
+
+// A single-context kubeconfig keeps working exactly as before.
+func TestNewClientSet_SingleContext(t *testing.T) {
+	cs, err := NewClientSet(writeKubeconfig(t, testKubeconfig), nil, false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"test"}, cs.Names())
+	assert.Equal(t, "test", cs.DefaultContext())
+
+	// The real factory builds without touching the network.
+	c, err := cs.Get("")
+	require.NoError(t, err)
+	assert.NotNil(t, c.dyn)
+}
+
+// --- Get ---
+
+func TestClientSet_Get(t *testing.T) {
+	cs, err := NewClientSet(writeKubeconfig(t, multiContextKubeconfig), nil, false)
+	require.NoError(t, err)
+	calls := map[string]int{}
+	cs.newClient = countingFactory(calls, nil)
+
+	// Empty name resolves to the default context.
+	def, err := cs.Get("")
+	require.NoError(t, err)
+	require.NotNil(t, def)
+	assert.Equal(t, map[string]int{"prod": 1}, calls)
+
+	// A named context builds its own client.
+	local, err := cs.Get("local")
+	require.NoError(t, err)
+	assert.NotSame(t, def, local)
+	assert.Equal(t, 1, calls["local"])
+
+	// Repeat calls are served from the cache.
+	again, err := cs.Get("local")
+	require.NoError(t, err)
+	assert.Same(t, local, again)
+	assert.Equal(t, 1, calls["local"], "cached client must not be rebuilt")
+}
+
+func TestClientSet_Get_UnknownContext(t *testing.T) {
+	cs, err := NewClientSet(writeKubeconfig(t, multiContextKubeconfig), nil, false)
+	require.NoError(t, err)
+
+	_, err = cs.Get("nope")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown context "nope"`)
+	assert.Contains(t, err.Error(), "available: local, prod, staging")
+}
+
+// A context that fails to build reports the failure against its own name, does
+// not poison the cache, and leaves the other contexts usable.
+func TestClientSet_Get_BuildErrorIsNotCached(t *testing.T) {
+	cs, err := NewClientSet(writeKubeconfig(t, multiContextKubeconfig), nil, false)
+	require.NoError(t, err)
+	calls := map[string]int{}
+	cs.newClient = countingFactory(calls, fmt.Errorf("cluster unreachable"))
+
+	_, err = cs.Get("local")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `context "local"`)
+	assert.Contains(t, err.Error(), "cluster unreachable")
+
+	// Retried, not remembered as broken.
+	_, err = cs.Get("local")
+	require.Error(t, err)
+	assert.Equal(t, 2, calls["local"])
+
+	// A healthy context still works after the failure.
+	cs.newClient = countingFactory(calls, nil)
+	c, err := cs.Get("prod")
+	require.NoError(t, err)
+	assert.NotNil(t, c)
+}
+
+func TestClientSet_ContextsIsACopy(t *testing.T) {
+	cs, err := NewClientSet(writeKubeconfig(t, multiContextKubeconfig), nil, false)
+	require.NoError(t, err)
+
+	got := cs.Contexts()
+	got[0].Name = "mutated"
+	assert.Equal(t, "local", cs.Contexts()[0].Name)
+}

--- a/mcp/k8s-mcp/clientset_test.go
+++ b/mcp/k8s-mcp/clientset_test.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 // multiContextKubeconfig has three contexts with current-context set to "prod",
@@ -48,9 +50,13 @@ users:
     token: def
 `
 
-// countingFactory records how many times a client was built per context.
-func countingFactory(calls map[string]int, err error) clientFactory {
-	return func(_, kubeContext string, _ bool) (*Client, error) {
+// countingFactory records how many times a client was built per context, and
+// asserts the factory is handed the already-parsed config rather than re-reading
+// the kubeconfig itself.
+func countingFactory(t *testing.T, calls map[string]int, err error) clientFactory {
+	t.Helper()
+	return func(cfg *clientcmdapi.Config, kubeContext string, _ bool) (*Client, error) {
+		assert.NotNil(t, cfg, "factory must receive the parsed kubeconfig")
 		calls[kubeContext]++
 		if err != nil {
 			return nil, err
@@ -140,7 +146,7 @@ func TestClientSet_Get(t *testing.T) {
 	cs, err := NewClientSet(writeKubeconfig(t, multiContextKubeconfig), nil, false)
 	require.NoError(t, err)
 	calls := map[string]int{}
-	cs.newClient = countingFactory(calls, nil)
+	cs.newClient = countingFactory(t, calls, nil)
 
 	// Empty name resolves to the default context.
 	def, err := cs.Get("")
@@ -177,7 +183,7 @@ func TestClientSet_Get_BuildErrorIsNotCached(t *testing.T) {
 	cs, err := NewClientSet(writeKubeconfig(t, multiContextKubeconfig), nil, false)
 	require.NoError(t, err)
 	calls := map[string]int{}
-	cs.newClient = countingFactory(calls, fmt.Errorf("cluster unreachable"))
+	cs.newClient = countingFactory(t, calls, fmt.Errorf("cluster unreachable"))
 
 	_, err = cs.Get("local")
 	require.Error(t, err)
@@ -190,10 +196,29 @@ func TestClientSet_Get_BuildErrorIsNotCached(t *testing.T) {
 	assert.Equal(t, 2, calls["local"])
 
 	// A healthy context still works after the failure.
-	cs.newClient = countingFactory(calls, nil)
+	cs.newClient = countingFactory(t, calls, nil)
 	c, err := cs.Get("prod")
 	require.NoError(t, err)
 	assert.NotNil(t, c)
+}
+
+// The kubeconfig is parsed once, at construction, and building a context's
+// client must not touch the file again. Deleting the file after NewClientSet
+// proves it with the real factory: when Get resolved a path instead of the
+// parsed config, it re-read the file here (twice — once in the client config,
+// once in the GKE auth-plugin probe) and this would fail.
+func TestClientSet_Get_DoesNotRereadKubeconfig(t *testing.T) {
+	path := writeKubeconfig(t, multiContextKubeconfig)
+	cs, err := NewClientSet(path, nil, false)
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(path))
+
+	c, err := cs.Get("local")
+	require.NoError(t, err)
+	assert.NotNil(t, c.dyn)
+
+	// The startup snapshot still describes the contexts, file or no file.
+	assert.Equal(t, []string{"local", "prod", "staging"}, cs.Names())
 }
 
 // Get claims a concurrent duplicate build is harmless because one wins the map
@@ -203,7 +228,7 @@ func TestClientSet_Get_BuildErrorIsNotCached(t *testing.T) {
 func TestClientSet_Get_Concurrent(t *testing.T) {
 	cs, err := NewClientSet(writeKubeconfig(t, multiContextKubeconfig), nil, false)
 	require.NoError(t, err)
-	cs.newClient = func(_, _ string, _ bool) (*Client, error) { return newTestClient(), nil }
+	cs.newClient = func(*clientcmdapi.Config, string, bool) (*Client, error) { return newTestClient(), nil }
 
 	const n = 16
 	clients := make([]*Client, n)

--- a/mcp/k8s-mcp/gcpauth.go
+++ b/mcp/k8s-mcp/gcpauth.go
@@ -7,7 +7,7 @@ import (
 
 	"golang.org/x/oauth2/google"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/transport"
 )
 
@@ -26,14 +26,12 @@ const gkeAuthPluginCommand = "gke-gcloud-auth-plugin"
 var findDefaultCredentials = google.FindDefaultCredentials
 
 // usesGKEAuthPlugin reports whether the auth-info of the selected (or current)
-// context in the kubeconfig authenticates via the gke-gcloud-auth-plugin exec
-// plugin. Any load or lookup failure returns false; NewClient surfaces those
-// errors on its own.
-func usesGKEAuthPlugin(kubeconfigPath, kubeContext string) bool {
-	cfg, err := clientcmd.LoadFromFile(kubeconfigPath)
-	if err != nil {
-		return false
-	}
+// context authenticates via the gke-gcloud-auth-plugin exec plugin. It takes the
+// already-parsed kubeconfig rather than a path so that serving many contexts
+// does not re-read the same file once per context. An empty kubeContext selects
+// the kubeconfig's current-context; an unknown context or auth-info returns
+// false.
+func usesGKEAuthPlugin(cfg *clientcmdapi.Config, kubeContext string) bool {
 	name := kubeContext
 	if name == "" {
 		name = cfg.CurrentContext

--- a/mcp/k8s-mcp/gcpauth_test.go
+++ b/mcp/k8s-mcp/gcpauth_test.go
@@ -74,25 +74,30 @@ func withFakeCredentials(t *testing.T) {
 
 // --- usesGKEAuthPlugin ---
 
+// loadTestKubeconfig writes content and returns the parsed config.
+func loadTestKubeconfig(t *testing.T, content string) *clientcmdapi.Config {
+	t.Helper()
+	cfg, err := loadKubeconfig(writeKubeconfig(t, content))
+	require.NoError(t, err)
+	return cfg
+}
+
 func TestUsesGKEAuthPlugin(t *testing.T) {
-	gkePath := writeKubeconfig(t, gkeKubeconfig)
-	plainPath := writeKubeconfig(t, testKubeconfig)
+	gke := loadTestKubeconfig(t, gkeKubeconfig)
+	plain := loadTestKubeconfig(t, testKubeconfig)
 
 	// Current context uses the gke exec plugin.
-	assert.True(t, usesGKEAuthPlugin(gkePath, ""))
+	assert.True(t, usesGKEAuthPlugin(gke, ""))
 
 	// Named-context selection within the same file.
-	assert.True(t, usesGKEAuthPlugin(gkePath, "gke"))
-	assert.False(t, usesGKEAuthPlugin(gkePath, "plain"))
+	assert.True(t, usesGKEAuthPlugin(gke, "gke"))
+	assert.False(t, usesGKEAuthPlugin(gke, "plain"))
 
 	// Token-based user → false.
-	assert.False(t, usesGKEAuthPlugin(plainPath, ""))
+	assert.False(t, usesGKEAuthPlugin(plain, ""))
 
 	// Unknown context name → false.
-	assert.False(t, usesGKEAuthPlugin(gkePath, "no-such-context"))
-
-	// Missing file → false.
-	assert.False(t, usesGKEAuthPlugin(filepath.Join(t.TempDir(), "does-not-exist"), ""))
+	assert.False(t, usesGKEAuthPlugin(gke, "no-such-context"))
 }
 
 func TestUsesGKEAuthPlugin_MissingAuthInfo(t *testing.T) {
@@ -110,7 +115,7 @@ contexts:
     user: ghost
 current-context: c
 `
-	assert.False(t, usesGKEAuthPlugin(writeKubeconfig(t, cfg), ""))
+	assert.False(t, usesGKEAuthPlugin(loadTestKubeconfig(t, cfg), ""))
 }
 
 // --- applyGCPAuth ---
@@ -148,43 +153,43 @@ func TestApplyGCPAuth_ADCFailure(t *testing.T) {
 	assert.Contains(t, err.Error(), "gcloud auth application-default login")
 }
 
-// --- NewClient with GCP auth ---
+// --- newClientForContext with GCP auth ---
 
-func TestNewClient_GCPAuthForced(t *testing.T) {
+func TestNewClientForContext_GCPAuthForced(t *testing.T) {
 	withFakeCredentials(t)
 
 	// A plain token kubeconfig with --gcp-auth forced still builds: ADC
 	// replaces the token.
-	c, err := NewClient(writeKubeconfig(t, testKubeconfig), "", true)
+	c, err := newClientForContext(loadTestKubeconfig(t, testKubeconfig), "", true)
 	require.NoError(t, err)
 	require.NotNil(t, c)
 	assert.NotNil(t, c.dyn)
 	assert.NotNil(t, c.typed)
 }
 
-func TestNewClient_GCPAuthAutoDetected(t *testing.T) {
+func TestNewClientForContext_GCPAuthAutoDetected(t *testing.T) {
 	withFakeCredentials(t)
 
 	// The kubeconfig's user declares the gke exec plugin; the client builds
 	// without the plugin binary because ADC auth replaces it.
-	c, err := NewClient(writeKubeconfig(t, gkeKubeconfig), "", false)
+	c, err := newClientForContext(loadTestKubeconfig(t, gkeKubeconfig), "", false)
 	require.NoError(t, err)
 	require.NotNil(t, c)
 
 	// Named context selection takes the same path.
-	c2, err := NewClient(writeKubeconfig(t, gkeKubeconfig), "gke", false)
+	c2, err := newClientForContext(loadTestKubeconfig(t, gkeKubeconfig), "gke", false)
 	require.NoError(t, err)
 	require.NotNil(t, c2)
 }
 
-func TestNewClient_GCPAuthADCFailure(t *testing.T) {
+func TestNewClientForContext_GCPAuthADCFailure(t *testing.T) {
 	orig := findDefaultCredentials
 	findDefaultCredentials = func(_ context.Context, _ ...string) (*google.Credentials, error) {
 		return nil, errors.New("no ADC found")
 	}
 	t.Cleanup(func() { findDefaultCredentials = orig })
 
-	_, err := NewClient(writeKubeconfig(t, gkeKubeconfig), "", false)
+	_, err := newClientForContext(loadTestKubeconfig(t, gkeKubeconfig), "", false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "gcloud auth application-default login")
 }

--- a/mcp/k8s-mcp/k8s.go
+++ b/mcp/k8s-mcp/k8s.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 // maxLogBytes caps a pod-log read so a chatty pod cannot blow out the model's
@@ -35,25 +36,39 @@ type Client struct {
 	mapper meta.RESTMapper
 }
 
-// NewClient builds a Client from a kubeconfig file and optional context. Auth
-// (bearer token or embedded client certificate) comes straight from the
+// loadKubeconfig reads and merges a kubeconfig the same way the deferred loader
+// does — including ResolveLocalPaths, so relative certificate paths inside the
+// file still resolve — and returns the parsed config for reuse.
+func loadKubeconfig(kubeconfigPath string) (*clientcmdapi.Config, error) {
+	rules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPath}
+	cfg, err := rules.Load()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load kubeconfig %s: %w", kubeconfigPath, err)
+	}
+	return cfg, nil
+}
+
+// newClientForContext builds a Client for one context of an already-parsed
+// kubeconfig. An empty kubeContext selects the kubeconfig's current-context.
+//
+// It takes the parsed config rather than a path because a server that serves
+// many contexts would otherwise re-read and re-parse the same file on every
+// context's first use, and could disagree with the context set enumerated at
+// startup if the file changed underneath it.
+//
+// Auth (bearer token or embedded client certificate) comes straight from the
 // kubeconfig. GKE kubeconfigs are the exception: their gke-gcloud-auth-plugin
 // exec plugin is not available in the container, so when the selected context
 // uses it (or gcpAuth forces it) the kubeconfig's auth is replaced with Google
 // Application Default Credentials minted and refreshed in-process.
-func NewClient(kubeconfigPath, kubeContext string, gcpAuth bool) (*Client, error) {
-	loadingRules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPath}
-	overrides := &clientcmd.ConfigOverrides{}
-	if kubeContext != "" {
-		overrides.CurrentContext = kubeContext
-	}
-	cc := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)
+func newClientForContext(cfg *clientcmdapi.Config, kubeContext string, gcpAuth bool) (*Client, error) {
+	cc := clientcmd.NewNonInteractiveClientConfig(*cfg, kubeContext, &clientcmd.ConfigOverrides{}, nil)
 	restConfig, err := cc.ClientConfig()
 	if err != nil {
-		return nil, fmt.Errorf("failed to load kubeconfig %s: %w", kubeconfigPath, err)
+		return nil, fmt.Errorf("failed to build client config: %w", err)
 	}
 
-	if gcpAuth || usesGKEAuthPlugin(kubeconfigPath, kubeContext) {
+	if gcpAuth || usesGKEAuthPlugin(cfg, kubeContext) {
 		if err := applyGCPAuth(context.Background(), restConfig); err != nil {
 			return nil, err
 		}

--- a/mcp/k8s-mcp/k8s_test.go
+++ b/mcp/k8s-mcp/k8s_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -60,6 +61,26 @@ func newTestClient(objs ...runtime.Object) *Client {
 		disco:  &fakeDiscovery{},
 		mapper: testMapper(),
 	}
+}
+
+// staticClientSet wraps an already-built Client as the single served context
+// "test", so tests that care about tool behaviour rather than context routing
+// need no kubeconfig. The client is pre-cached, so newClient is never called.
+func staticClientSet(c *Client) *ClientSet {
+	return &ClientSet{
+		kubeconfigPath: "/nonexistent",
+		defaultContext: "test",
+		infos:          []ContextInfo{{Name: "test", Cluster: "test", Server: "https://127.0.0.1:6443", Default: true}},
+		clients:        map[string]*Client{"test": c},
+		newClient: func(string, string, bool) (*Client, error) {
+			return nil, fmt.Errorf("unexpected client build in test")
+		},
+	}
+}
+
+// newTestClientSet is staticClientSet over a fresh fake Client.
+func newTestClientSet(objs ...runtime.Object) *ClientSet {
+	return staticClientSet(newTestClient(objs...))
 }
 
 // unstructuredObj builds a minimal unstructured resource for seeding the dynamic

--- a/mcp/k8s-mcp/k8s_test.go
+++ b/mcp/k8s-mcp/k8s_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/client-go/discovery"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	kfake "k8s.io/client-go/kubernetes/fake"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 // --- shared test fakes (used by k8s_test.go, tools_test.go, server_test.go) ---
@@ -68,11 +69,10 @@ func newTestClient(objs ...runtime.Object) *Client {
 // need no kubeconfig. The client is pre-cached, so newClient is never called.
 func staticClientSet(c *Client) *ClientSet {
 	return &ClientSet{
-		kubeconfigPath: "/nonexistent",
 		defaultContext: "test",
 		infos:          []ContextInfo{{Name: "test", Cluster: "test", Server: "https://127.0.0.1:6443", Default: true}},
 		clients:        map[string]*Client{"test": c},
-		newClient: func(string, string, bool) (*Client, error) {
+		newClient: func(*clientcmdapi.Config, string, bool) (*Client, error) {
 			return nil, fmt.Errorf("unexpected client build in test")
 		},
 	}
@@ -147,13 +147,16 @@ users:
     token: abc
 `
 
-func TestNewClient(t *testing.T) {
+func TestNewClientForContext(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config")
 	require.NoError(t, os.WriteFile(path, []byte(testKubeconfig), 0o600))
 
-	// Default context.
-	c, err := NewClient(path, "", false)
+	cfg, err := loadKubeconfig(path)
+	require.NoError(t, err)
+
+	// Empty context falls back to the kubeconfig's current-context.
+	c, err := newClientForContext(cfg, "", false)
 	require.NoError(t, err)
 	require.NotNil(t, c)
 	assert.NotNil(t, c.dyn)
@@ -161,14 +164,20 @@ func TestNewClient(t *testing.T) {
 	assert.NotNil(t, c.disco)
 	assert.NotNil(t, c.mapper)
 
-	// Explicit context override.
-	c2, err := NewClient(path, "test", false)
+	// Explicit context.
+	c2, err := newClientForContext(cfg, "test", false)
 	require.NoError(t, err)
 	require.NotNil(t, c2)
+
+	// A context the kubeconfig does not define is rejected here rather than
+	// silently falling back to current-context.
+	_, err = newClientForContext(cfg, "no-such-context", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to build client config")
 }
 
-func TestNewClient_LoadError(t *testing.T) {
-	_, err := NewClient(filepath.Join(t.TempDir(), "does-not-exist"), "", false)
+func TestLoadKubeconfig_Error(t *testing.T) {
+	_, err := loadKubeconfig(filepath.Join(t.TempDir(), "does-not-exist"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load kubeconfig")
 }

--- a/mcp/k8s-mcp/main.go
+++ b/mcp/k8s-mcp/main.go
@@ -8,16 +8,34 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 )
 
+// contextList collects a repeatable --context flag. It also splits on commas, so
+// --context=a,b and --context=a --context=b are equivalent.
+type contextList []string
+
+func (c *contextList) String() string { return strings.Join(*c, ",") }
+
+func (c *contextList) Set(v string) error {
+	for _, part := range strings.Split(v, ",") {
+		if part = strings.TrimSpace(part); part != "" {
+			*c = append(*c, part)
+		}
+	}
+	return nil
+}
+
 func main() {
+	var kubeContexts contextList
 	addr := flag.String("addr", ":8080", "Listen address")
 	kubeconfig := flag.String("kubeconfig", "", "Path to kubeconfig (defaults to $KUBECONFIG, then ~/.kube/config)")
-	kubeContext := flag.String("context", "", "Kubeconfig context to use (defaults to current-context)")
+	flag.Var(&kubeContexts, "context",
+		"Kubeconfig context to serve; repeatable or comma-separated. Defaults to every context in the kubeconfig")
 	gcpAuth := flag.Bool("gcp-auth", false,
-		"Force Google ADC auth; auto-enabled when the kubeconfig uses gke-gcloud-auth-plugin")
+		"Force Google ADC auth for every context; auto-enabled per context that uses gke-gcloud-auth-plugin")
 	flag.Parse()
 
 	kc := *kubeconfig
@@ -30,12 +48,22 @@ func main() {
 		}
 	}
 
-	client, err := NewClient(kc, *kubeContext, *gcpAuth)
+	clients, err := NewClientSet(kc, kubeContexts, *gcpAuth)
 	if err != nil {
-		log.Fatalf("Failed to initialize Kubernetes client: %v", err)
+		log.Fatalf("Failed to load kubeconfig: %v", err)
+	}
+	// Log the served set at startup: individual clients are built on first use,
+	// so this is the only place the operator sees which clusters are on offer
+	// (and at which endpoint) without making a call.
+	for _, info := range clients.Contexts() {
+		suffix := ""
+		if info.Default {
+			suffix = " (default)"
+		}
+		log.Printf("Serving context %q -> %s%s", info.Name, info.Server, suffix)
 	}
 
-	server := NewServer(&Policy{}, client)
+	server := NewServer(&Policy{}, clients)
 	mux := http.NewServeMux()
 	mux.Handle("/mcp", server)
 	httpServer := &http.Server{Addr: *addr, Handler: mux}

--- a/mcp/k8s-mcp/main_test.go
+++ b/mcp/k8s-mcp/main_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextList(t *testing.T) {
+	var c contextList
+
+	// Repeated flag.
+	require.NoError(t, c.Set("prod"))
+	require.NoError(t, c.Set("local"))
+	assert.Equal(t, contextList{"prod", "local"}, c)
+
+	// Comma-separated, with surrounding space and empty entries ignored.
+	var c2 contextList
+	require.NoError(t, c2.Set("prod, local ,,staging"))
+	assert.Equal(t, contextList{"prod", "local", "staging"}, c2)
+
+	assert.Equal(t, "prod,local,staging", c2.String())
+
+	// An empty value contributes nothing, leaving the "serve everything" default.
+	var c3 contextList
+	require.NoError(t, c3.Set(""))
+	assert.Empty(t, c3)
+}

--- a/mcp/k8s-mcp/server.go
+++ b/mcp/k8s-mcp/server.go
@@ -40,15 +40,16 @@ type mcpToolResult struct {
 }
 
 // Server implements the MCP Streamable HTTP protocol for Kubernetes operations,
-// enforcing the kube-render carveout policy on every call.
+// enforcing the kube-render carveout policy on every call. It serves every
+// context in the ClientSet; each call picks one via its "context" argument.
 type Server struct {
-	policy *Policy
-	client *Client
+	policy  *Policy
+	clients *ClientSet
 }
 
 // NewServer creates a new MCP server.
-func NewServer(policy *Policy, client *Client) *Server {
-	return &Server{policy: policy, client: client}
+func NewServer(policy *Policy, clients *ClientSet) *Server {
+	return &Server{policy: policy, clients: clients}
 }
 
 // ServeHTTP handles HTTP requests to the MCP endpoint.
@@ -160,7 +161,7 @@ func (s *Server) handleToolsCall(r *http.Request, req *jsonRPCRequest) *jsonRPCR
 		params.Arguments = map[string]any{}
 	}
 
-	result, isError, err := executeTool(r.Context(), params.Name, params.Arguments, s.policy, s.client)
+	result, isError, err := executeTool(r.Context(), params.Name, params.Arguments, s.policy, s.clients)
 	if err != nil {
 		log.Printf("tool %s error: %v", params.Name, err)
 		return &jsonRPCResponse{

--- a/mcp/k8s-mcp/server_test.go
+++ b/mcp/k8s-mcp/server_test.go
@@ -36,7 +36,7 @@ func mcpCall(t *testing.T, server *Server, method string, params any) *jsonRPCRe
 }
 
 func TestInitialize(t *testing.T) {
-	server := NewServer(&Policy{}, newTestClient())
+	server := NewServer(&Policy{}, newTestClientSet())
 	resp := mcpCall(t, server, "initialize", nil)
 	require.NotNil(t, resp)
 	assert.Nil(t, resp.Error)
@@ -52,7 +52,7 @@ func TestInitialize(t *testing.T) {
 }
 
 func TestToolsList(t *testing.T) {
-	server := NewServer(&Policy{}, newTestClient())
+	server := NewServer(&Policy{}, newTestClientSet())
 	resp := mcpCall(t, server, "tools/list", nil)
 	require.NotNil(t, resp)
 	assert.Nil(t, resp.Error)
@@ -71,7 +71,7 @@ func TestToolsList(t *testing.T) {
 }
 
 func TestToolsCall_Success(t *testing.T) {
-	server := NewServer(&Policy{}, newTestClient(unstructuredObj("v1", "Pod", "default", "p1")))
+	server := NewServer(&Policy{}, newTestClientSet(unstructuredObj("v1", "Pod", "default", "p1")))
 	resp := mcpCall(t, server, "tools/call", map[string]any{
 		"name":      "list_resources",
 		"arguments": map[string]any{"api_version": "v1", "kind": "Pod", "namespace": "default"},
@@ -89,7 +89,7 @@ func TestToolsCall_Success(t *testing.T) {
 
 func TestToolsCall_ToolError(t *testing.T) {
 	// A denied Secret get surfaces as an isError result, not a JSON-RPC error.
-	server := NewServer(&Policy{}, newTestClient())
+	server := NewServer(&Policy{}, newTestClientSet())
 	resp := mcpCall(t, server, "tools/call", map[string]any{
 		"name":      "get_resource",
 		"arguments": map[string]any{"api_version": "v1", "kind": "Secret", "name": "s1"},
@@ -102,7 +102,7 @@ func TestToolsCall_ToolError(t *testing.T) {
 }
 
 func TestToolsCall_UnknownTool(t *testing.T) {
-	server := NewServer(&Policy{}, newTestClient())
+	server := NewServer(&Policy{}, newTestClientSet())
 	resp := mcpCall(t, server, "tools/call", map[string]any{
 		"name":      "no_such_tool",
 		"arguments": map[string]any{},
@@ -115,7 +115,7 @@ func TestToolsCall_UnknownTool(t *testing.T) {
 }
 
 func TestToolsCall_MissingName(t *testing.T) {
-	server := NewServer(&Policy{}, newTestClient())
+	server := NewServer(&Policy{}, newTestClientSet())
 	resp := mcpCall(t, server, "tools/call", map[string]any{"arguments": map[string]any{}})
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.Error)
@@ -126,7 +126,7 @@ func TestToolsCall_MissingName(t *testing.T) {
 func TestToolsCall_NilArgumentsDefaulted(t *testing.T) {
 	c := newTestClient()
 	c.disco = &fakeDiscovery{resources: sampleAPIResourceLists()}
-	server := NewServer(&Policy{}, c)
+	server := NewServer(&Policy{}, staticClientSet(c))
 	// No "arguments" key at all → defaulted to an empty map.
 	resp := mcpCall(t, server, "tools/call", map[string]any{"name": "list_api_resources"})
 	require.NotNil(t, resp)
@@ -137,7 +137,7 @@ func TestToolsCall_NilArgumentsDefaulted(t *testing.T) {
 }
 
 func TestMethodNotFound(t *testing.T) {
-	server := NewServer(&Policy{}, newTestClient())
+	server := NewServer(&Policy{}, newTestClientSet())
 	resp := mcpCall(t, server, "does/not/exist", nil)
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.Error)
@@ -145,13 +145,13 @@ func TestMethodNotFound(t *testing.T) {
 }
 
 func TestNotificationsInitialized(t *testing.T) {
-	server := NewServer(&Policy{}, newTestClient())
+	server := NewServer(&Policy{}, newTestClientSet())
 	resp := mcpCall(t, server, "notifications/initialized", nil)
 	assert.Nil(t, resp) // 204 No Content, no body
 }
 
 func TestServeHTTP_NonPost(t *testing.T) {
-	server := NewServer(&Policy{}, newTestClient())
+	server := NewServer(&Policy{}, newTestClientSet())
 	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
 	w := httptest.NewRecorder()
 	server.ServeHTTP(w, req)
@@ -164,7 +164,7 @@ func TestServeHTTP_NonPost(t *testing.T) {
 }
 
 func TestServeHTTP_BadJSON(t *testing.T) {
-	server := NewServer(&Policy{}, newTestClient())
+	server := NewServer(&Policy{}, newTestClientSet())
 	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader("{not json"))
 	w := httptest.NewRecorder()
 	server.ServeHTTP(w, req)
@@ -177,7 +177,7 @@ func TestServeHTTP_BadJSON(t *testing.T) {
 }
 
 func TestServeHTTP_InvalidParams(t *testing.T) {
-	server := NewServer(&Policy{}, newTestClient())
+	server := NewServer(&Policy{}, newTestClientSet())
 	// params is a JSON string where an object is expected → unmarshal error.
 	req := httptest.NewRequest(http.MethodPost, "/mcp",
 		strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":"oops"}`))

--- a/mcp/k8s-mcp/tools.go
+++ b/mcp/k8s-mcp/tools.go
@@ -38,7 +38,13 @@ type toolDef struct {
 	Definition  ToolDefinition
 	Access      access
 	Destructive bool
-	handle      func(ctx context.Context, args map[string]any, policy *Policy, client *Client) (string, bool, error)
+	// handle serves a tool bound to one cluster; executeTool resolves the
+	// "context" argument to a Client before calling it.
+	handle func(ctx context.Context, args map[string]any, policy *Policy, client *Client) (string, bool, error)
+	// handleSet serves a tool that is about the set of contexts rather than any
+	// single cluster, so it never touches a Kubernetes API. Exactly one of
+	// handle/handleSet is set.
+	handleSet func(ctx context.Context, args map[string]any, clients *ClientSet) (string, bool, error)
 }
 
 type jsonSchema struct {
@@ -62,6 +68,7 @@ func init() {
 		"delete_resource":    deleteResourceTool(),
 		"get_logs":           getLogsTool(),
 		"list_api_resources": listAPIResourcesTool(),
+		"list_contexts":      listContextsTool(),
 	}
 }
 
@@ -78,16 +85,50 @@ func allToolDefinitions() []ToolDefinition {
 	for _, td := range toolRegistry {
 		def := td.Definition
 		def.Annotations = annotationsFor(td)
+		if td.handle != nil {
+			// Advertised here rather than in each tool's own schema, so a tool
+			// added later cannot forget to accept a context.
+			def.InputSchema = withContextProperty(def.InputSchema)
+		}
 		defs = append(defs, def)
 	}
 	return defs
 }
 
-// executeTool runs a tool call.
-func executeTool(ctx context.Context, name string, args map[string]any, policy *Policy, client *Client) (string, bool, error) {
+// withContextProperty adds the optional "context" parameter to a cluster-bound
+// tool's schema. It copies the property map rather than writing through to the
+// registry's shared definition.
+func withContextProperty(schema any) any {
+	s, ok := schema.(jsonSchema)
+	if !ok {
+		return schema
+	}
+	props := make(map[string]property, len(s.Properties)+1)
+	for k, v := range s.Properties {
+		props[k] = v
+	}
+	props["context"] = property{
+		Type: "string",
+		Description: "Kubeconfig context to target. Defaults to the kubeconfig's current-context; " +
+			"call list_contexts to see every cluster this server can reach.",
+	}
+	s.Properties = props
+	return s
+}
+
+// executeTool runs a tool call, resolving the "context" argument to the Client
+// for that cluster.
+func executeTool(ctx context.Context, name string, args map[string]any, policy *Policy, clients *ClientSet) (string, bool, error) {
 	td, ok := toolRegistry[name]
 	if !ok {
 		return "", false, fmt.Errorf("unknown tool: %s", name)
+	}
+	if td.handleSet != nil {
+		return td.handleSet(ctx, args, clients)
+	}
+	client, err := clients.Get(getString(args, "context"))
+	if err != nil {
+		return "", false, err
 	}
 	return td.handle(ctx, args, policy, client)
 }
@@ -421,6 +462,25 @@ func listAPIResourcesTool() *toolDef {
 				return "", false, err
 			}
 			return s, false, nil
+		},
+	}
+}
+
+func listContextsTool() *toolDef {
+	return &toolDef{
+		Access: accessRead,
+		Definition: ToolDefinition{
+			Name: "list_contexts",
+			Description: "List the kubeconfig contexts this server can target, with each cluster's " +
+				"API endpoint and which context is used when a call names none.",
+			InputSchema: jsonSchema{Type: "object"},
+		},
+		handleSet: func(ctx context.Context, args map[string]any, clients *ClientSet) (string, bool, error) {
+			out, err := toJSON(clients.Contexts())
+			if err != nil {
+				return "", false, err
+			}
+			return out, false, nil
 		},
 	}
 }

--- a/mcp/k8s-mcp/tools_test.go
+++ b/mcp/k8s-mcp/tools_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	kfake "k8s.io/client-go/kubernetes/fake"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 // runTool is a thin wrapper over executeTool with a default policy, routing to a
@@ -89,7 +90,7 @@ func twoContextClientSet(a, b *Client) *ClientSet {
 			{Name: "b", Cluster: "b", Server: "https://b.example:6443"},
 		},
 		clients: map[string]*Client{"a": a, "b": b},
-		newClient: func(string, string, bool) (*Client, error) {
+		newClient: func(*clientcmdapi.Config, string, bool) (*Client, error) {
 			return nil, fmt.Errorf("unexpected client build in test")
 		},
 	}

--- a/mcp/k8s-mcp/tools_test.go
+++ b/mcp/k8s-mcp/tools_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -10,19 +12,22 @@ import (
 	kfake "k8s.io/client-go/kubernetes/fake"
 )
 
-// runTool is a thin wrapper over executeTool with a default policy.
+// runTool is a thin wrapper over executeTool with a default policy, routing to a
+// single-context ClientSet.
 func runTool(t *testing.T, client *Client, name string, args map[string]any) (string, bool, error) {
 	t.Helper()
-	return executeTool(context.Background(), name, args, &Policy{}, client)
+	return executeTool(context.Background(), name, args, &Policy{}, staticClientSet(client))
 }
 
 // --- registry / definitions ---
 
 func TestRegistryComplete(t *testing.T) {
-	require.Len(t, toolRegistry, 6)
+	require.Len(t, toolRegistry, 7)
 	for name, td := range toolRegistry {
 		assert.NotEqualf(t, accessUnset, td.Access, "tool %q must classify its access", name)
-		assert.NotNil(t, td.handle, "tool %q must have a handler", name)
+		// Exactly one handler kind: cluster-bound, or about the context set.
+		assert.Truef(t, (td.handle == nil) != (td.handleSet == nil),
+			"tool %q must set exactly one of handle/handleSet", name)
 		assert.Equal(t, name, td.Definition.Name)
 	}
 }
@@ -52,6 +57,92 @@ func TestExecuteTool_Unknown(t *testing.T) {
 	_, _, err := runTool(t, newTestClient(), "no_such_tool", map[string]any{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown tool")
+}
+
+// Every cluster-bound tool advertises the optional context parameter; the
+// context-set tool does not, since it is not bound to a cluster.
+func TestAllToolDefinitions_ContextProperty(t *testing.T) {
+	for _, d := range allToolDefinitions() {
+		s, ok := d.InputSchema.(jsonSchema)
+		require.Truef(t, ok, "tool %q has an unexpected schema type", d.Name)
+		if d.Name == "list_contexts" {
+			assert.NotContains(t, s.Properties, "context")
+			continue
+		}
+		assert.Containsf(t, s.Properties, "context", "tool %q must accept a context", d.Name)
+		assert.NotContains(t, s.Required, "context", "context must stay optional")
+	}
+
+	// The injection copies rather than mutating the shared registry definition.
+	registered := toolRegistry["list_api_resources"].Definition.InputSchema.(jsonSchema)
+	assert.NotContains(t, registered.Properties, "context")
+}
+
+// --- context routing ---
+
+// twoContextClientSet serves two pre-built clients as contexts "a" and "b".
+func twoContextClientSet(a, b *Client) *ClientSet {
+	return &ClientSet{
+		defaultContext: "a",
+		infos: []ContextInfo{
+			{Name: "a", Cluster: "a", Server: "https://a.example:6443", Default: true},
+			{Name: "b", Cluster: "b", Server: "https://b.example:6443"},
+		},
+		clients: map[string]*Client{"a": a, "b": b},
+		newClient: func(string, string, bool) (*Client, error) {
+			return nil, fmt.Errorf("unexpected client build in test")
+		},
+	}
+}
+
+func TestExecuteTool_RoutesByContext(t *testing.T) {
+	clients := twoContextClientSet(
+		newTestClient(unstructuredObj("v1", "Pod", "default", "pod-in-a")),
+		newTestClient(unstructuredObj("v1", "Pod", "default", "pod-in-b")),
+	)
+	args := func(extra map[string]any) map[string]any {
+		a := map[string]any{"api_version": "v1", "kind": "Pod", "namespace": "default"}
+		for k, v := range extra {
+			a[k] = v
+		}
+		return a
+	}
+
+	// No context named → the default context.
+	out, _, err := executeTool(context.Background(), "list_resources", args(nil), &Policy{}, clients)
+	require.NoError(t, err)
+	assert.Contains(t, out, "pod-in-a")
+	assert.NotContains(t, out, "pod-in-b")
+
+	// Explicit context → the other cluster.
+	out, _, err = executeTool(context.Background(), "list_resources",
+		args(map[string]any{"context": "b"}), &Policy{}, clients)
+	require.NoError(t, err)
+	assert.Contains(t, out, "pod-in-b")
+	assert.NotContains(t, out, "pod-in-a")
+}
+
+func TestExecuteTool_UnknownContext(t *testing.T) {
+	clients := twoContextClientSet(newTestClient(), newTestClient())
+	_, _, err := executeTool(context.Background(), "list_resources", map[string]any{
+		"api_version": "v1", "kind": "Pod", "context": "nope",
+	}, &Policy{}, clients)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown context "nope"`)
+}
+
+func TestExecuteTool_ListContexts(t *testing.T) {
+	clients := twoContextClientSet(newTestClient(), newTestClient())
+	out, isErr, err := executeTool(context.Background(), "list_contexts", map[string]any{}, &Policy{}, clients)
+	require.NoError(t, err)
+	assert.False(t, isErr)
+
+	var got []ContextInfo
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, []ContextInfo{
+		{Name: "a", Cluster: "a", Server: "https://a.example:6443", Default: true},
+		{Name: "b", Cluster: "b", Server: "https://b.example:6443"},
+	}, got)
 }
 
 // --- happy paths for each tool ---


### PR DESCRIPTION
## Summary

- **`k8s-mcp` now serves every context in the mounted kubeconfig** instead of binding one at startup. Each tool call picks a cluster with an optional `context` argument; `--context` (repeatable, comma-separated) narrows the served set.
- **New `list_contexts` tool** reporting each context's cluster and API endpoint, and which one is used when a call names none — what makes "wrong cluster" and "unreachable endpoint" diagnosable from the agent side.
- **Clients are built lazily per context and cached**, so an unreachable cluster no longer aborts startup or affects the contexts that work. Build failures are deliberately not cached, so a context that recovers works on the next call without a restart.
- **The kubeconfig is parsed once**, at construction, and threaded through — serving N contexts no longer re-reads the file per context, and the enumerated set and every client built from it come from one snapshot.

## Why

Reaching a second cluster previously meant running a second sidecar with a different `--context`, even though mounting `~/.kube` already handed the sidecar credentials for every cluster in the file. The one-context limit was structural, not a security boundary.

## Behaviour notes

- `--context=foo` still yields exactly `foo`, so existing configs are unaffected. An unknown name fails at startup rather than at first use.
- Omitting `context` resolves to the kubeconfig's `current-context`.
- GKE/ADC detection was already per-context, so GKE and token- or certificate-based clusters coexist in one server.
- `mcp/k8s-mcp/policy.go` (the canonical carveout list) is unchanged and applies uniformly to every context.

## Verification

- `-race` suite green, `vet` and `gofmt` clean, coverage **94.8%** against the 90% gate.
- Per CLAUDE.md, mocks can't catch wiring mistakes, so the built binary was run against a two-context kubeconfig — one live cluster, one deliberately dead. Both served; the dead context failed independently with `connection refused`; the live one reached its API server; an unknown context returned `unknown context "typo" (available: …)`.
- Confirmed in a real claude-forge session after `make images` + `claude-forge mcp restart`: a GKE context and a local microk8s context are both reachable through the same sidecar, verified by distinct namespace uids and field managers (`kube-apiserver` vs `kubelite`). The GKE path also exercises the refactored `usesGKEAuthPlugin` + in-process ADC token minting against a live cluster.

## Review feedback

- *Concurrency claim untested* → `TestClientSet_Get_Concurrent` races 16 goroutines at an uncached context (`f8d4335`).
- *Kubeconfig re-parsed per context* → parsed config threaded through `newClientForContext`/`usesGKEAuthPlugin` (`3bca283`). `loadKubeconfig` mirrors the deferred loader (`rules.Load()`, which runs `ResolveLocalPaths`) so relative certificate paths still resolve. `TestClientSet_Get_DoesNotRereadKubeconfig` pins it by deleting the kubeconfig after construction and requiring `Get` to still build.
- *Default widens the credential surface* → intentional, signed off on the thread rather than changed. `--context` is documented as the narrowing mechanism for operators who keep production merged into the same kubeconfig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)